### PR TITLE
Use kubernetes service and service accounts for kubedns, instead of kubeconfig file

### DIFF
--- a/ansible/roles/addon-kubernetes-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/addon-kubernetes-dns/templates/kubernetes-dns.yaml
@@ -82,7 +82,6 @@ spec:
         # command = "/kube-dns"
         - --domain=cluster.local
         - --dns-port=10053
-        - --kubecfg-file={{ kubernetes_kubeconfig_path }}
         volumeMounts:
         - mountPath: {{ kubernetes_certificates_ca_path }}
           name: "ssl-certs"


### PR DESCRIPTION
In order to better support our hosts file modification feature, we make `kubedns` use the kubernetes service and service accounts for accessing the API server.

Fixes #123 