### PR TITLE
Calico v2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ KET operational tools include:
 | --- | --- |
 | Kubernetes | 1.5.1 |
 | Docker | 1.11.2 |
-| Calico | 1.6 |
+| Calico | 2.0.0 |
 | Etcd (for Kubernetes) | 3.0.15 |
 | Etcd (for Calico) | 2.37 |
 

--- a/ansible/_calico.yaml
+++ b/ansible/_calico.yaml
@@ -9,5 +9,4 @@
 
     roles:
       - kubeconfig
-      - network-environment
       - calico

--- a/ansible/_kubelet-ingress.yaml
+++ b/ansible/_kubelet-ingress.yaml
@@ -10,6 +10,5 @@
       - kubernetes_schedulable: false
 
     roles:
-      - network-environment
       - kubeconfig
       - kubelet

--- a/ansible/_kubelet-master.yaml
+++ b/ansible/_kubelet-master.yaml
@@ -10,6 +10,5 @@
       - kubernetes_schedulable: false
 
     roles:
-      - network-environment
       - kubeconfig
       - kubelet

--- a/ansible/_kubelet-worker.yaml
+++ b/ansible/_kubelet-worker.yaml
@@ -10,6 +10,5 @@
       - kubernetes_schedulable: true
 
     roles:
-      - network-environment
       - kubeconfig
       - kubelet

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -8,8 +8,8 @@ kismatic_kubernetes_node_apt_version: 1.5.1-1
 kismatic_kubernetes_etcd_apt_version: 1.5.1-1
 kismatic_docker_engine_apt_version: 1.11.2-0~xenial
 
-calico_docker_version: v0.22.0
-calico_kube_policy_controller_version: v0.4.0
+calico_docker_version: "v1.0.0"
+calico_kube_policy_controller_version: "v0.4.0"
 kubedns_version: "1.9"
 kube_dnsmasq_version: "1.4"
 exechealthz_version: "1.2"
@@ -66,19 +66,18 @@ docker_certificates_key_path: "{{ docker_install_dir }}/{{ docker_certificates_k
 #===============================================================================
 # calico
 # directories
-network_plugin_bin_dir: /opt/cni/bin
+calico_dir: /etc/calico
 # paths
-calico_conf_path: "{{network_plugin_dir}}/10-calico.conf"
-network_environment_path: "/etc/network-environment"
+calico_ippool_path: "{{ calico_dir }}/ip-pool.yaml"
+calicoctl_conf_path: "{{ calico_dir }}/calicoctl.cfg"
 #file modes
 calico_executable_mode: 0775
 #networking
 modify_hosts_file: false
-default_cidr: 192.168.0.0/16
-kubernetes_dns_service_ip: 10.3.0.10
+kubernetes_dns_service_ip: 172.17.0.2
 kubernetes_dns_service_addr: https://{{kubernetes_dns_service_ip}}:{{kubernetes_master_secure_port}}
-kubernetes_services_cidr: 10.3.0.0/24
-kubernetes_pods_cidr: 10.2.0.0/16
+kubernetes_services_cidr: 172.17.0.0/16
+kubernetes_pods_cidr: 172.16.0.0/16
 calico_network_type: overlay # Default to the overlay type. Must be 'routed' or 'overlay'
 enable_calico_policy: false
 #===============================================================================

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -1,11 +1,11 @@
 #===============================================================================
 # VERSIONS
-kismatic_kubernetes_master_yum_version: 1.5.1_1-1
-kismatic_kubernetes_node_yum_version: 1.5.1_1-1
-kismatic_kubernetes_etcd_yum_version: 1.5.1_1-1
-kismatic_kubernetes_master_apt_version: 1.5.1-1
-kismatic_kubernetes_node_apt_version: 1.5.1-1
-kismatic_kubernetes_etcd_apt_version: 1.5.1-1
+kismatic_kubernetes_master_yum_version: 1.5.1_3-1
+kismatic_kubernetes_node_yum_version: 1.5.1_3-1
+kismatic_kubernetes_etcd_yum_version: 1.5.1_3-1
+kismatic_kubernetes_master_apt_version: 1.5.1-3
+kismatic_kubernetes_node_apt_version: 1.5.1-3
+kismatic_kubernetes_etcd_apt_version: 1.5.1-3
 kismatic_docker_engine_apt_version: 1.11.2-0~xenial
 
 calico_docker_version: "v1.0.0"

