### PR TITLE
Fix add worker

### DIFF
--- a/ansible/_worker-smoke-test.yaml
+++ b/ansible/_worker-smoke-test.yaml
@@ -5,8 +5,5 @@
     remote_user: root
     become_method: sudo
     run_once: true
-    vars_files:
-      - group_vars/all.yaml
-      - group_vars/kubelet-master.yaml
     roles:
       - worker-smoke-test

--- a/pkg/install/add_worker.go
+++ b/pkg/install/add_worker.go
@@ -118,7 +118,7 @@ func (ae *ansibleExecutor) AddWorker(originalPlan *Plan, newWorker Node) (*Plan,
 	if err != nil {
 		return nil, err
 	}
-	eventStream, err = runner.StartPlaybookOnNode(playbook, inventory, ev, newWorker.Host)
+	eventStream, err = runner.StartPlaybook(playbook, inventory, ev)
 	if err != nil {
 		return nil, fmt.Errorf("error running new worker smoke test: %v", err)
 	}

--- a/pkg/install/add_worker_test.go
+++ b/pkg/install/add_worker_test.go
@@ -253,8 +253,14 @@ func TestAddWorkerHostsFilesDNSEnabled(t *testing.T) {
 		t.Errorf("unexpected error")
 	}
 	expectedPlaybook := "_hosts.yaml"
-	if fakeRunner.allNodesPlaybook != expectedPlaybook {
-		t.Errorf("expected playbook %s, but ran %s", expectedPlaybook, fakeRunner.allNodesPlaybook)
+	found := false
+	for _, p := range fakeRunner.allNodesPlaybooks {
+		if p == expectedPlaybook {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected playbook %s was not run during add-worker. The following plays ran: %v", expectedPlaybook, fakeRunner.allNodesPlaybooks)
 	}
 }
 
@@ -281,14 +287,14 @@ func (f *fakePKI) GenerateClusterCA(p *Plan) (*tls.CA, error) {
 func (f *fakePKI) GenerateClusterCertificates(p *Plan, ca *tls.CA, users []string) error { return f.err }
 
 type fakeRunner struct {
-	eventChan        chan ansible.Event
-	err              error
-	incomingVars     map[string]ansible.ExtraVars
-	allNodesPlaybook string
+	eventChan         chan ansible.Event
+	err               error
+	incomingVars      map[string]ansible.ExtraVars
+	allNodesPlaybooks []string
 }
 
 func (f *fakeRunner) StartPlaybook(playbookFile string, inventory ansible.Inventory, vars ansible.ExtraVars) (<-chan ansible.Event, error) {
-	f.allNodesPlaybook = playbookFile
+	f.allNodesPlaybooks = append(f.allNodesPlaybooks, playbookFile)
 	return f.eventChan, f.err
 }
 func (f *fakeRunner) WaitPlaybook() error { return f.err }


### PR DESCRIPTION
The add-worker smoke test is currently broken. It is meant to be run on a master node, but the inventory being passed to ansible only contained the new worker.

Also fixed an issue where the ansible vars that were being used for add-worker were missing the admin password. (Fixes #148)

