### PR TITLE
Use the actual kube-dns version in rep. controller

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -11,6 +11,7 @@ kismatic_docker_engine_apt_version: 1.11.2-0~xenial
 calico_docker_version: v0.22.0
 calico_kube_policy_controller_version: v0.4.0
 kubedns_version: "1.9"
+kubedns_version_id: "v19" # Used for the kube-dns replication controller's name (e.g. kube-dns-v19)
 kube_dnsmasq_version: "1.4"
 exechealthz_version: "1.2"
 kubernetes_dashboard_version: v1.5.0

--- a/ansible/roles/addon-kubernetes-dns/tasks/main.yaml
+++ b/ansible/roles/addon-kubernetes-dns/tasks/main.yaml
@@ -8,7 +8,7 @@
     command: kubectl apply -f /tmp/kubernetes-dns.yaml
     register: out
   - name: wait until at least one DNS pod is ready
-    command: kubectl get rc kube-dns-v18 --namespace kube-system -o jsonpath='{.status.readyReplicas}'
+    command: kubectl get rc kube-dns-{{kubedns_version_id}} --namespace kube-system -o jsonpath='{.status.readyReplicas}'
     register: readyReplicas
     until: readyReplicas.stdout|int > 0
     retries: 15

--- a/ansible/roles/addon-kubernetes-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/addon-kubernetes-dns/templates/kubernetes-dns.yaml
@@ -23,22 +23,22 @@ spec:
 apiVersion: v1
 kind: ReplicationController
 metadata:
-  name: kube-dns-v18
+  name: kube-dns-{{kubedns_version_id}}
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: v18
+    version: {{kubedns_version_id}}
     kubernetes.io/cluster-service: "true"
 spec:
   replicas: 1
   selector:
     k8s-app: kube-dns
-    version: v18
+    version: {{kubedns_version_id}}
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: v18
+        version: {{kubedns_version_id}}
         kubernetes.io/cluster-service: "true"
     spec:
       volumes:


### PR DESCRIPTION
While debugging kube-dns, I noticed that the wrong version was being used for the replication controller's name.