### PR TITLE
Improve error message when package check fails

### DIFF
--- a/pkg/inspector/check/package.go
+++ b/pkg/inspector/check/package.go
@@ -23,7 +23,7 @@ type PackageAvailableCheck struct {
 func (c PackageAvailableCheck) Check() (bool, error) {
 	ok, err := IsPackageReadyToContinue(c.PackageManager, c.PackageQuery)
 	if err != nil {
-		return false, fmt.Errorf("failed to determine if %s is available from the operating system's package manager: %v", c.PackageQuery, err)
+		return false, err
 	}
 	return ok, nil
 }

--- a/pkg/install/explain/preflight.go
+++ b/pkg/install/explain/preflight.go
@@ -36,7 +36,7 @@ func (explainer *PreflightEventExplainer) ExplainEvent(e ansible.Event, verbose 
 		util.PrintColor(buf, util.Red, "\n=> The following checks failed on %q:\n", event.Host)
 		for _, r := range results {
 			if !r.Success && r.Error != "" {
-				util.PrintColor(buf, util.Red, "   - Error occurred when trying to verify rule %s: %v\n", r.Name, r.Error)
+				util.PrintColor(buf, util.Red, "   - %s: %v\n", r.Name, r.Error)
 				continue
 			}
 			if !r.Success {


### PR DESCRIPTION
Fixes #73 

Improved message:
```
Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [OK]
1/3....  Configure Cluster Prerequisites                                        [OK]
2/3....  Update Hosts File                                                      [OK]
3/3....  Run Cluster Pre-Flight Checks
=> The following checks failed on "worker01":
   - Package Available: kismatic-kubernetes-node 1.4.5_1-1: kismatic-kubernetes-node 1.4.5_1-1 is not installed and isn't available in known package repositories
```