### PR TITLE
Use load_balanced_fqdn when setting up the cluster

### DIFF
--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -24,6 +24,7 @@ Our AWS infrastructure provisioner has defaults for other pieces of information,
 the AMI ID, the subnet ID, etc. All these options can be overridden using environment variables:
 - AWS_TARGET_REGION: The AWS region to be used for provisioning machines (e.g. "us-east-1")
 - AWS_SUBNET_ID: The ID of the VPC subnet to use
+- AWS_HOSTED_ZONE_ID: The Route53 ID configured for the VPC
 - AWS_KEY_NAME: The name of the AWS key pair to use when creating the machines
 - AWS_SECURITY_GROUP_ID: The ID of the security group
 - AWS_SSH_KEY_PATH: The path to the SSH key to be used for SSH'ing into the machines

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -106,7 +106,8 @@ docker_certificates_group: root
 kubernetes_cluster_name: kubernetes
 kubernetes_admin_password: admin_password
 kubernetes_master_apiserver_count: "{{ groups['master'] | length }}"
-kubernetes_master_ip: https://{{ hostvars[groups['master'][0]].internal_ipv4 }}:{{ kubernetes_master_secure_port }} # TODO change to load balancer
+kubernetes_load_balanced_fqdn: "{{ hostvars[groups['master'][0]].internal_ipv4 }}"
+kubernetes_master_ip: https://{{ kubernetes_load_balanced_fqdn }}:{{ kubernetes_master_secure_port }}
 # kubernetes certificate config
 kubernetes_certificates_ca_file_name: ca.pem
 kubernetes_certificates_cert_file_name: kubenode.pem