--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -2,50 +2,27 @@
   ## Configure a calico pool for the nodes. We need to configure calico
   ## before starting calico-node on the nodes due to
   ## https://github.com/projectcalico/calico-containers/issues/716
-  # Check if default pool exists
-  - name: check if default pool ({{default_cidr}})  exists
-    command: calicoctl pool show --ipv4
-    register: calico_default_pool_check
-    environment:
-      DEFAULT_IPV4: "{{ internal_ipv4 }}"
-      ETCD_ENDPOINTS: "{{ etcd_networking_cluster_ip_list }}"
-      ETCD_CA_CERT_FILE: "{{ kubernetes_certificates_ca_path }}"
-      ETCD_CERT_FILE: "{{ kubernetes_certificates_cert_path }}"
-      ETCD_KEY_FILE: "{{ kubernetes_certificates_key_path }}"
-    when: "'master' in group_names"
-  - name: remove default CIDR - {{ default_cidr }}
-    command: calicoctl pool remove {{ default_cidr }}
-    environment:
-      DEFAULT_IPV4: "{{ internal_ipv4 }}"
-      ETCD_ENDPOINTS: "{{ etcd_networking_cluster_ip_list }}"
-      ETCD_CA_CERT_FILE: "{{ kubernetes_certificates_ca_path }}"
-      ETCD_CERT_FILE: "{{ kubernetes_certificates_cert_path }}"
-      ETCD_KEY_FILE: "{{ kubernetes_certificates_key_path }}"
-    ignore_errors: yes # TODO better way to handle when this is run more than once
-    # Only run on Master nodes if the default pool exists
-    when: "'master' in group_names and '{{ default_cidr }}' in calico_default_pool_check.stdout"
-    run_once: true
-  # Two networking modes are supported: 'routed' and 'overlay'. Depending on the mode
-  # the pool flags change. Mainly, --ipip is added when 'overlay' is specified.
-  - name: add pods CIDR (Routed mode) - {{ kubernetes_pods_cidr }}
-    command: calicoctl pool add {{ kubernetes_pods_cidr }} --nat-outgoing
-    environment:
-      DEFAULT_IPV4: "{{ internal_ipv4 }}"
-      ETCD_ENDPOINTS: "{{ etcd_networking_cluster_ip_list }}"
-      ETCD_CA_CERT_FILE: "{{ kubernetes_certificates_ca_path }}"
-      ETCD_CERT_FILE: "{{ kubernetes_certificates_cert_path }}"
-      ETCD_KEY_FILE: "{{ kubernetes_certificates_key_path }}"
-    when: "'master' in group_names and calico_network_type == 'routed'"
-    run_once: true
-  - name: add pods CIDR (Overlay mode) - {{ kubernetes_pods_cidr }}
-    command: calicoctl pool add {{ kubernetes_pods_cidr }} --nat-outgoing --ipip
-    environment:
-      DEFAULT_IPV4: "{{ internal_ipv4 }}"
-      ETCD_ENDPOINTS: "{{ etcd_networking_cluster_ip_list }}"
-      ETCD_CA_CERT_FILE: "{{ kubernetes_certificates_ca_path }}"
-      ETCD_CERT_FILE: "{{ kubernetes_certificates_cert_path }}"
-      ETCD_KEY_FILE: "{{ kubernetes_certificates_key_path }}"
-    when: "'master' in group_names and calico_network_type == 'overlay'"
+
+  - name: create /etc/calico directory
+    file:
+      path: "{{ calico_dir }}"
+      state: directory
+  - name: copy calicoctl.cfg to remote
+    template:
+      src: calicoctl.cfg.j2
+      dest: "{{ calicoctl_conf_path }}"
+      owner: "{{ kubernetes_owner }}"
+      group: "{{ kubernetes_group }}"
+      mode: "{{ network_environment_mode }}"
+  - name: copy ip-pool.yaml to remote
+    template:
+      src: ip-pool.yaml.j2
+      dest: "{{ calico_ippool_path }}"
+      owner: "{{ kubernetes_owner }}"
+      group: "{{ kubernetes_group }}"
+      mode: "{{ network_environment_mode }}"
+  - name: add pods CIDR - {{ kubernetes_pods_cidr }}
+    command: calicoctl apply -f {{ calico_ippool_path }}
     run_once: true
 
   ## Start calico-node serivce on the nodes after configuring the calico pool.

