### PR TITLE
Improved version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 # Set the build version
 ifeq ($(origin VERSION), undefined)
-	VERSION := $(shell git rev-parse --short HEAD)
+	VERSION := $(shell git describe --tags --always --dirty)
+endif
+# build date
+ifeq ($(origin BUILD_DATE), undefined)
+	BUILD_DATE := $(shell date -u)
 endif
 
 # Setup some useful vars
@@ -15,7 +19,7 @@ ifeq ($(origin GOOS), undefined)
 endif
 
 build: vendor
-	go build -o bin/kismatic -ldflags "-X main.version=$(VERSION)" ./cmd/kismatic
+	go build -o bin/kismatic -ldflags "-X main.version=$(VERSION) -X 'main.buildDate=$(BUILD_DATE)'" ./cmd/kismatic
 	GOOS=linux go build -o bin/inspector/linux/$(HOST_GOARCH)/kismatic-inspector ./cmd/kismatic-inspector
 	GOOS=darwin go build -o bin/inspector/darwin/$(HOST_GOARCH)/kismatic-inspector ./cmd/kismatic-inspector
 

--- a/cmd/kismatic-docs/main.go
+++ b/cmd/kismatic-docs/main.go
@@ -1,4 +1,5 @@
-package main // Set via linker flag
+package main
+
 import (
 	"os"
 
@@ -7,9 +8,9 @@ import (
 )
 
 var version string
+var buildDate string
 
 func main() {
-
-	cmd, _ := cli.NewKismaticCommand(version, os.Stdin, os.Stdout)
+	cmd, _ := cli.NewKismaticCommand(version, buildDate, os.Stdin, os.Stdout)
 	doc.GenMarkdownTree(cmd, "./docs/kismatic-cli")
 }

--- a/cmd/kismatic/main.go
+++ b/cmd/kismatic/main.go
@@ -9,18 +9,16 @@ import (
 
 // Set via linker flag
 var version string
+var buildDate string
 
 func main() {
-
-	cmd, err := cli.NewKismaticCommand(version, os.Stdin, os.Stdout)
+	cmd, err := cli.NewKismaticCommand(version, buildDate, os.Stdin, os.Stdout)
 	if err != nil {
 		util.PrintColor(os.Stderr, util.Red, "Error initializing command: %v\n", err)
 		os.Exit(1)
 	}
-
 	if err := cmd.Execute(); err != nil {
 		util.PrintColor(os.Stderr, util.Red, "%v\n", err)
 		os.Exit(1)
 	}
-
 }

--- a/pkg/cli/kismatic.go
+++ b/pkg/cli/kismatic.go
@@ -7,11 +7,11 @@ import (
 )
 
 // NewKismaticCommand creates the kismatic command
-func NewKismaticCommand(version string, in io.Reader, out io.Writer) (*cobra.Command, error) {
+func NewKismaticCommand(version string, buildDate string, in io.Reader, out io.Writer) (*cobra.Command, error) {
 	cmd := &cobra.Command{
 		Use:   "kismatic",
 		Short: "kismatic is the main tool for managing your Kubernetes cluster",
-		Long: `kismatic is the main tool for managing your Kubernetes cluster  
+		Long: `kismatic is the main tool for managing your Kubernetes cluster
 more documentation is availble at https://github.com/apprenda/kismatic`,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmd.Help()
@@ -20,7 +20,7 @@ more documentation is availble at https://github.com/apprenda/kismatic`,
 		SilenceErrors: true,
 	}
 
-	cmd.AddCommand(NewCmdVersion(version, out))
+	cmd.AddCommand(NewCmdVersion(version, buildDate, out))
 	cmd.AddCommand(NewCmdInstall(in, out))
 
 	return cmd, nil

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -3,17 +3,21 @@ package cli
 import (
 	"fmt"
 	"io"
+	"runtime"
 
 	"github.com/spf13/cobra"
 )
 
 // NewCmdVersion returns the version command
-func NewCmdVersion(version string, out io.Writer) *cobra.Command {
+func NewCmdVersion(version string, buildDate string, out io.Writer) *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "display the Kismatic CLI version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Fprintf(out, "Kismatic version: %s\n", version)
+			fmt.Fprintln(out, "Kismatic:")
+			fmt.Fprintf(out, "  Version: %s\n", version)
+			fmt.Fprintf(out, "  Built: %s\n", buildDate)
+			fmt.Fprintf(out, "  Go Version: %s\n", runtime.Version())
 		},
 	}
 }


### PR DESCRIPTION
Now that we will build a release after tagging, it seems appropriate to improve the version command.

The new version command will have the version (e.g. `v1.1.1` for a tagged version, or `v1.1.0-11-gaa03a54` for a dev version), the build date and the Go version.

Output:
```
# ./kismatic version
Kismatic:
  Version: v1.1.0-11-gaa03a54
  Built: Wed Jan  4 13:02:55 UTC 2017
  Go Version: go1.7.1
```