### PR TITLE
Add make target for focused integration test

### DIFF
--- a/INTEGRATION_TESTING.md
+++ b/INTEGRATION_TESTING.md
@@ -39,15 +39,20 @@ In order to run tests against Packet.net, you'll need to define the following en
 
  You run integration tests via
 
- ```make integration-tests```
+ ```make integration-test```
 
  which will also build a distributable for your machine's architecture.
 
  To avoid rebuild, you can also call
 
- ```make just-integration-tests```
+ ```make just-integration-test```
 
  This step will complain if your keys aren't set up, with clues as to how you can remedy the issue.
+
+To run a specific test, you can call:
+```
+FOCUS=[pattern to match here] make focus-integration-test
+```
 
  Test early. Test often. Test hard.
 

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ just-integration-test: integration/vendor
 serial-integration-test: integration/vendor
 	ginkgo -v integration
 
+focus-integration-test: integration/vendor
+	ginkgo --focus $(FOCUS) -v integration
+
 docs/kismatic-cli:
 	mkdir docs/kismatic-cli
 	go run cmd/kismatic-docs/main.go


### PR DESCRIPTION
Makes it easier to run a specific test using an env var.