--- a/ansible/roles/calico/templates/10-calico.conf.j2
+++ b/ansible/roles/calico/templates/10-calico.conf.j2
@@ -5,6 +5,7 @@
     "etcd_cert_file": "{{ kubernetes_certificates_cert_path }}",
     "etcd_key_file": "{{ kubernetes_certificates_key_path }}",
     "etcd_ca_cert_file": "{{ kubernetes_certificates_ca_path }}",
+    "hostname": "{{ inventory_hostname }}",
     "kubernetes": {
       "kubeconfig": "{{ kubernetes_kubeconfig_path }}"
     },
@@ -14,8 +15,7 @@
     },
 {% endif %}
     "ipam": {
-      "type": "calico-ipam",
-      "subnet": "usePodCidr"
+      "type": "calico-ipam"
     },
     "log_level": "info"
 }

--- a/ansible/roles/calico/templates/calico-node.service.j2
+++ b/ansible/roles/calico/templates/calico-node.service.j2
@@ -6,12 +6,11 @@ After=docker.service
 
 [Service]
 User=root
-Environment=INTERNAL_IP={{ internal_ipv4 }}
+Environment=DEFAULT_IPV4={{ internal_ipv4 }}
+Environment=HOSTNAME={{ inventory_hostname }}
 Environment=DOCKER_IMAGE={{ calico_node_img }}
-EnvironmentFile={{ network_environment_path }}
-PermissionsStartOnly=true
-ExecStart={{ bin_dir }}/calicoctl node --ip=${INTERNAL_IP} --node-image=${DOCKER_IMAGE} --no-pull --detach=false
-Restart=always
+ExecStart={{ bin_dir }}/calicoctl node run --name=${HOSTNAME} --ip=${DEFAULT_IPV4} --node-image=${DOCKER_IMAGE} --no-default-ippools --init-system
+Restart=on-failure
 RestartSec=3
 
 [Install]

--- a/ansible/roles/calico/templates/calicoctl.cfg.j2
+++ b/ansible/roles/calico/templates/calicoctl.cfg.j2
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: calicoApiConfig
+metadata:
+spec:
+  etcdEndpoints: {{ etcd_networking_cluster_ip_list }}
+  etcdKeyFile: {{ kubernetes_certificates_key_path }}
+  etcdCertFile: {{ kubernetes_certificates_cert_path }}
+  etcdCACertFile: {{ kubernetes_certificates_ca_path }}

--- a/ansible/roles/calico/templates/ip-pool.yaml.j2
+++ b/ansible/roles/calico/templates/ip-pool.yaml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ipPool
+metadata:
+  cidr: "{{ kubernetes_pods_cidr }}"
+spec:
+  ipip:
+    enabled: {% if calico_network_type == 'overlay' %}true{% else %}false{% endif %}
+
+  nat-outgoing: true
+  disabled: false

--- a/ansible/roles/kubelet/templates/kubelet.service.j2
+++ b/ansible/roles/kubelet/templates/kubelet.service.j2
@@ -5,7 +5,7 @@ After=docker.service
 Requires=docker.service
 
 [Service]
-EnvironmentFile={{ network_environment_path }}
+Environment=INTERNAL_IP={{ internal_ipv4 }}
 Environment=CLUSTER_DNS={{ kubernetes_dns_service_ip }}
 Environment=HOSTNAME={{ inventory_hostname }}
 Environment=KUBECONFIG={{ kubernetes_kubeconfig_path }}
