### PR TITLE
Use nginx instead of the large echoserver image

### DIFF
--- a/integration/install.go
+++ b/integration/install.go
@@ -166,9 +166,6 @@ func verifyIngressNodes(master NodeDeets, ingressNodes []NodeDeets, sshKey strin
 	By("Adding a service and an ingress resource")
 	addIngressResource(master, sshKey)
 
-	By("Waiting a bit before attempting to verify ingress")
-	time.Sleep(90*time.Second)
-
 	By("Verifying the service is accessible via the ingress point(s)")
 	for _, ingNode := range ingressNodes {
 		if err := verifyIngressPoint(ingNode); err != nil {

--- a/integration/test-resources/ingress.yaml
+++ b/integration/test-resources/ingress.yaml
@@ -23,7 +23,7 @@ spec:
     spec:
       containers:
       - image: nginx
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: echoserver
         ports:
         - containerPort: 80
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
       - image: nginx
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: echoserver-tls
         ports:
         - containerPort: 80

--- a/integration/test-resources/ingress.yaml
+++ b/integration/test-resources/ingress.yaml
@@ -22,7 +22,7 @@ spec:
         app: echoserver
     spec:
       containers:
-      - image: gcr.io/google_containers/echoserver:1.0
+      - image: nginx
         imagePullPolicy: Always
         name: echoserver
         ports:
@@ -52,7 +52,7 @@ spec:
         app: echoserver-tls
     spec:
       containers:
-      - image: gcr.io/google_containers/echoserver:1.0
+      - image: nginx
         imagePullPolicy: Always
         name: echoserver-tls
         ports:

--- a/integration/test-resources/ingress.yaml
+++ b/integration/test-resources/ingress.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 80
     protocol: TCP
   selector:
     app: echoserver
@@ -26,7 +26,7 @@ spec:
         imagePullPolicy: Always
         name: echoserver
         ports:
-        - containerPort: 8080
+        - containerPort: 80
 ---
 apiVersion: v1
 kind: Service
@@ -35,7 +35,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: 8080
+    targetPort: 80
     protocol: TCP
   selector:
     app: echoserver-tls
@@ -56,7 +56,7 @@ spec:
         imagePullPolicy: Always
         name: echoserver-tls
         ports:
-        - containerPort: 8080
+        - containerPort: 80
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress


### PR DESCRIPTION
The echoserver image is 650Mbs, the nginx box is already there from the smoketest