### PR TITLE
Remove condition that prevents smoke test from running in minikube setup

### DIFF
--- a/ansible/_smoketest.yaml
+++ b/ansible/_smoketest.yaml
@@ -1,5 +1,5 @@
 ---
-  - hosts: master:!worker
+  - hosts: master
     any_errors_fatal: true
     name: "Smoke test Master Nodes"
     remote_user: root


### PR DESCRIPTION
I set up a Minikube cluster and discovered that `kuberang` was not installed on the machine. This prompted me to look into it, and realized that the smoke test is not being run for minikube-style deployments.