### PR TITLE
Improve SSH validation error message

### DIFF
--- a/pkg/cli/validate.go
+++ b/pkg/cli/validate.go
@@ -68,7 +68,7 @@ func doValidate(out io.Writer, planner install.Planner, opts *validateOpts) erro
 	if !ok {
 		util.PrettyPrintErr(out, "Validating SSH connections to nodes")
 		printValidationErrors(out, errs)
-		return fmt.Errorf("node SSH error prevents installation from proceeding")
+		return fmt.Errorf("SSH connectivity validation failure prevents installation from proceeding")
 	}
 
 	if opts.skipPreFlight {

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -211,7 +211,7 @@ func (s *SSHConnection) validate() (bool, []error) {
 				sshErr := verifySSH(&node, s.SSHConfig, sshClientConfig)
 				// Need to send something the buffered channel
 				if sshErr != nil {
-					errQueue <- fmt.Errorf("error SSH into node: %s, %v", node.InternalIP, sshErr)
+					errQueue <- fmt.Errorf("SSH connectivity validation failed for %q: %v", node.IP, sshErr)
 				} else {
 					errQueue <- nil
 				}


### PR DESCRIPTION
Before this change, the SSH validation error was using the InternalIP in the error message, which is not always defined, and is also not the IP we use for SSH:

```
Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [OK]
Validating SSH connections to nodes                                             [ERROR]
- Etcd nodes: error SSH into node: , dial tcp 192.168.205.15:22: getsockopt: no route to host
node SSH error prevents installation from proceeding
```

The error message now shows the correct IP address:
```
Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [OK]
Validating SSH connections to nodes                                             [ERROR]
- Etcd nodes: SSH connectivity validation failed for "192.168.205.15": dial tcp 192.168.205.15:22: getsockopt: no route to host
SSH connectivity validation failure prevents installation from proceeding
```
