### PR TITLE
Use systemd to manage kismatic-inspector

### DIFF
--- a/ansible/roles/preflight/handlers/main.yaml
+++ b/ansible/roles/preflight/handlers/main.yaml
@@ -1,0 +1,3 @@
+---
+  - name: reload services
+    command: systemctl daemon-reload

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -15,6 +15,8 @@
     template:
       src: kismatic-inspector.service.j2
       dest: "{{ init_system_dir }}/kismatic-inspector.service"
+    notify:
+      - reload services
 
   - name: start kismatic-inspector service
     service:

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -3,32 +3,31 @@
     fail: msg="systemd is required"
     when: ansible_service_mgr != "systemd"
     changed_when: false
-    # Kill any existing inspector before attempting
-    # to start a new one.
-  - name: check if Kismatic Inspector is running
-    command: "pgrep -f ^{{bin_dir}}/kismatic-inspector"
-    register: inspector_running
-    ignore_errors: yes
-  - name: kill existing Kismatic Inspector
-    command: "pkill -f ^{{bin_dir}}/kismatic-inspector"
-    when: inspector_running.failed is not defined
+
+  # setup Kismatic Inspector
   - name: copy Kismatic Inspector to node
     copy:
       src: "{{ kismatic_preflight_checker }}"
       dest: "{{ bin_dir }}/kismatic-inspector"
       mode: 0744
-  - name: start the Kismatic Inspector in server mode
-    command: "{{ bin_dir }}/kismatic-inspector server --node-roles {{ \",\".join(group_names) }} --port 8888 {{ (allow_package_installation == 'true') | ternary('', '-e') }}"
-    async: 300
-    register: start_inspector
-  - name: ensure Kismatic Inspector server is running
-    async_status: jid={{ start_inspector.ansible_job_id }}
-    register: job_result
+  - debug: msg="{{ bin_dir }}/kismatic-inspector server --node-roles {{ \",\".join(group_names) }} --port 8888 {{ (allow_package_installation == 'true') | ternary('', '-e') }}"
+  - name: copy calico-node.service to remote
+    template:
+      src: kismatic-inspector.service.j2
+      dest: "{{ init_system_dir }}/kismatic-inspector.service"
+
+  - name: start kismatic-inspector service
+    service:
+      name: kismatic-inspector.service
+      state: started
+
   # Run the pre-flights checks, and always stop the checker regardless of result
   - block:
     - name: run pre-flight checks using Kismatic Inspector
       local_action: command {{ kismatic_preflight_checker_local | default(kismatic_preflight_checker) }} client {{ ansible_host }}:8888 -o json --node-roles {{ ",".join(group_names) }}
       become: no
     always:
-      - name: stop the inspector
-        command: "pkill -f ^{{bin_dir}}/kismatic-inspector"
+      - name: stop kismatic-inspector service
+        service:
+          name: kismatic-inspector.service
+          state: stopped

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -10,8 +10,8 @@
       src: "{{ kismatic_preflight_checker }}"
       dest: "{{ bin_dir }}/kismatic-inspector"
       mode: 0744
-  - debug: msg="{{ bin_dir }}/kismatic-inspector server --node-roles {{ \",\".join(group_names) }} --port 8888 {{ (allow_package_installation == 'true') | ternary('', '-e') }}"
-  - name: copy calico-node.service to remote
+
+  - name: copy kismatic-inspector.service to remote
     template:
       src: kismatic-inspector.service.j2
       dest: "{{ init_system_dir }}/kismatic-inspector.service"

--- a/ansible/roles/preflight/templates/kismatic-inspector.service.j2
+++ b/ansible/roles/preflight/templates/kismatic-inspector.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Kismatic Inspector
+Documentation=https://github.com/apprenda/kismatic
+
+[Service]
+User=root
+ExecStart={{ bin_dir }}/kismatic-inspector server --node-roles {{ group_names|join(",") }} --port 8888 {{ (allow_package_installation == 'true') | ternary('', '-e') }}
+
+[Install]
+WantedBy=multi-user.target

--- a/integration/validate_test.go
+++ b/integration/validate_test.go
@@ -40,7 +40,9 @@ var _ = Describe("kismatic install validate tests", func() {
 func validateMiniPkgInstallEnabled(provisioner infrastructureProvisioner, distro linuxDistro) {
 	By("Provisioning nodes on AWS")
 	nodes, err := provisioner.ProvisionNodes(NodeCount{Worker: 1}, distro)
-	defer provisioner.TerminateNodes(nodes)
+	if !leaveIt() {
+		defer provisioner.TerminateNodes(nodes)
+	}
 	FailIfError(err, "Failed to provision nodes for test")
 
 	By("Waiting until nodes are SSH-accessible")
@@ -54,7 +56,9 @@ func validateMiniPkgInstallEnabled(provisioner infrastructureProvisioner, distro
 func validateMiniPkgInstallationDisabled(provisioner infrastructureProvisioner, distro linuxDistro) {
 	By("Provisioning nodes on AWS")
 	nodes, err := provisioner.ProvisionNodes(NodeCount{Worker: 1}, distro)
-	defer provisioner.TerminateNodes(nodes)
+	if !leaveIt() {
+		defer provisioner.TerminateNodes(nodes)
+	}
 	FailIfError(err, "Failed to provision nodes for test")
 
 	By("Waiting until nodes are SSH-accessible")

--- a/pkg/ansible/runner.go
+++ b/pkg/ansible/runner.go
@@ -147,7 +147,7 @@ func (r *runner) startPlaybook(playbookFile string, inv Inventory, vars ExtraVar
 	os.Setenv("ANSIBLE_JSON_LINES_PIPE", r.namedPipe)
 
 	// Print Ansible command
-	fmt.Fprint(r.out, strings.Join(cmd.Args, " "))
+	fmt.Fprintln(r.out, strings.Join(cmd.Args, " "))
 	// Starts async execution of ansible, which will block until
 	// we start reading from the named pipe
 	err = cmd.Start()


### PR DESCRIPTION
The Kismatic Inspector didn't always start correctly and caused many integration test failures

Minor fixes:
* Print Ansible run command in a new line 
* Always respect `LEAVE_ARTIFACTS` 