--- a/integration/aws/client.go
+++ b/integration/aws/client.go
@@ -65,31 +65,23 @@ type Credentials struct {
 
 // Client for provisioning machines on AWS
 type Client struct {
-	Config        ClientConfig
-	Credentials   Credentials
-	session       *session.Session
-	ec2Client     *ec2.EC2
-	route53Client *route53.Route53
+	Config      ClientConfig
+	Credentials Credentials
+	session     *session.Session
 }
 
 func (c *Client) getEC2APIClient() (*ec2.EC2, error) {
-	if c.ec2Client == nil {
-		if err := c.prepareSession(); err != nil {
-			return nil, err
-		}
-		c.ec2Client = ec2.New(c.session)
+	if err := c.prepareSession(); err != nil {
+		return nil, err
 	}
-	return c.ec2Client, nil
+	return ec2.New(c.session), nil
 }
 
 func (c *Client) getRoute53APIClient() (*route53.Route53, error) {
-	if c.ec2Client == nil {
-		if err := c.prepareSession(); err != nil {
-			return nil, err
-		}
-		c.route53Client = route53.New(c.session)
+	if err := c.prepareSession(); err != nil {
+		return nil, err
 	}
-	return c.route53Client, nil
+	return route53.New(c.session), nil
 }
 
 func (c *Client) prepareSession() error {
@@ -331,9 +323,9 @@ func modifyHostedZone(record *DNSRecord, action string, hostedZoneID string, api
 	if changeID == nil || *changeID == "" {
 		return fmt.Errorf("Something went wrong, DNS change ID is nil")
 	}
-	// TODO verify propagated
+
 	changeReq := &route53.GetChangeInput{
-		Id: aws.String(*changeID), // Required
+		Id: aws.String(*changeID),
 	}
 
 	err = retryWithBackoff(func() error {

--- a/integration/aws/client_test.go
+++ b/integration/aws/client_test.go
@@ -23,6 +23,7 @@ func TestClient(t *testing.T) {
 			SubnetID:        os.Getenv("AWS_SUBNET_ID"),
 			Keyname:         os.Getenv("AWS_KEYNAME"),
 			SecurityGroupID: os.Getenv("AWS_SECURITY_GROUP_ID"),
+			HostedZoneID:    os.Getenv("AWS_HOSTED_ZONE_ID"),
 		},
 	}
 	fmt.Println("Creating node")
@@ -38,5 +39,57 @@ func TestClient(t *testing.T) {
 	fmt.Println(node)
 	if err := c.DestroyNodes([]string{nodeID}); err != nil {
 		t.Fatalf("Failed to destroy node: %v", err)
+	}
+}
+
+func TestCreateAndDeleteDNSRecords(t *testing.T) {
+	c := Client{
+		Credentials: Credentials{
+			ID:     os.Getenv("AWS_ACCESS_KEY_ID"),
+			Secret: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		},
+		Config: ClientConfig{
+			Region:          os.Getenv("AWS_DEFAULT_REGION"),
+			SubnetID:        os.Getenv("AWS_SUBNET_ID"),
+			Keyname:         os.Getenv("AWS_KEYNAME"),
+			SecurityGroupID: os.Getenv("AWS_SECURITY_GROUP_ID"),
+			HostedZoneID:    os.Getenv("AWS_HOSTED_ZONE_ID"),
+		},
+	}
+	fmt.Println("Creating DNS Records")
+	nodes := []string{"10.0.0.1", "10.0.0.2"}
+	record, err := c.CreateDNSRecords(nodes)
+	if err != nil {
+		t.Fatalf("Failed to create DNS records: %v", err)
+	}
+	if record.Name == "" {
+		t.Fatalf("DNS record name is empty")
+	}
+
+	// Delete record
+	fmt.Println("Deleting DNS Records")
+	if err := c.DeleteDNSRecords(record); err != nil {
+		t.Fatalf("Failed to delete DNS records: %v", record)
+	}
+}
+
+func TestGetDNSRecords(t *testing.T) {
+	c := Client{
+		Credentials: Credentials{
+			ID:     os.Getenv("AWS_ACCESS_KEY_ID"),
+			Secret: os.Getenv("AWS_SECRET_ACCESS_KEY"),
+		},
+		Config: ClientConfig{
+			Region:          os.Getenv("AWS_DEFAULT_REGION"),
+			SubnetID:        os.Getenv("AWS_SUBNET_ID"),
+			Keyname:         os.Getenv("AWS_KEYNAME"),
+			SecurityGroupID: os.Getenv("AWS_SECURITY_GROUP_ID"),
+			HostedZoneID:    os.Getenv("AWS_HOSTED_ZONE_ID"),
+		},
+	}
+	fmt.Println("Get DNS Records")
+	_, err := c.GetDNSRecords()
+	if err != nil {
+		t.Fatalf("Failed to get DNS records: %v", err)
 	}
 }

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -65,7 +65,7 @@ func WithInfrastructureAndDNS(nodeCount NodeCount, distro linuxDistro, provision
 	for _, node := range nodes.master {
 		mastterIPs = append(mastterIPs, node.PrivateIP)
 	}
-	dnsRecord, err := provisioner.ConfgiureDNS(mastterIPs)
+	dnsRecord, err := provisioner.ConfigureDNS(mastterIPs)
 	nodes.dnsRecord = dnsRecord
 	Expect(err).ToNot(HaveOccurred())
 	if !leaveIt() {

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -46,6 +46,36 @@ func WithInfrastructure(nodeCount NodeCount, distro linuxDistro, provisioner inf
 	f(nodes, sshKey)
 }
 
+// WithInfrastructureAndDNS runs the spec with the requested infrastructure and DNS
+func WithInfrastructureAndDNS(nodeCount NodeCount, distro linuxDistro, provisioner infrastructureProvisioner, f infraDependentTest) {
+	By("Provisioning nodes")
+	nodes, err := provisioner.ProvisionNodes(nodeCount, distro)
+	if !leaveIt() {
+		defer provisioner.TerminateNodes(nodes)
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Waiting until nodes are SSH-accessible")
+	sshKey := provisioner.SSHKey()
+	err = waitForSSH(nodes, sshKey)
+	Expect(err).ToNot(HaveOccurred())
+
+	By("Configuring DNS entries")
+	var mastterIPs []string
+	for _, node := range nodes.master {
+		mastterIPs = append(mastterIPs, node.PrivateIP)
+	}
+	dnsRecord, err := provisioner.ConfgiureDNS(mastterIPs)
+	nodes.dnsRecord = dnsRecord
+	Expect(err).ToNot(HaveOccurred())
+	if !leaveIt() {
+		By("Removing DNS entries")
+		defer provisioner.RemoveDNS(dnsRecord)
+	}
+
+	f(nodes, sshKey)
+}
+
 type miniInfraDependentTest func(node NodeDeets, sshKey string)
 
 // WithMiniInfrastructure runs the spec with a Minikube-like infrastructure setup.

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -61,11 +61,11 @@ func WithInfrastructureAndDNS(nodeCount NodeCount, distro linuxDistro, provision
 	Expect(err).ToNot(HaveOccurred())
 
 	By("Configuring DNS entries")
-	var mastterIPs []string
+	var masterIPs []string
 	for _, node := range nodes.master {
-		mastterIPs = append(mastterIPs, node.PrivateIP)
+		masterIPs = append(masterIPs, node.PrivateIP)
 	}
-	dnsRecord, err := provisioner.ConfigureDNS(mastterIPs)
+	dnsRecord, err := provisioner.ConfigureDNS(masterIPs)
 	nodes.dnsRecord = dnsRecord
 	Expect(err).ToNot(HaveOccurred())
 	if !leaveIt() {

--- a/integration/install.go
+++ b/integration/install.go
@@ -127,6 +127,44 @@ func installKismatic(nodes provisionedNodes, installOpts installOptions, sshKey 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+
+}
+
+func installKismaticWithDNS(nodes provisionedNodes, installOpts installOptions, sshKey string) error {
+	By("Building a template")
+	template, err := template.New("planAWSOverlay").Parse(planAWSOverlay)
+	FailIfError(err, "Couldn't parse template")
+
+	By("Building a plan to set up an overlay network cluster on this hardware")
+	sshUser := nodes.master[0].SSHUser
+	plan := PlanAWS{
+		AllowPackageInstallation: installOpts.allowPackageInstallation,
+		Etcd:                 nodes.etcd,
+		Master:               nodes.master,
+		Worker:               nodes.worker,
+		MasterNodeFQDN:       nodes.dnsRecord.Name,
+		MasterNodeShortName:  nodes.dnsRecord.Name,
+		SSHKeyFile:           sshKey,
+		SSHUser:              sshUser,
+		DockerRegistryCAPath: installOpts.dockerRegistryCAPath,
+		DockerRegistryIP:     installOpts.dockerRegistryIP,
+		DockerRegistryPort:   installOpts.dockerRegistryPort,
+	}
+
+	f, err := os.Create("kismatic-testing.yaml")
+	FailIfError(err, "Error creating plan")
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	err = template.Execute(w, &plan)
+	FailIfError(err, "Error filling in plan template")
+	w.Flush()
+
+	By("Punch it Chewie!")
+	cmd := exec.Command("./kismatic", "install", "apply", "-f", f.Name())
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
 }
 
 func installKismaticWithABadNode() {

--- a/integration/install.go
+++ b/integration/install.go
@@ -167,6 +167,20 @@ func installKismaticWithDNS(nodes provisionedNodes, installOpts installOptions, 
 	return cmd.Run()
 }
 
+func verifyMasterNodeFailure(nodes provisionedNodes, installOpts installOptions, provisioner infrastructureProvisioner, sshKey string) error {
+	By("Removing a Kubernetes master node")
+	if err := provisioner.TerminateNode(nodes.master[0]); err != nil {
+		return fmt.Errorf("Could not remove node: %v", err)
+	}
+
+	By("Rerunning Kuberang")
+	if err := runViaSSH([]string{"sudo kuberang"}, []NodeDeets{nodes.master[1]}, sshKey, 5*time.Minute); err != nil {
+		return fmt.Errorf("Failed to run kuberang: %v", err)
+	}
+
+	return nil
+}
+
 func installKismaticWithABadNode() {
 	By("Building a template")
 	template, err := template.New("planAWSOverlay").Parse(planAWSOverlay)

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -81,10 +81,10 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					})
 				})
 			})
-			Context("using a 3/2/3 layout with CentOS 7", func() {
+			Context("using a 3/2/3 layout with CentOS 7, with DNS", func() {
 				ItOnAWS("should result in a working cluster", func(provisioner infrastructureProvisioner) {
-					WithInfrastructure(NodeCount{3, 2, 3}, CentOS7, provisioner, func(nodes provisionedNodes, sshKey string) {
-						err := installKismatic(nodes, installOpts, sshKey)
+					WithInfrastructureAndDNS(NodeCount{3, 2, 3}, CentOS7, provisioner, func(nodes provisionedNodes, sshKey string) {
+						err := installKismaticWithDNS(nodes, installOpts, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -81,10 +81,20 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					})
 				})
 			})
-			Context("using a 3/2/3 layout with CentOS 7, with DNS", func() {
+			Context("using a 3/2/3 layout with CentOS 7", func() {
 				ItOnAWS("should result in a working cluster", func(provisioner infrastructureProvisioner) {
 					WithInfrastructureAndDNS(NodeCount{3, 2, 3}, CentOS7, provisioner, func(nodes provisionedNodes, sshKey string) {
+						err := installKismatic(nodes, installOpts, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+			Context("using a 1/2/1 layout with CentOS 7, with DNS", func() {
+				ItOnAWS("should result in a working cluster", func(provisioner infrastructureProvisioner) {
+					WithInfrastructureAndDNS(NodeCount{1, 2, 1}, CentOS7, provisioner, func(nodes provisionedNodes, sshKey string) {
 						err := installKismaticWithDNS(nodes, installOpts, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+						err = verifyMasterNodeFailure(nodes, installOpts, provisioner, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})

--- a/integration/provision.go
+++ b/integration/provision.go
@@ -355,12 +355,12 @@ func (p packetProvisioner) TerminateNode(node NodeDeets) error {
 
 func (p packetProvisioner) ConfigureDNS(masterIPs []string) (*DNSRecord, error) {
 	// TODO
-	return nil, fmt.Errorf("ConfigureDNS not imeplemented")
+	return nil, fmt.Errorf("ConfigureDNS not implemented")
 }
 
 func (p packetProvisioner) RemoveDNS(dnsRecord *DNSRecord) error {
 	// TODO
-	return fmt.Errorf("RemoveDNS not imeplemented")
+	return fmt.Errorf("RemoveDNS not implemented")
 }
 
 func (p packetProvisioner) createNode(distro packet.OS, count uint16) (string, error) {

--- a/integration/provision.go
+++ b/integration/provision.go
@@ -29,7 +29,7 @@ type infrastructureProvisioner interface {
 	ProvisionNodes(NodeCount, linuxDistro) (provisionedNodes, error)
 	TerminateNodes(provisionedNodes) error
 	SSHKey() string
-	ConfgiureDNS(masterIPs []string) (*DNSRecord, error)
+	ConfigureDNS(masterIPs []string) (*DNSRecord, error)
 	RemoveDNS(dnsRecord *DNSRecord) error
 }
 
@@ -220,7 +220,7 @@ func (p awsProvisioner) TerminateNodes(runningNodes provisionedNodes) error {
 	return p.client.DestroyNodes(nodeIDs)
 }
 
-func (p awsProvisioner) ConfgiureDNS(masterIPs []string) (*DNSRecord, error) {
+func (p awsProvisioner) ConfigureDNS(masterIPs []string) (*DNSRecord, error) {
 	// add DNS name
 	awsDNSRecord, err := p.client.CreateDNSRecords(masterIPs)
 	if err != nil {
@@ -328,9 +328,9 @@ func (p packetProvisioner) TerminateNodes(nodes provisionedNodes) error {
 	return nil
 }
 
-func (p packetProvisioner) ConfgiureDNS(masterIPs []string) (*DNSRecord, error) {
+func (p packetProvisioner) ConfigureDNS(masterIPs []string) (*DNSRecord, error) {
 	// TODO
-	return nil, fmt.Errorf("ConfgiureDNS not imeplemented")
+	return nil, fmt.Errorf("ConfigureDNS not imeplemented")
 }
 
 func (p packetProvisioner) RemoveDNS(dnsRecord *DNSRecord) error {

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -187,6 +187,12 @@ func (ae *ansibleExecutor) buildInstallExtraVars(p *Plan, tlsDirectory string) (
 		"enable_calico_policy":       strconv.FormatBool(p.Cluster.Networking.PolicyEnabled),
 		"allow_package_installation": strconv.FormatBool(p.Cluster.AllowPackageInstallation),
 	}
+
+	// Setup FQDN or default to first master
+	if p.Master.LoadBalancedFQDN != "" {
+		ev["kubernetes_load_balanced_fqdn"] = p.Master.LoadBalancedFQDN
+	}
+
 	// Setup an internal Docker registry or use a provided one
 	// Else just use DockerHub
 	if p.DockerRegistry.SetupInternal || p.DockerRegistry.Address != "" {


### PR DESCRIPTION
* Propogate `load_balanced_fqdn` to Ansible
* Run an integration test with DNS records pointing to API server with AWS Route53