### PR TITLE
Add NFS volume validation

### DIFF
--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -42,6 +42,7 @@ var _ = Describe("kismatic", func() {
 				Expect(helpText).To(ContainSubstring("3 worker nodes"))
 				Expect(helpText).To(ContainSubstring("2 ingress nodes"))
 				Expect(helpText).To(ContainSubstring("0 storage nodes"))
+				Expect(helpText).To(ContainSubstring("0 nfs volumes"))
 
 				Expect(FileExists("kismatic-cluster.yaml")).To(Equal(true))
 
@@ -63,6 +64,7 @@ var _ = Describe("kismatic", func() {
 				Expect(planFromYaml.Worker.ExpectedCount).To(Equal(3))
 				Expect(planFromYaml.Ingress.ExpectedCount).To(Equal(2))
 				Expect(planFromYaml.Storage.ExpectedCount).To(Equal(0))
+				Expect(len(planFromYaml.NFS.Volumes)).To(Equal(0))
 			})
 		})
 	})

--- a/integration/planfile.go
+++ b/integration/planfile.go
@@ -44,6 +44,9 @@ type ClusterPlan struct {
 		ExpectedCount int `yaml:"expected_count"`
 		Nodes         []NodePlan
 	}
+	NFS struct {
+		Volumes []NFSVolume `yaml:"nfs_volume"`
+	}
 }
 
 type NodePlan struct {

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -174,15 +174,6 @@ func WritePlanTemplate(p *Plan, w PlanReadWriter) error {
 		}
 	}
 
-	p.NFS = NFS{
-		Volumes: []NFSVolume{
-			NFSVolume{
-				Host: "",
-				Path: "/",
-			},
-		},
-	}
-
 	if err := w.Write(p); err != nil {
 		return fmt.Errorf("error writing installation plan template: %v", err)
 	}

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -377,11 +377,26 @@ func (nfs *NFS) validate() (bool, []error) {
 	v := newValidator()
 	uniqueVolumes := make(map[NFSVolume]bool)
 	for _, vol := range nfs.Volumes {
+		v.validate(vol)
 		if _, ok := uniqueVolumes[vol]; ok {
 			v.addError(fmt.Errorf("Duplicate NFS volume %v", vol))
 		} else {
 			uniqueVolumes[vol] = true
 		}
+	}
+	return v.valid()
+}
+
+func (nfsVol NFSVolume) validate() (bool, []error) {
+	v := newValidator()
+	if nfsVol.Host == "" {
+		v.addError(errors.New("NFS volume host cannot be empty"))
+	}
+	if nfsVol.Path == "" {
+		v.addError(errors.New("NFS volume path cannot be empty"))
+	}
+	if len(nfsVol.Path) > 0 && nfsVol.Path[0] != '/' {
+		v.addError(errors.New("NFS volume path must be absolute"))
 	}
 	return v.valid()
 }

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -455,6 +455,44 @@ func TestValidatePlanNFSDupes(t *testing.T) {
 	assertInvalidPlan(t, p)
 }
 
+func TestValidateNFSVolume(t *testing.T) {
+	tests := []struct {
+		host  string
+		path  string
+		valid bool
+	}{
+		{
+			host:  "10.10.2.10",
+			path:  "/foo",
+			valid: true,
+		},
+		{
+			host:  "10.10.2.10",
+			path:  "",
+			valid: false,
+		},
+		{
+			host:  "10.10.2.10",
+			path:  "../someRelativePath",
+			valid: false,
+		},
+		{
+			host:  "",
+			path:  "/foo",
+			valid: false,
+		},
+	}
+	for _, test := range tests {
+		v := NFSVolume{
+			Host: test.host,
+			Path: test.path,
+		}
+		if valid, _ := v.validate(); valid != test.valid {
+			t.Errorf("Expected valid = %v, but got %v", test.valid, valid)
+		}
+	}
+}
+
 func TestValidatePlanCerts(t *testing.T) {
 	p := &validPlan
 


### PR DESCRIPTION
Given that the default plan file includes a bad NFS volume, the installation fails at a late stage, resulting in confusion on the user's end. 

To fix this, I added validation to the NFS volume and  also included a new question in the planning stage:
```
Number of existing NFS volumes to be attached
```
