### PR TITLE
Use Node instead of just IP in ListableNode struct

### DIFF
--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -102,7 +102,7 @@ func doUpgradeOffline(out io.Writer, planFile string, opts upgradeOpts) error {
 	if len(toSkip) > 0 {
 		util.PrintHeader(out, "Skipping nodes", '=')
 		for _, n := range toSkip {
-			util.PrettyPrintOk(out, "- %q is at the target version %q", n.IP, n.Version)
+			util.PrettyPrintOk(out, "- %q is at the target version %q", n.Node.IP, n.Version)
 		}
 		fmt.Fprintln(out)
 	}

--- a/pkg/install/about.go
+++ b/pkg/install/about.go
@@ -28,7 +28,7 @@ type ClusterVersion struct {
 }
 
 type ListableNode struct {
-	IP      string
+	Node    Node
 	Roles   []string
 	Version Version
 }
@@ -82,15 +82,15 @@ func parseVersion(versionString string) Version {
 }
 
 func ListVersions(plan *Plan) (ClusterVersion, error) {
-	ips := plan.GetUniqueNodeIPs()
+	nodes := plan.GetUniqueNodes()
 
 	cv := ClusterVersion{
 		Nodes: []ListableNode{},
 	}
 
-	for i, ip := range ips {
+	for i, node := range nodes {
 		sshDeets := plan.Cluster.SSH
-		client, err := ssh.NewClient(ip, sshDeets.Port, sshDeets.User, sshDeets.Key)
+		client, err := ssh.NewClient(node.IP, sshDeets.Port, sshDeets.User, sshDeets.Key)
 		if err != nil {
 			return cv, fmt.Errorf("error creating SSH client: %v", err)
 		}
@@ -115,7 +115,7 @@ func ListVersions(plan *Plan) (ClusterVersion, error) {
 			}
 		}
 
-		cv.Nodes = append(cv.Nodes, ListableNode{ip, plan.GetRolesForIP(ip), thisVersion})
+		cv.Nodes = append(cv.Nodes, ListableNode{node, plan.GetRolesForIP(node.IP), thisVersion})
 	}
 
 	cv.IsTransitioning = cv.EarliestVersion != cv.LatestVersion

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -370,11 +370,8 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 	for _, nodeToUpgrade := range nodesToUpgrade {
 		for _, role := range nodeToUpgrade.Roles {
 			if role == "etcd" {
-				node, err := plan.getNodeWithIP(nodeToUpgrade.IP)
-				if err != nil {
-					return err
-				}
-				if err := ae.upgradeNode(plan, *node); err != nil {
+				node := nodeToUpgrade.Node
+				if err := ae.upgradeNode(plan, node); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Host, err)
 				}
 				upgradedNodes[node.IP] = true
@@ -385,16 +382,13 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 
 	// Upgrade master nodes
 	for _, nodeToUpgrade := range nodesToUpgrade {
-		if upgradedNodes[nodeToUpgrade.IP] == true {
+		if upgradedNodes[nodeToUpgrade.Node.IP] == true {
 			continue
 		}
 		for _, role := range nodeToUpgrade.Roles {
 			if role == "master" {
-				node, err := plan.getNodeWithIP(nodeToUpgrade.IP)
-				if err != nil {
-					return err
-				}
-				if err := ae.upgradeNode(plan, *node); err != nil {
+				node := nodeToUpgrade.Node
+				if err := ae.upgradeNode(plan, node); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Host, err)
 				}
 				upgradedNodes[node.IP] = true
@@ -405,16 +399,13 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 
 	// Upgrade the rest of the nodes
 	for _, nodeToUpgrade := range nodesToUpgrade {
-		if upgradedNodes[nodeToUpgrade.IP] == true {
+		if upgradedNodes[nodeToUpgrade.Node.IP] == true {
 			continue
 		}
 		for _, role := range nodeToUpgrade.Roles {
 			if role != "etcd" && role != "master" {
-				node, err := plan.getNodeWithIP(nodeToUpgrade.IP)
-				if err != nil {
-					return err
-				}
-				if err := ae.upgradeNode(plan, *node); err != nil {
+				node := nodeToUpgrade.Node
+				if err := ae.upgradeNode(plan, node); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Host, err)
 				}
 				upgradedNodes[node.IP] = true

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -112,22 +112,19 @@ type SSHConnection struct {
 	Node      *Node
 }
 
-func (p *Plan) GetUniqueNodeIPs() []string {
-	ipMap := make(map[string]bool)
-	nodes := p.getAllNodes()
-	for _, node := range nodes {
-		ipMap[node.IP] = true
+// GetUniqueNodes returns a list of the unique nodes that are listed in the plan file.
+// That is, if a node has multiple roles, it will only appear once in the list.
+func (p *Plan) GetUniqueNodes() []Node {
+	seenNodes := map[Node]bool{}
+	nodes := []Node{}
+	for _, node := range p.getAllNodes() {
+		if seenNodes[node] {
+			continue
+		}
+		nodes = append(nodes, node)
+		seenNodes[node] = true
 	}
-
-	ips := make([]string, len(ipMap))
-
-	i := 0
-	for k := range ipMap {
-		ips[i] = k
-		i++
-	}
-
-	return ips
+	return nodes
 }
 
 func (p *Plan) getAllNodes() []Node {


### PR DESCRIPTION
The ListableNode struct only included the node's IP, which resulted in some awkward usage and the need to lookup nodes in the plan using an IP address. With this change, the Node is part of the ListableNode struct.

Also added SSH connectivity validation to the info command, as it was succeeding with non-existent infrastructure.