### PR TITLE
Set use_private_docker_registry to false to skip the playbook cleanly

### DIFF
--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -197,6 +197,8 @@ func (ae *ansibleExecutor) buildInstallExtraVars(p *Plan, tlsDirectory string) (
 	// Else just use DockerHub
 	if p.DockerRegistry.SetupInternal || p.DockerRegistry.Address != "" {
 		ev["use_private_docker_registry"] = "true"
+	} else {
+		ev["use_private_docker_registry"] = "false"
 	}
 	ev["setup_internal_docker_registry"] = strconv.FormatBool(p.DockerRegistry.SetupInternal)
 


### PR DESCRIPTION
Currently Anisble still outputs the play even all tasks are going to be skipped

```
Installing Cluster==================================================================
1/18...  Configure Cluster Prerequisites                                        [OK]
2/18...  Install Kismatic packages                                              [OK]
3/18...  Install Kubernetes Etcd Cluster                                        [OK]
4/18...  Install Network Etcd Cluster                                           [OK]
5/18...  Install Docker                                                         [OK]
6/18...  Load Docker Images Into Private Registry                               [OK] -->should not be here
7/18...  Deploy Cluster Certificates                                            [OK]
8/18...  Configure Cluster Network                                              [OK]
9/18...  Install Kubernetes API Server                                          [OK]
10/18..  Install Kubernetes Scheduler                                           [OK]
11/18..  Install Kubernetes Controller Manager                                  [OK]
12/18..  Install Kubernetes Kubelet on Master Nodes                             [OK]
13/18..  Install Kubernetes Kubelet on Worker Nodes                             [OK]
14/18..  Install Kubernetes Kubelet on Ingress Nodes                            [OK]
15/18..  Install Kubernetes Proxy                                               [OK]
16/18..  Configure Kubernetes DNS                                               [OK]
17/18..  Configure Kubernetes Ingress                                           [OK]
18/18..  Configure Kubernetes Dashboard                                         [OK]
```
After the fix
```
Installing Cluster==================================================================
1/17...  Configure Cluster Prerequisites                                        [OK]
2/17...  Install Kismatic packages                                              [OK]
3/17...  Install Kubernetes Etcd Cluster                                        [OK]
4/17...  Install Network Etcd Cluster                                           [OK]
5/17...  Install Docker                                                         [OK]
6/17...  Deploy Cluster Certificates                                            [OK]
7/17...  Configure Cluster Network                                              [OK]
8/17...  Install Kubernetes API Server                                          [OK]
9/17...  Install Kubernetes Scheduler                                           [OK]
10/17..  Install Kubernetes Controller Manager                                  [OK]
11/17..  Install Kubernetes Kubelet on Master Nodes                             [OK]
12/17..  Install Kubernetes Kubelet on Worker Nodes                             [OK]
13/17..  Install Kubernetes Kubelet on Ingress Nodes                            [OK]
14/17..  Install Kubernetes Proxy                                               [OK]
15/17..  Configure Kubernetes DNS                                               [OK]
16/17..  Configure Kubernetes Ingress                                           [OK]
17/17..  Configure Kubernetes Dashboard                                         [OK]
```