### PR TITLE
Add UTC timestamps to the ansible log

### DIFF
--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"bufio"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -387,15 +388,16 @@ func (ae *ansibleExecutor) getAnsibleRunnerAndExplainer(explainer explain.Ansibl
 	if ae.runnerExplainerFactory != nil {
 		return ae.runnerExplainerFactory(explainer, ansibleLog)
 	}
+
 	// Setup sinks for explainer and ansible stdout
 	var explainerOut, ansibleOut io.Writer
 	switch ae.consoleOutputFormat {
 	case ansible.JSONLinesFormat:
 		explainerOut = ae.stdout
-		ansibleOut = ansibleLog
+		ansibleOut = timestampWriter(ansibleLog)
 	case ansible.RawFormat:
 		explainerOut = ioutil.Discard
-		ansibleOut = io.MultiWriter(ae.stdout, ansibleLog)
+		ansibleOut = io.MultiWriter(ae.stdout, timestampWriter(ansibleLog))
 	}
 
 	// Send stdout and stderr to ansibleOut
@@ -464,4 +466,16 @@ func installNodeToAnsibleNode(n *Node, s *SSHConfig) ansible.Node {
 		SSHUser:       s.User,
 		SSHPort:       s.Port,
 	}
+}
+
+// Prepend each line of the incoming stream with a timestamp
+func timestampWriter(out io.Writer) io.Writer {
+	pr, pw := io.Pipe()
+	go func(r io.Reader) {
+		s := bufio.NewScanner(r)
+		for s.Scan() {
+			fmt.Fprintf(out, "%s - %s\n", time.Now().UTC().Format("2006-01-02 15:04:05.000-0700"), s.Text())
+		}
+	}(pr)
+	return pw
 }


### PR DESCRIPTION
Add UTC timestamps to ansible log file:

Sample: 
```
2017-01-03 16:21:39.691+0000 - ansible/bin/ansible-playbook -i ansible/inventory.ini -s ansible/playbooks/preflight.yaml --extra-vars {"allow_package_installation":"true","kismatic_preflight_checker":"inspector/linux/amd64/kismatic-inspector","kismatic_preflight_checker_local":"/Users/abrand/Dev/go/src/github.com/apprenda/kismatic/out/ansible/playbooks/inspector/darwin/amd64/kismatic-inspector","modify_hosts_file":"true"} -vvvv
2017-01-03 16:21:40.268+0000 -  [WARNING]: Optional dependency 'cryptography' raised an exception, falling
2017-01-03 16:21:40.268+0000 - back to 'Crypto'
2017-01-03 16:21:40.420+0000 - Using ansible/playbooks/ansible.cfg as config file
2017-01-03 16:21:40.597+0000 - Loaded callback default of type stdout, v2.0
2017-01-03 16:21:40.621+0000 - Loaded callback json-lines of type notification, v2.0
2017-01-03 16:21:40.647+0000 -
2017-01-03 16:21:40.647+0000 - PLAYBOOK: preflight.yaml *******************************************************
2017-01-03 16:21:40.647+0000 - 3 plays in ansible/playbooks/preflight.yaml
2017-01-03 16:21:40.661+0000 -
```
