### PR TITLE
Update to ansible 2.2.1.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 HOST_GOOS = $(shell go env GOOS)
 HOST_GOARCH = $(shell go env GOARCH)
 GLIDE_VERSION = v0.11.1
-ANSIBLE_VERSION = 2.1.4.0
+ANSIBLE_VERSION = 2.2.1.0
 PROVISIONER_VERSION = v1.1
 
 ifeq ($(origin GLIDE_GOOS), undefined)


### PR DESCRIPTION
It's possible that some of the slowness we are seeing with ansible is due to a regression in ansible 2.1. I am basing this on https://bugzilla.redhat.com/show_bug.cgi?id=1360440

Opening this PR to see if we experience any drastic improvement in the test runs.