### PR TITLE
Reduce retries on ingress integration test

### DIFF
--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					WithInfrastructure(NodeCount{1, 1, 1, 1}, Ubuntu1604LTS, provisioner, func(nodes provisionedNodes, sshKey string) {
 						err := installKismatic(nodes, installOpts, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNodes(nodes, sshKey)
+						err = verifyIngressNodes(nodes.master[0], nodes.ingress, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
@@ -85,7 +85,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					WithInfrastructure(NodeCount{1, 1, 1, 1}, CentOS7, provisioner, func(nodes provisionedNodes, sshKey string) {
 						err := installKismatic(nodes, installOpts, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNodes(nodes, sshKey)
+						err = verifyIngressNodes(nodes.master[0], nodes.ingress, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
@@ -95,7 +95,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					WithInfrastructure(NodeCount{1, 1, 1, 1}, RedHat7, provisioner, func(nodes provisionedNodes, sshKey string) {
 						err := installKismatic(nodes, installOpts, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNodes(nodes, sshKey)
+						err = verifyIngressNodes(nodes.master[0], nodes.ingress, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
@@ -105,7 +105,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					WithInfrastructure(NodeCount{3, 2, 3, 2}, CentOS7, provisioner, func(nodes provisionedNodes, sshKey string) {
 						err := installKismatic(nodes, installOpts, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNodes(nodes, sshKey)
+						err = verifyIngressNodes(nodes.master[0], nodes.ingress, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
@@ -130,7 +130,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					WithMiniInfrastructure(CentOS7, provisioner, func(node NodeDeets, sshKey string) {
 						err := installKismaticMini(node, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNode(node, sshKey)
+						err = verifyIngressNodes(node, []NodeDeets{node}, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
@@ -140,7 +140,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 					WithMiniInfrastructure(Ubuntu1604LTS, provisioner, func(node NodeDeets, sshKey string) {
 						err := installKismaticMini(node, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNode(node, sshKey)
+						err = verifyIngressNodes(node, []NodeDeets{node}, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
@@ -202,7 +202,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 						}
 						err := installKismatic(nodes, installOpts, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNodes(nodes, sshKey)
+						err = verifyIngressNodes(nodes.master[0], nodes.ingress, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
@@ -223,7 +223,7 @@ var _ = Describe("Happy Path Installation Tests", func() {
 						}
 						err = installKismatic(nodes, installOpts, sshKey)
 						Expect(err).ToNot(HaveOccurred())
-						err = verifyIngressNodes(nodes, sshKey)
+						err = verifyIngressNodes(nodes.master[0], nodes.ingress, sshKey)
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})


### PR DESCRIPTION
After catching an integration test that timed out, and doing a post-mortem on the nodes that were left over, I noticed that pulling the images used in the ingress integration test was failing:

```
 28m 23m 3 {kubelet ip-10-0-3-14} Warning  FailedSync	Error syncing pod, skipping: failed to "StartContainer" for "echoserver" with ErrImagePull: "image pull failed for gcr.io/google_containers/echoserver:1.0, this may be because there are no credentials on this request.  details: (net/http: request canceled)"
```

This leads me to believe that the integration tests are sometimes getting stuck in the ingress verification retry loop. 

As a first step, I propose reducing the number of retries as I prefer a test that fails over a test that times out the entire suite on Snap. Once we have a couple of runs with reduced retries, we can continue investigating / improving.