@@ -24,6 +24,7 @@ ExecStart=/usr/bin/kubelet \
   --hostname-override=${HOSTNAME} \
   --require-kubeconfig \
   --kubeconfig=${KUBECONFIG} \
+  --node-ip=${INTERNAL_IP} \
   --pod-infra-container-image=${INFRA_IMG} \
   --register-schedulable=${REGISTER_SCHEDULABLE} \
   --serialize-image-pulls=false \

--- a/ansible/roles/network-environment/tasks/main.yaml
+++ b/ansible/roles/network-environment/tasks/main.yaml
@@ -1,8 +1,0 @@
----
-  - name: copy network-environment to remote
-    template:
-      src: network-environment.j2
-      dest: "{{ network_environment_path }}"
-      owner: "{{ kubernetes_owner }}"
-      group: "{{ kubernetes_group }}"
-      mode: "{{ network_environment_mode }}"

--- a/ansible/roles/network-environment/templates/network-environment.j2
+++ b/ansible/roles/network-environment/templates/network-environment.j2
@@ -1,5 +1,0 @@
-DEFAULT_IPV4={{ internal_ipv4 }}
-ETCD_ENDPOINTS={{ etcd_networking_cluster_ip_list }}
-ETCD_CA_CERT_FILE={{ kubernetes_certificates_ca_path }}
-ETCD_CERT_FILE={{ kubernetes_certificates_cert_path }}
-ETCD_KEY_FILE={{ kubernetes_certificates_key_path }}

--- a/docs/PROVISION.md
+++ b/docs/PROVISION.md
@@ -128,7 +128,7 @@ If you are building a large cluster or one that won't have access to these repos
     <td>yes</td>
   </tr>
   <tr>
-    <td>Kismatic package of Calico 0.22.0</td>
+    <td>Kismatic package of Calico 2.0.0</td>
     <td>inter-pod networking</td>
     <td></td>
     <td>yes</td>

--- a/docs/PROVISION.md
+++ b/docs/PROVISION.md
@@ -142,14 +142,14 @@ If you are building a large cluster or one that won't have access to these repos
     <td></td>
   </tr>
   <tr>
-    <td>Kismatic package of Kubernetes Master 1.5.1-1</td>
+    <td>Kismatic package of Kubernetes Master 1.5.1-3</td>
     <td>Kubernetes</td>
     <td></td>
     <td>yes </td>
     <td></td>
   </tr>
   <tr>
-    <td>Kismatic package of Kubernetes Worker 1.5.1-1</td>
+    <td>Kismatic package of Kubernetes Worker 1.5.1-3</td>
     <td>Kubernetes</td>
     <td></td>
     <td></td>

