### PR TITLE
Use apiserver load balancer in all k8s components

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -106,7 +106,8 @@ docker_certificates_group: root
 kubernetes_cluster_name: kubernetes
 kubernetes_admin_password: admin_password
 kubernetes_master_apiserver_count: "{{ groups['master'] | length }}"
-kubernetes_master_ip: https://{{ hostvars[groups['master'][0]].internal_ipv4 }}:{{ kubernetes_master_secure_port }} # TODO change to load balancer
+kubernetes_load_balanced_fqdn: "{{ hostvars[groups['master'][0]].internal_ipv4 }}"
+kubernetes_master_ip: https://{{ kubernetes_load_balanced_fqdn }}:{{ kubernetes_master_secure_port }}
 # kubernetes certificate config
 kubernetes_certificates_ca_file_name: ca.pem
 kubernetes_certificates_cert_file_name: kubenode.pem

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -187,6 +187,10 @@ func (ae *ansibleExecutor) buildInstallExtraVars(p *Plan, tlsDirectory string) (
 		"enable_calico_policy":       strconv.FormatBool(p.Cluster.Networking.PolicyEnabled),
 		"allow_package_installation": strconv.FormatBool(p.Cluster.AllowPackageInstallation),
 	}
+	if p.Master.LoadBalancedFQDN != "" {
+		ev["kubernetes_load_balanced_fqdn"] = p.Master.LoadBalancedFQDN
+	}
+
 	// Setup an internal Docker registry or use a provided one
 	// Else just use DockerHub
 	if p.DockerRegistry.SetupInternal || p.DockerRegistry.Address != "" {


### PR DESCRIPTION
Addresses #99 

Without using apiserver master load balancer, the cluster isn't
actually high availability since all components have a hard dependency
on the only just the first configured master. This change makes it so
that kubelets, kube-schedulers, kube-proxies, &
kube-controller-managers talk to the apiserver load balancer.

This change has been verified on the Kismatic provisioned cluster that I manage.