### PR TITLE
Pipelining support

### DIFF
--- a/ansible/roles/all/tasks/main.yaml
+++ b/ansible/roles/all/tasks/main.yaml
@@ -1,3 +1,13 @@
 ---
 - name: Install python 2.7
   script: python27.sh
+
+- name: detect SSH pipelining support
+  shell: grep --extended-regexp "^\w+\s+requiretty" /etc/sudoers || echo "string not found"
+  register: requiretty
+  changed_when: False
+
+- name: enable SSH pipelining
+  set_fact:
+    ansible_ssh_pipelining: yes
+  when: requiretty.stdout == "string not found"

--- a/integration/docker_registry_test.go
+++ b/integration/docker_registry_test.go
@@ -15,7 +15,7 @@ var _ = Describe("kismatic docker registry feature", func() {
 
 	Describe("enabling the internal docker registry feature", func() {
 		ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
-			WithInfrastructure(NodeCount{1, 1, 1, 0, 0}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
+			WithInfrastructure(NodeCount{1, 1, 1, 0, 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 				opts := installOptions{
 					allowPackageInstallation:    true,
 					autoConfigureDockerRegistry: true,
@@ -28,7 +28,7 @@ var _ = Describe("kismatic docker registry feature", func() {
 
 	Describe("using an existing private docker registry", func() {
 		ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
-			WithInfrastructure(NodeCount{1, 1, 1, 0, 0}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
+			WithInfrastructure(NodeCount{1, 1, 1, 0, 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 				By("Installing an external Docker registry on one of the nodes")
 				dockerRegistryPort := 8443
 				caFile, err := deployDockerRegistry(nodes.etcd[0], dockerRegistryPort, sshKey)

--- a/integration/hosts_file_test.go
+++ b/integration/hosts_file_test.go
@@ -16,7 +16,7 @@ var _ = Describe("hosts file modification feature", func() {
 
 	Describe("enabling the hosts file modification feature", func() {
 		ItOnAWS("should result in a functional cluster [slow]", func(aws infrastructureProvisioner) {
-			WithInfrastructure(NodeCount{1, 1, 2, 0, 0}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
+			WithInfrastructure(NodeCount{1, 1, 2, 0, 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 				By("Setting the hostnames to be different than the actual ones")
 
 				loadBalancedFQDN := nodes.master[0].PublicIP

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -85,7 +85,7 @@ var _ = Describe("kismatic", func() {
 				allowPackageInstallation: true,
 			}
 			ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
-				WithInfrastructure(NodeCount{1, 1, 1, 1, 1}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
+				WithInfrastructure(NodeCount{1, 1, 1, 1, 1}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 					err := installKismatic(nodes, installOpts, sshKey)
 					Expect(err).ToNot(HaveOccurred())
 				})
@@ -124,7 +124,7 @@ var _ = Describe("kismatic", func() {
 		// This spec is open to modification when new assertions have to be made
 		Context("when deploying a skunkworks cluster", func() {
 			ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
-				WithInfrastructureAndDNS(NodeCount{3, 2, 3, 2, 2}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
+				WithInfrastructureAndDNS(NodeCount{3, 2, 3, 2, 2}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 					// reserve one of the workers for the add-worker test
 					allWorkers := nodes.worker
 					nodes.worker = allWorkers[0 : len(nodes.worker)-1]
@@ -168,7 +168,7 @@ var _ = Describe("kismatic", func() {
 		})
 
 		ItOnPacket("should install successfully [slow]", func(packet infrastructureProvisioner) {
-			WithMiniInfrastructure(CentOS7, packet, func(node NodeDeets, sshKey string) {
+			WithMiniInfrastructure(Ubuntu1604LTS, packet, func(node NodeDeets, sshKey string) {
 				err := installKismaticMini(node, sshKey)
 				Expect(err).ToNot(HaveOccurred())
 			})

--- a/integration/step_test.go
+++ b/integration/step_test.go
@@ -16,7 +16,7 @@ var _ = Describe("install step commands", func() {
 
 	Describe("Running the api server play against an existing cluster", func() {
 		ItOnAWS("should return successfully [slow]", func(aws infrastructureProvisioner) {
-			WithMiniInfrastructure(CentOS7, aws, func(node NodeDeets, sshKey string) {
+			WithMiniInfrastructure(Ubuntu1604LTS, aws, func(node NodeDeets, sshKey string) {
 				err := installKismaticMini(node, sshKey)
 				Expect(err).ToNot(HaveOccurred())
 

--- a/integration/storage_test.go
+++ b/integration/storage_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Storage feature", func() {
 	Describe("Deploying a stateful workload", func() {
 		Context("on a cluster with storage nodes", func() {
 			ItOnAWS("should be able to read/write to a persistent volume [slow]", func(aws infrastructureProvisioner) {
-				WithInfrastructure(NodeCount{Etcd: 1, Master: 1, Worker: 2, Storage: 2}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
+				WithInfrastructure(NodeCount{Etcd: 1, Master: 1, Worker: 2, Storage: 2}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 					By("Installing a cluster with storage")
 					opts := installOptions{
 						allowPackageInstallation: true,

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Upgrade", func() {
 			// This spec is open to modification when new assertions have to be made.
 			Context("Using a skunkworks cluster", func() {
 				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
-					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 3, Ingress: 2, Storage: 2}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
+					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 3, Ingress: 2, Storage: 2}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 						// reserve one of the workers for the add-worker test
 						allWorkers := nodes.worker
 						nodes.worker = allWorkers[0 : len(nodes.worker)-1]

--- a/integration/validate_test.go
+++ b/integration/validate_test.go
@@ -33,9 +33,9 @@ var _ = Describe("kismatic install validate tests", func() {
 	})
 
 	Describe("Running validation with bad SSH key", func() {
-		Context("Using CentOS 7", func() {
+		Context("Using Ubuntu 16.04", func() {
 			ItOnAWS("should result in an ssh validation error", func(aws infrastructureProvisioner) {
-				WithMiniInfrastructure(CentOS7, aws, func(node NodeDeets, sshKey string) {
+				WithMiniInfrastructure(Ubuntu1604LTS, aws, func(node NodeDeets, sshKey string) {
 					badSSHKey, err := getBadSSHKeyFile()
 					if err != nil {
 						Fail("Unexpected error generating fake SSH key: %v")


### PR DESCRIPTION
Enabling pipelining in Ansible reduces the number of SSH connections
opened for each task performed. It is not enabled by default because
it is incompatible with the `requiretty` setting that is found
in some Linux distributions' default sudoers configuration.

With this change, we enable pipelining at the node level if we detect
that the sudoers file does not have the `requiretty` setting.

Given that CentOS does not support pipelining out of the box, I have also changed most of our integration tests to use Ubuntu instead.