--- a/integration/prepare.go
+++ b/integration/prepare.go
@@ -20,18 +20,18 @@ import (
 
 const (
 	copyKismaticYumRepo        = `sudo curl https://kismatic-packages-rpm.s3-accelerate.amazonaws.com/kismatic.repo -o /etc/yum.repos.d/kismatic.repo`
-	installEtcdYum             = `sudo yum -y install kismatic-etcd-1.5.1_1-1`
+	installEtcdYum             = `sudo yum -y install kismatic-etcd-1.5.1_1-3`
 	installDockerEngineYum     = `sudo yum -y install kismatic-docker-engine-1.11.2-1.el7.centos`
-	installKubernetesMasterYum = `sudo yum -y install kismatic-kubernetes-master-1.5.1_1-1`
-	installKubernetesYum       = `sudo yum -y install kismatic-kubernetes-node-1.5.1_1-1`
+	installKubernetesMasterYum = `sudo yum -y install kismatic-kubernetes-master-1.5.1_3-1`
+	installKubernetesYum       = `sudo yum -y install kismatic-kubernetes-node-1.5.1_3-1`
 
 	copyKismaticKeyDeb         = `wget -qO - https://kismatic-packages-deb.s3-accelerate.amazonaws.com/public.key | sudo apt-key add - `
 	copyKismaticRepoDeb        = `sudo add-apt-repository "deb https://kismatic-packages-deb.s3-accelerate.amazonaws.com xenial main"`
 	updateAptGet               = `sudo apt-get update`
-	installEtcdApt             = `sudo apt-get -y install kismatic-etcd=1.5.1-1`
+	installEtcdApt             = `sudo apt-get -y install kismatic-etcd=1.5.1-3`
 	installDockerApt           = `sudo apt-get -y install kismatic-docker-engine=1.11.2-0~xenial`
-	installKubernetesMasterApt = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-1 kismatic-kubernetes-node=1.5.1-1 kismatic-kubernetes-master=1.5.1-1`
-	installKubernetesApt       = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-1 kismatic-kubernetes-node=1.5.1-1`
+	installKubernetesMasterApt = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-3 kismatic-kubernetes-node=1.5.1-3 kismatic-kubernetes-master=1.5.1-3`
+	installKubernetesApt       = `sudo apt-get -y install kismatic-kubernetes-networking=1.5.1-3 kismatic-kubernetes-node=1.5.1-3`
 )
 
 type nodePrep struct {

--- a/integration/prepare.go
+++ b/integration/prepare.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	copyKismaticYumRepo        = `sudo curl https://kismatic-packages-rpm.s3-accelerate.amazonaws.com/kismatic.repo -o /etc/yum.repos.d/kismatic.repo`
-	installEtcdYum             = `sudo yum -y install kismatic-etcd-1.5.1_1-3`
+	installEtcdYum             = `sudo yum -y install kismatic-etcd-1.5.1_3-1`
 	installDockerEngineYum     = `sudo yum -y install kismatic-docker-engine-1.11.2-1.el7.centos`
 	installKubernetesMasterYum = `sudo yum -y install kismatic-kubernetes-master-1.5.1_3-1`
 	installKubernetesYum       = `sudo yum -y install kismatic-kubernetes-node-1.5.1_3-1`

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -103,53 +103,53 @@ const defaultRuleSet = `---
 - kind: PackageAvailable
   when: ["etcd", "ubuntu"]
   packageName: kismatic-etcd
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-3
 - kind: PackageAvailable
   when: ["master","ubuntu"]
   packageName: kismatic-kubernetes-master
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-3
 - kind: PackageAvailable
   when: ["worker","ubuntu"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-3
 - kind: PackageAvailable
   when: ["ingress","ubuntu"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1-1
+  packageVersion: 1.5.1-3
 
 - kind: PackageAvailable
   when: ["etcd", "centos"]
   packageName: kismatic-etcd
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 - kind: PackageAvailable
   when: ["master","centos"]
   packageName: kismatic-kubernetes-master
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 - kind: PackageAvailable
   when: ["worker","centos"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 - kind: PackageAvailable
   when: ["ingress","centos"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 
 - kind: PackageAvailable
   when: ["etcd", "rhel"]
   packageName: kismatic-etcd
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 - kind: PackageAvailable
   when: ["master","rhel"]
   packageName: kismatic-kubernetes-master
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 - kind: PackageAvailable
   when: ["worker","rhel"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 - kind: PackageAvailable
   when: ["ingress","rhel"]
   packageName: kismatic-kubernetes-node
-  packageVersion: 1.5.1_1-1
+  packageVersion: 1.5.1_3-1
 `
 
 // DefaultRules returns the list of rules that are built into the inspector


### PR DESCRIPTION
Fixes #206, #29

This updates to calicoctl and calico-node to `v1.0.0`
* Calico UX was modified to closer reflect that off kubernetes, hence the commands changes
* `network-environment` file is no longer required
* Modified Anisble default network vars to reflect the default in the CLI

Upstream issue https://github.com/projectcalico/calicoctl/issues/716 of intermittent networking issues fixed in Calico `v2.0.0`(the versioning is confusing but Calico `v2.0.0` includes calicoctl and calico-node to `v1.0.0`)