### PR TITLE
Dependency on nfs-utils

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,11 +1,11 @@
 #===============================================================================
 # VERSIONS
-kismatic_kubernetes_master_yum_version: 1.5.1_1-1
-kismatic_kubernetes_node_yum_version: 1.5.1_1-1
-kismatic_kubernetes_etcd_yum_version: 1.5.1_1-1
-kismatic_kubernetes_master_apt_version: 1.5.1-1
-kismatic_kubernetes_node_apt_version: 1.5.1-1
-kismatic_kubernetes_etcd_apt_version: 1.5.1-1
+kismatic_kubernetes_master_yum_version: 1.5.1_2-1
+kismatic_kubernetes_node_yum_version: 1.5.1_2-1
+kismatic_kubernetes_etcd_yum_version: 1.5.1_2-1
+kismatic_kubernetes_master_apt_version: 1.5.1-2
+kismatic_kubernetes_node_apt_version: 1.5.1-2
+kismatic_kubernetes_etcd_apt_version: 1.5.1-2
 kismatic_docker_engine_apt_version: 1.11.2-0~xenial
 
 calico_docker_version: v0.22.0

--- a/docs/PROVISION.md
+++ b/docs/PROVISION.md
@@ -142,14 +142,14 @@ If you are building a large cluster or one that won't have access to these repos
     <td></td>
   </tr>
   <tr>
-    <td>Kismatic package of Kubernetes Master 1.5.1-1</td>
+    <td>Kismatic package of Kubernetes Master 1.5.1-2</td>
     <td>Kubernetes</td>
     <td></td>
     <td>yes </td>
     <td></td>
   </tr>
   <tr>
-    <td>Kismatic package of Kubernetes Worker 1.5.1-1</td>
+    <td>Kismatic package of Kubernetes Worker 1.5.1-2</td>
     <td>Kubernetes</td>
     <td></td>
     <td></td>

--- a/integration/prepare.go
+++ b/integration/prepare.go
@@ -20,18 +20,18 @@ import (
 
 const (
 	copyKismaticYumRepo        = `sudo curl https://kismatic-packages-rpm.s3-accelerate.amazonaws.com/kismatic.repo -o /etc/yum.repos.d/kismatic.repo`
-	installEtcdYum             = `sudo yum -y install kismatic-etcd-1.5.1_1-1`
+	installEtcdYum             = `sudo yum -y install kismatic-etcd-1.5.1_2-1`
 	installDockerEngineYum     = `sudo yum -y install kismatic-docker-engine-1.11.2-1.el7.centos`
-	installKubernetesMasterYum = `sudo yum -y install kismatic-kubernetes-master-1.5.1_1-1`
-	installKubernetesYum       = `sudo yum -y install kismatic-kubernetes-node-1.5.1_1-1`
+	installKubernetesMasterYum = `sudo yum -y install kismatic-kubernetes-master-1.5.1_2-1`
+	installKubernetesYum       = `sudo yum -y install kismatic-kubernetes-node-1.5.1_2-1`
 
 	copyKismaticKeyDeb         = `wget -qO - https://kismatic-packages-deb.s3-accelerate.amazonaws.com/public.key | sudo apt-key add - `
 	copyKismaticRepoDeb        = `sudo add-apt-repository "deb https://kismatic-packages-deb.s3-accelerate.amazonaws.com xenial main"`
 	updateAptGet               = `sudo apt-get update`
-	installEtcdApt             = `sudo apt-get -y install kismatic-etcd=1.5.1-1`
+	installEtcdApt             = `sudo apt-get -y install kismatic-etcd=1.5.1-2`
 	installDockerApt           = `sudo apt-get -y install kismatic-docker-engine=1.11.2-0~xenial`
-	installKubernetesMasterApt = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-1 kismatic-kubernetes-node=1.5.1-1 kismatic-kubernetes-master=1.5.1-1`
-	installKubernetesApt       = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-1 kismatic-kubernetes-node=1.5.1-1`
+	installKubernetesMasterApt = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-2 kismatic-kubernetes-node=1.5.1-2 kismatic-kubernetes-master=1.5.1-2`
+	installKubernetesApt       = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-2 kismatic-kubernetes-node=1.5.1-2`
 )
 
 type nodePrep struct {

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -103,53 +103,53 @@ const defaultRuleSet = `---
 - kind: PackageAvailable
   when: ["etcd", "ubuntu"]
   packageName: kismatic-etcd
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-2
 - kind: PackageAvailable
   when: ["master","ubuntu"]
   packageName: kismatic-kubernetes-master
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-2
 - kind: PackageAvailable
   when: ["worker","ubuntu"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-2
 - kind: PackageAvailable
   when: ["ingress","ubuntu"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-2
 
 - kind: PackageAvailable
   when: ["etcd", "centos"]
   packageName: kismatic-etcd
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 - kind: PackageAvailable
   when: ["master","centos"]
   packageName: kismatic-kubernetes-master
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 - kind: PackageAvailable
   when: ["worker","centos"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 - kind: PackageAvailable
   when: ["ingress","centos"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 
 - kind: PackageAvailable
   when: ["etcd", "rhel"]
   packageName: kismatic-etcd
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 - kind: PackageAvailable
   when: ["master","rhel"]
   packageName: kismatic-kubernetes-master
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 - kind: PackageAvailable
   when: ["worker","rhel"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 - kind: PackageAvailable
   when: ["ingress","rhel"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_2-1
 `
 
 // DefaultRules returns the list of rules that are built into the inspector


### PR DESCRIPTION
Closes #200 

The only change required is the addition of a new dependency in `kismatic-kuberntes` packages:
* Deb: `nfs-common`
* RPM: `nfs-utils`  

Completed in https://github.com/apprenda/kismatic-distro-packages/commit/6168cca6f4fd88549858e1a5e5fff1611b1a303d

There is no Anisble playbook changes since the package will be automatically installed by the OS package manager
There is no Doc changes as this is just one of many underlying utilities required for kuberntes and is handled by the OS package manager