### PR TITLE
Force apt-get overwrite. Restart docker if package was installed

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -7,13 +7,15 @@
       enabled: yes
     when: force_docker_restart is not defined or force_docker_restart|bool == false # only run if not going to restart right after
 
-  # force_docker_restart=true to force restart
-  - name: force restart docker
+  # set force_docker_restart=true to force restart
+  - name: restart docker service
     service:
       name: docker
       state: restarted
       enabled: yes
-    when: force_docker_restart is defined and force_docker_restart|bool == true
+    when: > 
+      (force_docker_restart is defined and force_docker_restart|bool == true) or 
+      (docker_installation is defined and docker_installation|success)
 
   - name: verify docker is running
     command: docker ps

--- a/ansible/roles/packages/handlers/main.yaml
+++ b/ansible/roles/packages/handlers/main.yaml
@@ -11,8 +11,8 @@
   - name: install docker-engine yum package
     yum: name=docker-engine-{{ docker_engine_yum_version }} state=present
     when: "'worker' in group_names or 'ingress' in group_names or 'storage' in group_names or 'master' in group_names"
-    register: result
-    until: result|success
+    register: docker_installation
+    until: docker_installation|success
     retries: 3
     delay: 3
 
@@ -34,7 +34,11 @@
 
   # install DEB packages
   - name: install etcd deb package
-    apt: name=etcd={{ etcd_apt_version }} state=present default_release=kismatic-xenial
+    apt:
+      name: etcd={{etcd_apt_version}}
+      state: present
+      default_release: kismatic-xenial
+      dpkg_options: force-confdef,force-confold,force-overwrite
     when: "'etcd' in group_names"
     register: result
     until: result|success
@@ -42,15 +46,23 @@
     delay: 3
 
   - name: install docker-engine deb package
-    apt: name=docker-engine={{ docker_engine_apt_version }} state=present default_release=kismatic-xenial
+    apt: 
+      name: docker-engine={{ docker_engine_apt_version }} 
+      state: present 
+      default_release: kismatic-xenial
+      dpkg_options: force-confdef,force-confold,force-overwrite
     when: "'worker' in group_names or 'ingress' in group_names or 'storage' in group_names or 'master' in group_names"
-    register: result
-    until: result|success
+    register: docker_installation
+    until: docker_installation|success
     retries: 3
     delay: 3
 
   - name: install kubelet deb package
-    apt: name=kubelet={{ kismatic_apt_version }} state=present default_release=kismatic-xenial
+    apt: 
+      name: kubelet={{ kismatic_apt_version }} 
+      state: present 
+      default_release: kismatic-xenial
+      dpkg_options: force-confdef,force-confold,force-overwrite
     when: "'worker' in group_names or 'ingress' in group_names or 'storage' in group_names or 'master' in group_names"
     register: result
     until: result|success
@@ -58,7 +70,11 @@
     delay: 3
 
   - name: install kubectl deb package
-    apt: name=kubectl={{ kismatic_apt_version }} state=present default_release=kismatic-xenial
+    apt: 
+      name: kubectl={{ kismatic_apt_version }} 
+      state: present 
+      default_release: kismatic-xenial
+      dpkg_options: force-confdef,force-confold,force-overwrite
     when: "'master' in group_names"
     register: result
     until: result|success


### PR DESCRIPTION
Fixes #295 and #296 

Changes:
- Restart docker service if a new docker package was installed
- Force apt-get install to overwrite files