### PR TITLE
Add validation for duplicate IP/Hostname inside the same node group

### DIFF
--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -543,3 +543,62 @@ func TestValidatePlanMissingSomeCerts(t *testing.T) {
 		fmt.Println(errs)
 	}
 }
+
+func TestValidateNodeGroupDuplicateIP(t *testing.T) {
+	ng := NodeGroup{
+		ExpectedCount: 2,
+		Nodes: []Node{
+			{
+				Host: "host1",
+				IP:   "10.0.0.1",
+			},
+			{
+				Host: "host2",
+				IP:   "10.0.0.1",
+			},
+		},
+	}
+	if ok, _ := ng.validate(); ok {
+		t.Errorf("validation passed with duplicate IP")
+	}
+}
+
+func TestValidateNodeGroupDuplicateHostname(t *testing.T) {
+	ng := NodeGroup{
+		ExpectedCount: 2,
+		Nodes: []Node{
+			{
+				Host: "host1",
+				IP:   "10.0.0.1",
+			},
+			{
+				Host: "host1",
+				IP:   "10.0.0.2",
+			},
+		},
+	}
+	if ok, _ := ng.validate(); ok {
+		t.Errorf("validation passed with duplicate hostname")
+	}
+}
+
+func TestValidateNodeGroupDuplicateInternalIPs(t *testing.T) {
+	ng := NodeGroup{
+		ExpectedCount: 2,
+		Nodes: []Node{
+			{
+				Host:       "host1",
+				IP:         "10.0.0.1",
+				InternalIP: "192.168.205.10",
+			},
+			{
+				Host:       "host2",
+				IP:         "10.0.0.2",
+				InternalIP: "192.168.205.10",
+			},
+		},
+	}
+	if ok, _ := ng.validate(); ok {
+		t.Errorf("validation passed with duplicate hostname")
+	}
+}


### PR DESCRIPTION
Fixes #264 

Sample output:
```
./kismatic install validate

Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [ERROR]
- Storage nodes: Node #2 has the same hostname "node001" as node #1
- Storage nodes: Node #2 has the same IP "192.168.42.2" as node #1
Plan file validation error prevents installation from proceeding
```