### PR TITLE
Bump intall_released_test to v1.1.0

### DIFF
--- a/integration/install_released_test.go
+++ b/integration/install_released_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const previousKismaticVersion = "v1.0.3"
+const previousKismaticVersion = "v1.1.0"
 
 // Test a specific released version of Kismatic
 var _ = Describe("Installing with previous version of Kismatic", func() {


### PR DESCRIPTION
Still need to figure out when is the best time to do this after a release. 

IMO the previous version should be updated right after a release is cut.
We also might want to test multiple previous versions.
 