### PR TITLE
Smoketest as step command fix

### DIFF
--- a/integration/step_test.go
+++ b/integration/step_test.go
@@ -25,5 +25,19 @@ var _ = Describe("install step commands", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
+		Context("Running the smoketest play against an existing cluster", func() {
+			ItOnAWS("should return successfully", func(provisioner infrastructureProvisioner) {
+				WithMiniInfrastructure(CentOS7, provisioner, func(node NodeDeets, sshKey string) {
+					err := installKismaticMini(node, sshKey)
+					Expect(err).ToNot(HaveOccurred())
+
+					c := exec.Command("./kismatic", "install", "step", "_smoketest.yaml", "-f", "kismatic-testing.yaml")
+					c.Stdout = os.Stdout
+					c.Stderr = os.Stderr
+					err = c.Run()
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
 	})
 })

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -186,6 +186,7 @@ func (ae *ansibleExecutor) buildInstallExtraVars(p *Plan, tlsDirectory string) (
 		"modify_hosts_file":          strconv.FormatBool(p.Cluster.Networking.UpdateHostsFiles),
 		"enable_calico_policy":       strconv.FormatBool(p.Cluster.Networking.PolicyEnabled),
 		"allow_package_installation": strconv.FormatBool(p.Cluster.AllowPackageInstallation),
+		"kuberang_path":              filepath.Join("kuberang", "linux", "amd64", "kuberang"),
 	}
 
 	// Setup FQDN or default to first master


### PR DESCRIPTION
Fixes #219 

`kuberang_path` was missing in the variables. 