### PR TITLE
Use ANSIBLE_CONFIG, use ansible.cfg file for all static variables

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 timeout=60
+host_key_checking = False
 
 [ssh_connection]
 ssh_args = -o ControlMaster=auto -o ControlPersist=1800s -o ControlPath=/tmp/ssh-%r-%h-%p

--- a/pkg/ansible/runner.go
+++ b/pkg/ansible/runner.go
@@ -137,10 +137,9 @@ func (r *runner) startPlaybook(playbookFile string, inv Inventory, vars ExtraVar
 	}
 
 	os.Setenv("PYTHONPATH", r.pythonPath)
-	os.Setenv("ANSIBLE_HOST_KEY_CHECKING", "False")
 	os.Setenv("ANSIBLE_CALLBACK_PLUGINS", filepath.Join(r.ansibleDir, "playbooks", "callback"))
 	os.Setenv("ANSIBLE_CALLBACK_WHITELIST", "json_lines")
-	os.Setenv("ANSIBLE_TIMEOUT", "60")
+	os.Setenv("ANSIBLE_CONFIG", filepath.Join(r.ansibleDir, "playbooks", "ansible.cfg"))
 
 	// We always want the most verbose output from Ansible. If it's not going to
 	// stdout, it's going to a log file.


### PR DESCRIPTION
Fixes #93 

Currently `ansible.cfg` only gets used in our integration tests and does not get packaged up in a distribution.
Moved `ansible.cfg` to a common place and use an ENV var to point to the file whenever ansible is executed both during integration tests and using the binary.
