### PR TITLE
Use IP instead of hostname for etcd bind address

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -47,8 +47,7 @@ etcd_service_owner: root
 etcd_service_group: root
 etcd_service_mode: 0664
 # etcd cluster setup
-etcd_service_cluster_string: "{% for host in groups['etcd'] %}{{ host }}=https://{{ host }}:{{ etcd_service_peer_port }}{% if not loop.last %},{% endif %}{% endfor %}"
-#etcd_service_cluster_string: "{% for host in groups['etcd'] %}{% if hostvars[host]['inventory_hostname'] is defined %}{{ host }}=https://{{ host }}:{{ etcd_service_peer_port }}{% if not loop.last %},{% endif %}{% endif %}{% endfor %}"
+etcd_service_cluster_string: "{% for host in groups['etcd'] %}{{ host }}=https://{{ hostvars[host]['internal_ipv4'] }}:{{ etcd_service_peer_port }}{% if not loop.last %},{% endif %}{% endfor %}"
 #===============================================================================
 # docker-install
 docker_install_dir: /etc/docker

--- a/ansible/roles/etcd/templates/etcd.service.j2
+++ b/ansible/roles/etcd/templates/etcd.service.j2
@@ -10,7 +10,7 @@ Environment=ETCD_DATA_DIR={{ etcd_service_data_dir }}
 Environment=CERT_FILE={{ etcd_certificates_cert_file }}
 Environment=KEY_FILE={{ etcd_certificates_key_file }}
 Environment=CA_FILE={{ etcd_certificates_ca_file }}
-Environment=IP={{ inventory_hostname }}
+Environment=IP={{ internal_ipv4 }}
 Environment=PEER_PORT={{ etcd_service_peer_port }}
 Environment=CLIENT_PORT={{ etcd_service_client_port }}
 Environment=ETCD_CLUSTER_TOKEN={{ etcd_service_cluster_token }}


### PR DESCRIPTION
Specify the IP address that etcd should bind, instead of allowing it to choose one given the machine's hostname.

Fixes #145 