### PR TITLE
Validate that python is installed when asking for an ansible runner

### DIFF
--- a/pkg/ansible/runner.go
+++ b/pkg/ansible/runner.go
@@ -62,6 +62,12 @@ func (v ExtraVars) commandLineVars() (string, error) {
 
 // NewRunner returns a new runner for running Ansible playbooks.
 func NewRunner(out, errOut io.Writer, ansibleDir string) (Runner, error) {
+	// Ansible depends on python 2.7 being installed and on the path as "python".
+	// Validate that it is available
+	if _, err := exec.LookPath("python"); err != nil {
+		return nil, fmt.Errorf("Could not find 'python' in the PATH. Ensure that python 2.7 is installed and in the path as 'python'.")
+	}
+
 	ppath, err := getPythonPath()
 	if err != nil {
 		return nil, err

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -363,6 +363,9 @@ func (ae *ansibleExecutor) generateTLSAssets(p *Plan) error {
 func (ae *ansibleExecutor) runPlaybookWithExplainer(playbook string, eventExplainer explain.AnsibleEventExplainer, inv ansible.Inventory, ev ansible.ExtraVars, ansibleLog io.Writer) error {
 	// Setup sinks for explainer and ansible stdout
 	runner, explainer, err := ae.getAnsibleRunnerAndExplainer(eventExplainer, ansibleLog)
+	if err != nil {
+		return err
+	}
 
 	// Start running ansible with the given playbook
 	eventStream, err := runner.StartPlaybook(playbook, inv, ev)


### PR DESCRIPTION
Fixes #173 

Adds validation so that a more meaningful error is returned to the user when python is not available on the machine.