### PR TITLE
Add timeout to integration SSH check

### DIFF
--- a/integration/provision.go
+++ b/integration/provision.go
@@ -435,7 +435,9 @@ func (p packetProvisioner) waitForPublicIP(nodeID string) (*packet.Node, error) 
 func waitForSSH(provisionedNodes provisionedNodes, sshKey string) error {
 	nodes := provisionedNodes.allNodes()
 	for _, n := range nodes {
-		BlockUntilSSHOpen(n.PublicIP, n.SSHUser, sshKey)
+		if open := WaitUntilSSHOpen(n.PublicIP, n.SSHUser, sshKey, 5 * time.Minute); !open {
+			return fmt.Errorf("Timed out waiting for SSH at %q", n.PublicIP)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If a node provisioned by the integration test does not start up properly (I've seen it on AWS), the integration test will get stuck waiting for SSH. 

For this reason, the SSH check should be bounded with a timeout.