### PR TITLE
Initial work on online upgrade command

### DIFF
--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -17,7 +17,7 @@ type ClusterCatalog struct {
 	EnableModifyHosts         bool   `yaml:"modify_hosts_file"`
 	EnableCalicoPolicy        bool   `yaml:"enable_calico_policy"`
 	EnablePackageInstallation bool   `yaml:"allow_package_installation"`
-	DisconnectedInstallation         bool   `yaml:"disconnected_installation"`
+	DisconnectedInstallation  bool   `yaml:"disconnected_installation"`
 	KuberangPath              string `yaml:"kuberang_path"`
 	LoadBalancedFQDN          string `yaml:"kubernetes_load_balanced_fqdn"`
 

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -1,59 +1,78 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/apprenda/kismatic/pkg/data"
 	"github.com/apprenda/kismatic/pkg/install"
 	"github.com/apprenda/kismatic/pkg/util"
 	"github.com/spf13/cobra"
 )
 
-// NewCmdUpgrade returns the upgrade command
-func NewCmdUpgrade(out io.Writer) *cobra.Command {
-	var planFile string
-	cmd := &cobra.Command{
-		Use:   "upgrade",
-		Short: "upgrade your Kubernetes cluster",
-		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Help()
-		},
-	}
-
-	// Subcommands
-	cmd.AddCommand(NewCmdUpgradeOffline(out, &planFile))
-	addPlanFileFlag(cmd.PersistentFlags(), &planFile)
-	return cmd
-}
-
 type upgradeOpts struct {
 	generatedAssetsDir string
-	restartServices    bool
 	verbose            bool
 	outputFormat       string
 	skipPreflight      bool
+	online             bool
+	planFile           string
+	restartServices    bool
+}
+
+// NewCmdUpgrade returns the upgrade command
+func NewCmdUpgrade(out io.Writer) *cobra.Command {
+	var opts upgradeOpts
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "upgrade your Kubernetes cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.PersistentFlags().StringVar(&opts.generatedAssetsDir, "generated-assets-dir", "generated", "path to the directory where assets generated during the installation process will be stored")
+	cmd.PersistentFlags().BoolVar(&opts.verbose, "verbose", false, "enable verbose logging from the installation")
+	cmd.PersistentFlags().StringVarP(&opts.outputFormat, "output", "o", "simple", "installation output format (options \"simple\"|\"raw\")")
+	cmd.PersistentFlags().BoolVar(&opts.skipPreflight, "skip-preflight", false, "skip upgrade pre-flight checks")
+	cmd.PersistentFlags().BoolVar(&opts.restartServices, "restart-services", false, "force restart cluster services (Use with care)")
+	addPlanFileFlag(cmd.PersistentFlags(), &opts.planFile)
+
+	// Subcommands
+	cmd.AddCommand(NewCmdUpgradeOffline(out, &opts))
+	cmd.AddCommand(NewCmdUpgradeOnline(out, &opts))
+	return cmd
 }
 
 // NewCmdUpgradeOffline returns the command for running offline upgrades
-func NewCmdUpgradeOffline(out io.Writer, planFile *string) *cobra.Command {
-	opts := upgradeOpts{}
+func NewCmdUpgradeOffline(out io.Writer, opts *upgradeOpts) *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "offline",
 		Short: "perform an offline upgrade of your Kubernetes cluster",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return doUpgradeOffline(out, *planFile, opts)
+			return doUpgrade(out, opts)
 		},
 	}
-	cmd.Flags().StringVar(&opts.generatedAssetsDir, "generated-assets-dir", "generated", "path to the directory where assets generated during the installation process will be stored")
-	cmd.Flags().BoolVar(&opts.restartServices, "restart-services", false, "force restart cluster services (Use with care)")
-	cmd.Flags().BoolVar(&opts.verbose, "verbose", false, "enable verbose logging from the installation")
-	cmd.Flags().StringVarP(&opts.outputFormat, "output", "o", "simple", "installation output format (options \"simple\"|\"raw\")")
-	cmd.Flags().BoolVar(&opts.skipPreflight, "skip-preflight", false, "skip upgrade pre-flight checks")
 	return &cmd
 }
 
-func doUpgradeOffline(out io.Writer, planFile string, opts upgradeOpts) error {
+// NewCmdUpgradeOnline returns the command for running online upgrades
+func NewCmdUpgradeOnline(out io.Writer, opts *upgradeOpts) *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "online",
+		Short: "perform an online upgrade of your Kubernetes cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.online = true
+			return doUpgrade(out, opts)
+		},
+	}
+	return &cmd
+}
+
+func doUpgrade(out io.Writer, opts *upgradeOpts) error {
+	planFile := opts.planFile
 	planner := install.FilePlanner{File: planFile}
 	executorOpts := install.ExecutorOptions{
 		GeneratedAssetsDirectory: opts.generatedAssetsDir,
@@ -115,16 +134,8 @@ func doUpgradeOffline(out io.Writer, planFile string, opts upgradeOpts) error {
 	if len(toUpgrade) == 0 {
 		fmt.Fprintln(out, "All nodes are at the target version. Skipping node upgrades.")
 	} else {
-		// Run upgrade preflight on the nodes that are to be UpgradeNodes
-		if !opts.skipPreflight {
-			util.PrintHeader(out, "Validating nodes", '=')
-			if err := executor.RunUpgradePreFlightCheck(plan); err != nil {
-				return fmt.Errorf("Upgrade preflight check failed: %v", err)
-			}
-		}
-		// Run the upgrade on the nodes that need it
-		if err := executor.UpgradeNodes(*plan, toUpgrade); err != nil {
-			return fmt.Errorf("Failed to upgrade nodes: %v", err)
+		if err = upgradeNodes(out, *plan, *opts, toUpgrade, executor); err != nil {
+			return err
 		}
 	}
 
@@ -149,5 +160,47 @@ func doUpgradeOffline(out io.Writer, planFile string, opts upgradeOpts) error {
 	fmt.Fprintln(out)
 	util.PrintColor(out, util.Green, "Upgrade complete\n")
 	fmt.Fprintln(out)
+	return nil
+}
+
+func upgradeNodes(out io.Writer, plan install.Plan, opts upgradeOpts, toUpgrade []install.ListableNode, executor install.Executor) error {
+	// Validate that we are able to perform an online upgrade
+	if opts.online {
+		util.PrintHeader(out, "Validate Online Upgrade", '=')
+		var foundErrs bool
+		// Use the first master node for running kubectl
+		client, _ := plan.GetSSHClient(plan.Master.Nodes[0].Host)
+		kubeClient := data.RemoteKubectl{SSHClient: client}
+		for _, node := range toUpgrade {
+			util.PrettyPrint(out, "Node %q", node.Node.Host)
+			errs := install.DetectNodeUpgradeSafety(plan, node.Node, kubeClient)
+			if len(errs) != 0 {
+				foundErrs = true
+				util.PrintError(out)
+				fmt.Fprintln(out)
+				for _, err := range errs {
+					fmt.Println("-", err.Error())
+				}
+			} else {
+				util.PrintOkln(out)
+			}
+		}
+		if foundErrs {
+			return errors.New("Unable to perform an online upgrade due to the unsafe conditions detected.")
+		}
+	}
+
+	// Run upgrade preflight on the nodes that are to be UpgradeNodes
+	if !opts.skipPreflight {
+		util.PrintHeader(out, "Validating nodes", '=')
+		if err := executor.RunUpgradePreFlightCheck(&plan); err != nil {
+			return fmt.Errorf("Upgrade preflight check failed: %v", err)
+		}
+	}
+
+	// Run the upgrade on the nodes that need it
+	if err := executor.UpgradeNodes(plan, toUpgrade); err != nil {
+		return fmt.Errorf("Failed to upgrade nodes: %v", err)
+	}
 	return nil
 }

--- a/pkg/data/kubernetes.go
+++ b/pkg/data/kubernetes.go
@@ -8,12 +8,44 @@ import (
 	"github.com/apprenda/kismatic/pkg/ssh"
 )
 
+// PodLister lists pods on a Kubernetes cluster
 type PodLister interface {
 	ListPods() (*PodList, error)
 }
 
+// PVLister lists persistent volumes that exist on a Kubernetes cluster
 type PVLister interface {
 	ListPersistentVolumes() (*PersistentVolumeList, error)
+}
+
+// PersistentVolumeGetter gets a persistent volume
+type PersistentVolumeGetter interface {
+	GetPersistentVolume(name string) (*PersistentVolume, error)
+}
+
+// PersistentVolumeClaimGetter gets a persistent volume claim
+type PersistentVolumeClaimGetter interface {
+	GetPersistentVolumeClaim(namespace, name string) (*PersistentVolumeClaim, error)
+}
+
+// DaemonSetGetter gets a given daemonset
+type DaemonSetGetter interface {
+	GetDaemonSet(namespace, name string) (*DaemonSet, error)
+}
+
+// ReplicationControllerGetter gets a replication controller
+type ReplicationControllerGetter interface {
+	GetReplicationController(namespace, name string) (*ReplicationController, error)
+}
+
+// ReplicaSetGetter gets a replica set
+type ReplicaSetGetter interface {
+	GetReplicaSet(namespace, name string) (*ReplicaSet, error)
+}
+
+// StatefulSetGetter gets a stateful set
+type StatefulSetGetter interface {
+	GetStatefulSet(namespace, name string) (*StatefulSet, error)
 }
 
 type KubernetesClient interface {
@@ -21,7 +53,9 @@ type KubernetesClient interface {
 	PVLister
 }
 
-// RemoteKubectl
+// RemoteKubectl is a kubectl client that uses an underlying SSH connection
+// to connect to a node that has the kubectl binary. It is expected that this
+// node has access to a kubernetes cluster via kubectl.
 type RemoteKubectl struct {
 	SSHClient ssh.Client
 }
@@ -32,13 +66,11 @@ func (k RemoteKubectl) ListPersistentVolumes() (*PersistentVolumeList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting persistent volume data: %v", err)
 	}
-
 	return UnmarshalPVs(pvRaw)
 }
 
 func UnmarshalPVs(raw string) (*PersistentVolumeList, error) {
-	// an empty JSON response from kubectl contains this string
-	if strings.Contains(strings.TrimSpace(raw), "No resources found") {
+	if isNoResourcesResponse(raw) {
 		return nil, nil
 	}
 	var pvs PersistentVolumeList
@@ -46,7 +78,6 @@ func UnmarshalPVs(raw string) (*PersistentVolumeList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling persistent volume data: %v", err)
 	}
-
 	return &pvs, nil
 }
 
@@ -56,13 +87,11 @@ func (k RemoteKubectl) ListPods() (*PodList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting pod data: %v", err)
 	}
-
 	return UnmarshalPods(podsRaw)
 }
 
 func UnmarshalPods(raw string) (*PodList, error) {
-	// an empty JSON response from kubectl contains this string
-	if strings.Contains(raw, "No resources found") {
+	if isNoResourcesResponse(raw) {
 		return nil, nil
 	}
 	var pods PodList
@@ -70,6 +99,121 @@ func UnmarshalPods(raw string) (*PodList, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshalling pod data: %v", err)
 	}
-
 	return &pods, nil
+}
+
+// GetDaemonSet returns the DaemonSet with the given namespace and name. If not found,
+// returns an error.
+func (k RemoteKubectl) GetDaemonSet(namespace, name string) (*DaemonSet, error) {
+	cmd := fmt.Sprintf("sudo kubectl get ds --namespace=%s -o json %s", namespace, name)
+	dsRaw, err := k.SSHClient.Output(true, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("error getting daemon sets: %v", err)
+	}
+	if isNoResourcesResponse(dsRaw) {
+		return nil, fmt.Errorf("DaemonSet %s/%s was not found", namespace, name)
+	}
+	var d DaemonSet
+	if err := json.Unmarshal([]byte(dsRaw), &d); err != nil {
+		return nil, fmt.Errorf("error unmarshalling daemonset: %v", err)
+	}
+	return &d, nil
+}
+
+// GetReplicationController returns the ReplicationController with the given name in the given namespace.
+// If not found, returns an error.
+func (k RemoteKubectl) GetReplicationController(namespace, name string) (*ReplicationController, error) {
+	cmd := fmt.Sprintf("sudo kubectl get replicationcontroller --namespace=%s -o json %s", namespace, name)
+	rcRaw, err := k.SSHClient.Output(true, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("error getting replication controller: %v", err)
+	}
+	if isNoResourcesResponse(rcRaw) {
+		return nil, fmt.Errorf("ReplicationController %s/%s was not found", namespace, name)
+	}
+	var r ReplicationController
+	if err := json.Unmarshal([]byte(rcRaw), &r); err != nil {
+		return nil, fmt.Errorf("error unmarshalling replication controller: %v", err)
+	}
+	return &r, nil
+}
+
+// GetReplicaSet returns the ReplicaSet with the given name in the given namespace.
+// If not found, returns an error.
+func (k RemoteKubectl) GetReplicaSet(namespace, name string) (*ReplicaSet, error) {
+	cmd := fmt.Sprintf("sudo kubectl get replicaset --namespace=%s -o json %s", namespace, name)
+	raw, err := k.SSHClient.Output(true, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("error getting ReplicaSet: %v", err)
+	}
+	if isNoResourcesResponse(raw) {
+		return nil, fmt.Errorf("ReplicaSet %s/%s was not found", namespace, name)
+	}
+	var r ReplicaSet
+	if err := json.Unmarshal([]byte(raw), &r); err != nil {
+		return nil, fmt.Errorf("error unmarshalling ReplicaSet: %v", err)
+	}
+	return &r, nil
+}
+
+// GetPersistentVolume returns the persistent volume with the given name.
+// If not found, returns an error.
+func (k RemoteKubectl) GetPersistentVolume(name string) (*PersistentVolume, error) {
+	cmd := fmt.Sprintf("sudo kubectl get pv -o json %s", name)
+	raw, err := k.SSHClient.Output(true, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("error getting PersistentVolume: %v", err)
+	}
+	if isNoResourcesResponse(raw) {
+		return nil, fmt.Errorf("PersistentVolume %s was not found", name)
+	}
+	var p PersistentVolume
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return nil, fmt.Errorf("error unmarshalling PersistentVolume: %v", err)
+	}
+	return &p, nil
+}
+
+// GetPersistentVolumeClaim returns the persistent volume claim with the given name and namespace.
+// If not found, returns an error.
+func (k RemoteKubectl) GetPersistentVolumeClaim(namespace, name string) (*PersistentVolumeClaim, error) {
+	cmd := fmt.Sprintf("sudo kubectl get pvc --namespace %s -o json %s", namespace, name)
+	raw, err := k.SSHClient.Output(true, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("error getting PersistentVolumeClaim: %v", err)
+	}
+	if isNoResourcesResponse(raw) {
+		return nil, fmt.Errorf("PersistentVolumeClaim %s was not found", name)
+	}
+	var p PersistentVolumeClaim
+	if err := json.Unmarshal([]byte(raw), &p); err != nil {
+		return nil, fmt.Errorf("error unmarshalling PersistentVolumeClaim: %v", err)
+	}
+	return &p, nil
+}
+
+// GetStatefulSet returns the stateful set with the given name in the given namespace.
+// If not found, returns an error.
+func (k RemoteKubectl) GetStatefulSet(namespace, name string) (*StatefulSet, error) {
+	cmd := fmt.Sprintf("sudo kubectl get statefulset --namespace %s -o json %s", namespace, name)
+	raw, err := k.SSHClient.Output(true, cmd)
+	if err != nil {
+		return nil, fmt.Errorf("error getting StatefulSet: %v", err)
+	}
+	if isNoResourcesResponse(raw) {
+		return nil, fmt.Errorf("StatefulSet %s/%s was not found", namespace, name)
+	}
+	var s StatefulSet
+	if err := json.Unmarshal([]byte(raw), &s); err != nil {
+		return nil, fmt.Errorf("error unmarshalling StatefulSet: %v", err)
+	}
+	return &s, nil
+}
+
+// kubectl will print this message when no resources are returned
+func isNoResourcesResponse(s string) bool {
+	if strings.Contains(strings.TrimSpace(s), "No resources found") {
+		return true
+	}
+	return false
 }

--- a/pkg/data/kubernetes_type.go
+++ b/pkg/data/kubernetes_type.go
@@ -1,89 +1,62 @@
 package data
 
 type PodList struct {
-	Items []Pod `json:"items" protobuf:"bytes,2,rep,name=items"`
+	Items []Pod `json:"items"`
 }
 
 type Pod struct {
-	// Standard object's metadata.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	// +optional
-	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// Specification of the desired behavior of the pod.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#spec-and-status
-	// +optional
-	Spec PodSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+	ObjectMeta `json:"metadata,omitempty"`
+	Spec       PodSpec `json:"spec,omitempty"`
 }
+
 type ObjectMeta struct {
-	// Annotations is an unstructured key value map stored with a resource that may be
-	// set by external tools to store and retrieve arbitrary metadata. They are not
-	// queryable and should be preserved when modifying objects.
-	// More info: http://kubernetes.io/docs/user-guide/annotations
-	// +optional
-	Annotations map[string]string `json:"annotations,omitempty" protobuf:"bytes,12,rep,name=annotations"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Name        string            `json:"name,omitempty"`
+	Namespace   string            `json:"namespace,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
 
-	// Name must be unique within a namespace. Is required when creating resources, although
-	// some resources may allow a client to request the generation of an appropriate name
-	// automatically. Name is primarily intended for creation idempotence and configuration
-	// definition.
-	// Cannot be updated.
-	// More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	// +optional
-	Name string `json:"name,omitempty" protobuf:"bytes,1,opt,name=name"`
+// ObjectReference contains enough information to let you inspect or modify the referred object.
+type ObjectReference struct {
+	Kind      string
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
 
-	// Namespace defines the space within each name must be unique. An empty namespace is
-	// equivalent to the "default" namespace, but "default" is the canonical representation.
-	// Not all objects are required to be scoped to a namespace - the value of this field for
-	// those objects will be empty.
-	//
-	// Must be a DNS_LABEL.
-	// Cannot be updated.
-	// More info: http://kubernetes.io/docs/user-guide/namespaces
-	// +optional
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,3,opt,name=namespace"`
-
-	// Map of string keys and values that can be used to organize and categorize
-	// (scope and select) objects. May match selectors of replication controllers
-	// and services.
-	// More info: http://kubernetes.io/docs/user-guide/labels
-	// +optional
-	Labels map[string]string `json:"labels,omitempty" protobuf:"bytes,11,rep,name=labels"`
+type SerializedReference struct {
+	TypeMeta
+	Reference ObjectReference
 }
 
 // PodSpec is a description of a pod.
 type PodSpec struct {
-	// List of volumes that can be mounted by containers belonging to the pod.
-	// More info: http://kubernetes.io/docs/user-guide/volumes
-	// +optional
-	Volumes []Volume `json:"volumes,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=volumes"`
-	// List of containers belonging to the pod.
-	// Containers cannot currently be added or removed.
-	// There must be at least one container in a Pod.
-	// Cannot be updated.
-	// More info: http://kubernetes.io/docs/user-guide/containers
-	Containers []Container `json:"containers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=containers"`
+	NodeName   string      `json:"nodeName"`
+	Volumes    []Volume    `json:"volumes,omitempty"`
+	Containers []Container `json:"containers"`
 }
 
 // Volume represents a named volume in a pod that may be accessed by any container in the pod.
 type Volume struct {
-	// Volume's name.
-	// Must be a DNS_LABEL and unique within the pod.
-	// More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
-	// VolumeSource represents the location and type of the mounted volume.
-	// If not specified, the Volume is implied to be an EmptyDir.
-	// This implied behavior is deprecated and will be removed in a future version.
-	VolumeSource `json:",inline" protobuf:"bytes,2,opt,name=volumeSource"`
+	Name         string `json:"name"`
+	VolumeSource `json:",inline"`
 }
 
 // Represents the source of a volume to mount.
 // Only one of its members may be specified.
 type VolumeSource struct {
-	// PersistentVolumeClaimVolumeSource represents a reference to a
-	// PersistentVolumeClaim in the same namespace.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims
-	// +optional
-	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty" protobuf:"bytes,10,opt,name=persistentVolumeClaim"`
+	HostPath              *HostPathVolumeSource              `json:"hostPath,omitempty"`
+	EmptyDir              *EmptyDirVolumeSource              `json:"emptyDir,omitempty"`
+	PersistentVolumeClaim *PersistentVolumeClaimVolumeSource `json:"persistentVolumeClaim,omitempty"`
+}
+
+// Represents a host path mapped into a pod.
+type HostPathVolumeSource struct {
+	Path string `json:"path"`
+}
+
+// Represents an empty directory for a pod.
+type EmptyDirVolumeSource struct {
+	Medium string `json:"medium,omitempty"`
 }
 
 // PersistentVolumeClaimVolumeSource references the user's PVC in the same namespace.
@@ -91,127 +64,86 @@ type VolumeSource struct {
 // PersistentVolumeClaimVolumeSource is, essentially, a wrapper around another
 // type of volume that is owned by someone else (the system).
 type PersistentVolumeClaimVolumeSource struct {
-	// ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistentvolumeclaims
-	ClaimName string `json:"claimName" protobuf:"bytes,1,opt,name=claimName"`
-	// Will force the ReadOnly setting in VolumeMounts.
-	// Default false.
-	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"`
+	ClaimName string `json:"claimName"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
 }
 
 // A single application container that you want to run within a pod.
 type Container struct {
-	// Name of the container specified as a DNS_LABEL.
-	// Each container in a pod must have a unique name (DNS_LABEL).
-	// Cannot be updated.
-	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
-	// Pod volumes to mount into the container's filesystem.
-	// Cannot be updated.
-	// +optional
-	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty" patchStrategy:"merge" patchMergeKey:"mountPath" protobuf:"bytes,9,rep,name=volumeMounts"`
+	Name         string        `json:"name"`
+	VolumeMounts []VolumeMount `json:"volumeMounts,omitempty"`
 }
 
 // VolumeMount describes a mounting of a Volume within a container.
 type VolumeMount struct {
-	// This must match the Name of a Volume.
-	Name string `json:"name" protobuf:"bytes,1,opt,name=name"`
-	// Mounted read-only if true, read-write otherwise (false or unspecified).
-	// Defaults to false.
-	// +optional
-	ReadOnly bool `json:"readOnly,omitempty" protobuf:"varint,2,opt,name=readOnly"`
-	// Path within the container at which the volume should be mounted.  Must
-	// not contain ':'.
-	MountPath string `json:"mountPath" protobuf:"bytes,3,opt,name=mountPath"`
-	// Path within the volume from which the container's volume should be mounted.
-	// Defaults to "" (volume's root).
-	// +optional
-	SubPath string `json:"subPath,omitempty" protobuf:"bytes,4,opt,name=subPath"`
+	Name      string `json:"name"`
+	ReadOnly  bool   `json:"readOnly,omitempty"`
+	MountPath string `json:"mountPath"`
+	// Path within the volume from which the container's volume should be mounted
+	SubPath string `json:"subPath,omitempty"`
 }
 
 // PersistentVolumeList is a list of PersistentVolume items.
 type PersistentVolumeList struct {
 	TypeMeta `json:",inline"`
-	// Standard list metadata.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
-	// +optional
-	ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-	// List of persistent volumes.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes
-	Items []PersistentVolume `json:"items" protobuf:"bytes,2,rep,name=items"`
+	ListMeta `json:"metadata,omitempty"`
+	Items    []PersistentVolume `json:"items"`
 }
 
 // PersistentVolume (PV) is a storage resource provisioned by an administrator.
 // It is analogous to a node.
-// More info: http://kubernetes.io/docs/user-guide/persistent-volumes
 type PersistentVolume struct {
-	TypeMeta `json:",inline"`
-	// Standard object's metadata.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#metadata
-	// +optional
-	ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+	Spec       PersistentVolumeSpec   `json:"spec,omitempty"`
+	Status     PersistentVolumeStatus `json:"status,omitempty"`
+}
 
-	// Spec defines a specification of a persistent volume owned by the cluster.
-	// Provisioned by an administrator.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistent-volumes
-	// +optional
-	Spec PersistentVolumeSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
+// Similar to VolumeSource but meant for the administrator who creates PVs.
+type PersistentVolumeSource struct {
+	// HostPath represents a directory on the host.
+	HostPath *HostPathVolumeSource
+}
 
-	// Status represents the current information/status for the persistent volume.
-	// Populated by the system.
-	// Read-only.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#persistent-volumes
-	// +optional
-	Status PersistentVolumeStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
+// PersistentVolumeClaim is a user's request for and claim to a persistent volume
+type PersistentVolumeClaim struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Spec defines the volume requested by a pod author
+	Spec PersistentVolumeClaimSpec
+}
+
+// PersistentVolumeClaimSpec describes the common attributes of storage devices
+// and allows a Source for provider-specific attributes
+type PersistentVolumeClaimSpec struct {
+	// VolumeName is the binding reference to the PersistentVolume backing this
+	// claim. When set to non-empty value Selector is not evaluated
+	VolumeName string
 }
 
 // TypeMeta describes an individual object in an API response or request
 // with strings representing the type of the object and its API schema version.
 // Structures that are versioned or persisted should inline TypeMeta.
 type TypeMeta struct {
-	// Kind is a string value representing the REST resource this object represents.
-	// Servers may infer this from the endpoint the client submits requests to.
-	// Cannot be updated.
-	// In CamelCase.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#types-kinds
-	// +optional
-	Kind string `json:"kind,omitempty" protobuf:"bytes,1,opt,name=kind"`
-
-	// APIVersion defines the versioned schema of this representation of an object.
-	// Servers should convert recognized schemas to the latest internal value, and
-	// may reject unrecognized values.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#resources
-	// +optional
-	APIVersion string `json:"apiVersion,omitempty" protobuf:"bytes,2,opt,name=apiVersion"`
+	Kind       string `json:"kind,omitempty"`
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // ListMeta describes metadata that synthetic resources must have, including lists and
 // various status objects. A resource may have only one of {ObjectMeta, ListMeta}.
 type ListMeta struct {
-	// SelfLink is a URL representing this object.
-	// Populated by the system.
-	// Read-only.
-	// +optional
-	SelfLink string `json:"selfLink,omitempty" protobuf:"bytes,1,opt,name=selfLink"`
-
-	// String that identifies the server's internal version of this object that
-	// can be used by clients to determine when objects have changed.
-	// Value must be treated as opaque by clients and passed unmodified back to the server.
-	// Populated by the system.
-	// Read-only.
-	// More info: http://releases.k8s.io/HEAD/docs/devel/api-conventions.md#concurrency-control-and-consistency
-	// +optional
-	ResourceVersion string `json:"resourceVersion,omitempty" protobuf:"bytes,2,opt,name=resourceVersion"`
+	SelfLink        string `json:"selfLink,omitempty"`
+	ResourceVersion string `json:"resourceVersion,omitempty"`
 }
 
 // PersistentVolumeSpec is the specification of a persistent volume.
 type PersistentVolumeSpec struct {
+	PersistentVolumeSource
 	// ClaimRef is part of a bi-directional binding between PersistentVolume and PersistentVolumeClaim.
 	// Expected to be non-nil when bound.
 	// claim.VolumeName is the authoritative bind between PV and PVC.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#binding
-	// +optional
-	ClaimRef *ObjectReference `json:"claimRef,omitempty" protobuf:"bytes,4,opt,name=claimRef"`
+	ClaimRef *ObjectReference `json:"claimRef,omitempty"`
 }
 
 type PersistentVolumePhase string
@@ -219,19 +151,86 @@ type PersistentVolumePhase string
 // PersistentVolumeStatus is the current status of a persistent volume.
 type PersistentVolumeStatus struct {
 	// Phase indicates if a volume is available, bound to a claim, or released by a claim.
-	// More info: http://kubernetes.io/docs/user-guide/persistent-volumes#phase
-	// +optional
-	Phase PersistentVolumePhase `json:"phase,omitempty" protobuf:"bytes,1,opt,name=phase,casttype=PersistentVolumePhase"`
+	Phase PersistentVolumePhase `json:"phase,omitempty"`
 }
 
-// ObjectReference contains enough information to let you inspect or modify the referred object.
-type ObjectReference struct {
-	// Namespace of the referent.
-	// More info: http://kubernetes.io/docs/user-guide/namespaces
-	// +optional
-	Namespace string `json:"namespace,omitempty" protobuf:"bytes,2,opt,name=namespace"`
-	// Name of the referent.
-	// More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	// +optional
-	Name string `json:"name,omitempty" protobuf:"bytes,3,opt,name=name"`
+// DaemonSetList is a collection of daemon sets.
+type DaemonSetList struct {
+	TypeMeta `json:",inline"`
+	ListMeta `json:"metadata,omitempty"`
+	// Items is a list of daemon sets.
+	Items []DaemonSet `json:"items"`
+}
+
+// DaemonSet represents the configuration of a daemon set.
+type DaemonSet struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+	Status     DaemonSetStatus `json:"status,omitempty"`
+}
+
+// DaemonSetStatus represents the current status of a daemon set.
+type DaemonSetStatus struct {
+	// CurrentNumberScheduled is the number of nodes that are running at least 1
+	// daemon pod and are supposed to run the daemon pod.
+	CurrentNumberScheduled int32 `json:"currentNumberScheduled"`
+
+	// NumberMisscheduled is the number of nodes that are running the daemon pod, but are
+	// not supposed to run the daemon pod.
+	NumberMisscheduled int32 `json:"numberMisscheduled"`
+
+	// DesiredNumberScheduled is the total number of nodes that should be running the daemon
+	// pod (including nodes correctly running the daemon pod).
+	DesiredNumberScheduled int32 `json:"desiredNumberScheduled"`
+
+	// NumberReady is the number of nodes that should be running the daemon pod and have one
+	// or more of the daemon pod running and ready.
+	NumberReady int32 `json:"numberReady"`
+}
+
+// ReplicationController represents the configuration of a replication controller.
+type ReplicationController struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Status is the current status of this replication controller. This data may be
+	// out of date by some window of time.
+	Status ReplicationControllerStatus
+}
+
+// ReplicationControllerStatus represents the current status of a replication
+// controller.
+type ReplicationControllerStatus struct {
+	// Replicas is the number of actual replicas.
+	Replicas int32
+}
+
+// ReplicaSet represents the configuration of a replica set.
+type ReplicaSet struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	// Status is the current status of this ReplicaSet. This data may be
+	// out of date by some window of time.
+	Status ReplicaSetStatus
+}
+
+// ReplicaSetStatus represents the current status of a ReplicaSet.
+type ReplicaSetStatus struct {
+	// Replicas is the number of actual replicas.
+	Replicas int32
+}
+
+// StatefulSet represents a set of pods with consistent identities.
+type StatefulSet struct {
+	TypeMeta   `json:",inline"`
+	ObjectMeta `json:"metadata,omitempty"`
+
+	Status StatefulSetStatus
+}
+
+// StatefulSetStatus represents the current status of a StatefulSet.
+type StatefulSetStatus struct {
+	// Replicas is the number of actual replicas.
+	Replicas int32
 }

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -697,12 +697,3 @@ func timestampWriter(out io.Writer) io.Writer {
 	}(pr)
 	return pw
 }
-
-func findNodeWithIP(nodes []Node, ip string) (*Node, error) {
-	for _, n := range nodes {
-		if n.IP == ip {
-			return &n, nil
-		}
-	}
-	return nil, fmt.Errorf("Node with IP %q not found", ip)
-}

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -1,0 +1,259 @@
+package install
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/apprenda/kismatic/pkg/data"
+)
+
+const kubeCreatedBy = "kubernetes.io/created-by"
+
+type upgradeKubeInfoClient interface {
+	data.PodLister
+	data.DaemonSetGetter
+	data.ReplicationControllerGetter
+	data.ReplicaSetGetter
+	data.PersistentVolumeClaimGetter
+	data.PersistentVolumeGetter
+	data.StatefulSetGetter
+}
+
+type masterNodeCountErr struct{}
+
+func (e masterNodeCountErr) Error() string {
+	return "This is the only master node in the cluster. " +
+		"Upgrading it will make the cluster unavailable."
+}
+
+type masterNodeLoadBalancingErr struct{}
+
+func (e masterNodeLoadBalancingErr) Error() string {
+	return "This node is acting as the load balanced endpoint for the master nodes. " +
+		"Upgrading it will make the cluster unavailable"
+}
+
+type ingressNotSupportedErr struct{}
+
+func (e ingressNotSupportedErr) Error() string {
+	return "Performing an online upgrade of ingress nodes is not supported."
+}
+
+type storageNotSupportedErr struct{}
+
+func (e storageNotSupportedErr) Error() string {
+	return "Performing an online upgrade of storage nodes is not supported."
+}
+
+type workerNodeCountErr struct{}
+
+func (e workerNodeCountErr) Error() string {
+	return "This is the only worker node in the cluster. " +
+		"Upgrading it will make cluster features unavailable."
+}
+
+type podUnsafeVolumeErr struct {
+	namespace string
+	name      string
+	volType   string
+	volName   string
+}
+
+func (e podUnsafeVolumeErr) Error() string {
+	return fmt.Sprintf(`Pod "%s/%s" is using %s volume %q, which is unsafe for upgrades.`, e.namespace, e.name, e.volType, e.volName)
+}
+
+type podUnsafePersistentVolumeErr struct {
+	namespace string
+	name      string
+	volType   string
+	volName   string
+}
+
+func (e podUnsafePersistentVolumeErr) Error() string {
+	return fmt.Sprintf(`Pod "%s/%s" is using volume %q, which is backed by a %s PersistentVolume. `+
+		`This kind of volume is unsafe for upgrades.`, e.namespace, e.name, e.volName, e.volType)
+}
+
+type podUnsafeDaemonErr struct {
+	dsNamespace string
+	dsName      string
+}
+
+func (e podUnsafeDaemonErr) Error() string {
+	return fmt.Sprintf(`Pod managed by DaemonSet "%s/%s" is running on this node, and no other nodes `+
+		"are capable of hosting this daemon. Upgrading it will make the daemon unavailable.", e.dsNamespace, e.dsName)
+}
+
+type unmanagedPodErr struct {
+	namespace string
+	name      string
+}
+
+func (e unmanagedPodErr) Error() string {
+	return fmt.Sprintf(`The pod "%s/%s" is not being managed by a controller. `+
+		"Upgrading this node might result in data or availability loss.", e.namespace, e.name)
+}
+
+type unsafeReplicaCountErr struct {
+	kind      string
+	namespace string
+	name      string
+}
+
+func (e unsafeReplicaCountErr) Error() string {
+	return fmt.Sprintf(`Pod managed by %s "%s/%s" is running on this node, `+
+		"and the %s does not have a replica count greater than 1.", e.kind, e.namespace, e.name, e.kind)
+}
+
+type podRunningJobErr struct {
+	namespace string
+	name      string
+}
+
+func (e podRunningJobErr) Error() string {
+	return fmt.Sprintf(`Pod that belongs to job "%s/%s" is running on this node.`, e.name, e.namespace)
+}
+
+// DetectNodeUpgradeSafety determines whether it's safe to upgrade a specific node
+// listed in the plan file. If any condition that could result in data or availability
+// loss is detected, the upgrade is deemed unsafe, and the conditions are returned as errors.
+func DetectNodeUpgradeSafety(plan Plan, node Node, kubeClient upgradeKubeInfoClient) []error {
+	errs := []error{}
+	roles := plan.GetRolesForIP(node.IP)
+	for _, role := range roles {
+		switch role {
+		case "master":
+			if plan.Master.ExpectedCount < 2 {
+				errs = append(errs, masterNodeCountErr{})
+			}
+			lbFQDN := plan.Master.LoadBalancedFQDN
+			if lbFQDN == node.Host || lbFQDN == node.IP {
+				errs = append(errs, masterNodeLoadBalancingErr{})
+			}
+		case "ingress":
+			// we don't control load balancing of ingress nodes. therefore,
+			// upgrading an ingress node is potentially unsafe
+			errs = append(errs, ingressNotSupportedErr{})
+		case "storage":
+			// we could potentially detect safety of upgrading storage nodes by inspecting
+			// the volumes on the node. for now, we are choosing not to support online upgrade of storage nodes
+			errs = append(errs, storageNotSupportedErr{})
+		case "worker":
+			if plan.Worker.ExpectedCount < 2 {
+				errs = append(errs, workerNodeCountErr{})
+			}
+			if workerErrs := detectWorkerNodeUpgradeSafety(node, kubeClient); workerErrs != nil {
+				errs = append(errs, workerErrs...)
+			}
+		}
+	}
+	return errs
+}
+
+func detectWorkerNodeUpgradeSafety(node Node, kubeClient upgradeKubeInfoClient) []error {
+	errs := []error{}
+	podList, err := kubeClient.ListPods()
+	if err != nil {
+		errs = append(errs, fmt.Errorf("unable to determine node upgrade safety: %v", err))
+		return errs
+	}
+	nodePods := []data.Pod{}
+	for _, p := range podList.Items {
+		if p.Spec.NodeName == node.Host {
+			nodePods = append(nodePods, p)
+		}
+	}
+
+	// Are there any pods using a hostPath, emptyDir volume OR a hostPath PersistentVolume?
+	for _, p := range nodePods {
+		for _, v := range p.Spec.Volumes {
+			if v.VolumeSource.HostPath != nil {
+				errs = append(errs, podUnsafeVolumeErr{namespace: p.Namespace, name: p.Name, volType: "HostPath", volName: v.Name})
+			}
+			if v.VolumeSource.EmptyDir != nil {
+				errs = append(errs, podUnsafeVolumeErr{namespace: p.Namespace, name: p.Name, volType: "EmptyDir", volName: v.Name})
+			}
+			if v.VolumeSource.PersistentVolumeClaim != nil {
+				claimRef := v.VolumeSource.PersistentVolumeClaim
+				pvc, err := kubeClient.GetPersistentVolumeClaim(p.Namespace, claimRef.ClaimName)
+				if err != nil {
+					errs = append(errs, fmt.Errorf(`Failed to get PersistentVolumeClaim "%s/%s."`, p.Namespace, claimRef.ClaimName))
+					continue
+				}
+				pvName := pvc.Spec.VolumeName
+				pv, err := kubeClient.GetPersistentVolume(pvName)
+				if err != nil {
+					errs = append(errs, fmt.Errorf(`Failed to get PersistentVolume %q. This PV is being used by pod "%s/%s" on this node`, pvName, p.Namespace, p.Name))
+					continue
+				}
+				if pv.Spec.HostPath != nil {
+					errs = append(errs, podUnsafePersistentVolumeErr{namespace: p.Namespace, name: p.Name, volType: "HostPath", volName: v.Name})
+				}
+			}
+		}
+	}
+
+	// 1. are there any pods running on this node that are not managed by a controller?
+	// 2. are there any pods running on this node that are managed by a controller,
+	//    and have replicas less than 2?
+	// 3. are there any daemonset managed pods running on this node? If so,
+	//    verify that it is not the only one
+	// 4. are there any pods that belong to a job running on this node?
+	for _, p := range nodePods {
+		creator, ok := p.Annotations[kubeCreatedBy]
+		if !ok {
+			errs = append(errs, unmanagedPodErr{namespace: p.Namespace, name: p.Name})
+			continue
+		}
+		var r data.SerializedReference
+		err := json.Unmarshal([]byte(creator), &r)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("Unable to determine the creator of pod %s/%s", p.Namespace, p.Name))
+			continue
+		}
+		switch strings.ToLower(r.Reference.Kind) {
+		default:
+			errs = append(errs, fmt.Errorf("Unable to determine upgrade safety for a pod managed by a controller of type %q", r.Reference.Kind))
+		case "daemonset":
+			ds, err := kubeClient.GetDaemonSet(r.Reference.Namespace, r.Reference.Name)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("DaemonSet pod is running, but failed to get information about DaemonSet %s/%s", r.Reference.Namespace, r.Reference.Name))
+				continue
+			}
+			// Check if other nodes should be running this DS
+			if ds.Status.DesiredNumberScheduled < 2 {
+				errs = append(errs, podUnsafeDaemonErr{dsNamespace: r.Reference.Namespace, dsName: r.Reference.Name})
+			}
+		case "job":
+			errs = append(errs, podRunningJobErr{namespace: r.Reference.Namespace, name: r.Reference.Name})
+		case "replicationcontroller":
+			rc, err := kubeClient.GetReplicationController(r.Reference.Namespace, r.Reference.Name)
+			if err != nil {
+				errs = append(errs, fmt.Errorf(`Failed to get information about replication controller "%s/%s"`, r.Reference.Namespace, r.Reference.Name))
+			}
+			if rc.Status.Replicas < 2 {
+				errs = append(errs, unsafeReplicaCountErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+			}
+		case "replicaset":
+			rs, err := kubeClient.GetReplicaSet(r.Reference.Namespace, r.Reference.Name)
+			if err != nil {
+				errs = append(errs, fmt.Errorf(`Failed to get information about replica set "%s/%s"`, r.Reference.Namespace, r.Reference.Name))
+			}
+			if rs.Status.Replicas < 2 {
+				errs = append(errs, unsafeReplicaCountErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+			}
+		case "statefulset":
+			sts, err := kubeClient.GetStatefulSet(r.Reference.Namespace, r.Reference.Name)
+			if err != nil {
+				errs = append(errs, fmt.Errorf(`Failed to get information about stateful set "%s/%s"`, r.Reference.Namespace, r.Reference.Name))
+			}
+			if sts.Status.Replicas < 2 {
+				errs = append(errs, unsafeReplicaCountErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+			}
+		}
+	}
+
+	return errs
+}

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -1,0 +1,709 @@
+package install
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/apprenda/kismatic/pkg/data"
+)
+
+type fakeUpgradeKubeClient struct {
+	listPods                 func() (*data.PodList, error)
+	getDaemonSet             func() (*data.DaemonSet, error)
+	getReplicationController func() (*data.ReplicationController, error)
+	getReplicaSet            func() (*data.ReplicaSet, error)
+	getPersistentVolume      func(name string) (*data.PersistentVolume, error)
+	getPersistentVolumeClaim func(name string) (*data.PersistentVolumeClaim, error)
+	getStatefulSet           func() (*data.StatefulSet, error)
+}
+
+func (f fakeUpgradeKubeClient) ListPods() (*data.PodList, error) {
+	if f.listPods != nil {
+		return f.listPods()
+	}
+	return &data.PodList{}, nil
+}
+
+func (f fakeUpgradeKubeClient) GetDaemonSet(namespace, name string) (*data.DaemonSet, error) {
+	if f.getDaemonSet != nil {
+		return f.getDaemonSet()
+	}
+	return nil, errors.New("DS not found")
+}
+
+func (f fakeUpgradeKubeClient) GetReplicationController(namespace, name string) (*data.ReplicationController, error) {
+	if f.getReplicationController != nil {
+		return f.getReplicationController()
+	}
+	return nil, errors.New("RC not found")
+}
+
+func (f fakeUpgradeKubeClient) GetReplicaSet(namespace, name string) (*data.ReplicaSet, error) {
+	if f.getReplicaSet != nil {
+		return f.getReplicaSet()
+	}
+	return nil, errors.New("RS not found")
+}
+
+func (f fakeUpgradeKubeClient) GetPersistentVolume(name string) (*data.PersistentVolume, error) {
+	if f.getPersistentVolume != nil {
+		return f.getPersistentVolume(name)
+	}
+	return nil, errors.New("PV not found")
+}
+
+func (f fakeUpgradeKubeClient) GetPersistentVolumeClaim(namespace, name string) (*data.PersistentVolumeClaim, error) {
+	if f.getPersistentVolumeClaim != nil {
+		return f.getPersistentVolumeClaim(name)
+	}
+	return nil, errors.New("PVC not found")
+}
+
+func (f fakeUpgradeKubeClient) GetStatefulSet(namespace, name string) (*data.StatefulSet, error) {
+	if f.getStatefulSet != nil {
+		return f.getStatefulSet()
+	}
+	return nil, errors.New("StatefulSet not found")
+}
+
+func getSafePodWithCreatedByRef(t *testing.T, nodeName string, createdByKind string) data.Pod {
+	createdByRef := data.SerializedReference{
+		Reference: data.ObjectReference{
+			Kind: createdByKind,
+		},
+	}
+	b, err := json.Marshal(createdByRef)
+	if err != nil {
+		t.Fatalf("failed to marshal SerializedReference: %v", err)
+	}
+	return data.Pod{
+		ObjectMeta: data.ObjectMeta{
+			Name:        "foo",
+			Namespace:   "foo",
+			Annotations: map[string]string{kubeCreatedBy: string(b)},
+		},
+		Spec: data.PodSpec{
+			NodeName: nodeName,
+		},
+	}
+}
+
+func TestDetectNodeUpgradeSafetyMasterCountUnsafe(t *testing.T) {
+	plan := Plan{
+		Master: MasterNodeGroup{
+			ExpectedCount: 1,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Master.Nodes[0]
+	k8sClient := fakeUpgradeKubeClient{}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(masterNodeCountErr); !ok {
+		t.Errorf("Expected masterNodeCountError, but got %v", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyMasterLoadBalancingUnsafe(t *testing.T) {
+	plan := Plan{
+		Master: MasterNodeGroup{
+			ExpectedCount:    2,
+			LoadBalancedFQDN: "foo",
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "bar",
+					IP:   "10.0.0.2",
+				},
+			},
+		},
+	}
+	node := plan.Master.Nodes[0]
+	k8sClient := fakeUpgradeKubeClient{}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(masterNodeLoadBalancingErr); !ok {
+		t.Errorf("Expected masterNodeCountError, but got %v", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyMasterLoadBalancingSafe(t *testing.T) {
+	plan := Plan{
+		Master: MasterNodeGroup{
+			ExpectedCount:    2,
+			LoadBalancedFQDN: "someLoadBalancer",
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "bar",
+					IP:   "10.0.0.2",
+				},
+			},
+		},
+	}
+	node := plan.Master.Nodes[0]
+	k8sClient := fakeUpgradeKubeClient{}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 0 {
+		t.Errorf("did not expect an error, but got %d", len(errs))
+	}
+}
+
+func TestDetectNodeUpgradeSafetyIngress(t *testing.T) {
+	plan := Plan{
+		Ingress: OptionalNodeGroup{
+			ExpectedCount: 1,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Ingress.Nodes[0]
+	k8sClient := fakeUpgradeKubeClient{}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(ingressNotSupportedErr); !ok {
+		t.Errorf("Expected ingressUnsupportedError, but got %v", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyStorage(t *testing.T) {
+	plan := Plan{
+		Storage: OptionalNodeGroup{
+			ExpectedCount: 1,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Storage.Nodes[0]
+	k8sClient := fakeUpgradeKubeClient{}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(storageNotSupportedErr); !ok {
+		t.Errorf("Expected storageUnsupportedError, but got %v", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyWorkerCountUnsafe(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 1,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+	k8sClient := fakeUpgradeKubeClient{}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(workerNodeCountErr); !ok {
+		t.Errorf("Expected storageUnsupportedError, but got %v", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyWorkerPodListError(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+	k8sClient := fakeUpgradeKubeClient{listPods: func() (*data.PodList, error) { return nil, errors.New("some error") }}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if !strings.Contains(errs[0].Error(), "some error") {
+		t.Errorf("unexpected error received: %v", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyWorkerPodHostPathVol(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+	pod := getSafePodWithCreatedByRef(t, node.Host, "replicationcontroller")
+	pod.Spec.Volumes = []data.Volume{
+		{
+			VolumeSource: data.VolumeSource{
+				HostPath: &data.HostPathVolumeSource{},
+			},
+		},
+	}
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getReplicationController: func() (*data.ReplicationController, error) {
+			return &data.ReplicationController{
+				Status: data.ReplicationControllerStatus{
+					Replicas: 2,
+				},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(podUnsafeVolumeErr); !ok {
+		t.Errorf("expected podUnsafeVolumeError, but got %T", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyWorkerPodEmptyDirVol(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that was created by a daemonset
+	pod := getSafePodWithCreatedByRef(t, node.Host, "ReplicationController")
+	pod.Spec.Volumes = []data.Volume{
+		{
+			VolumeSource: data.VolumeSource{
+				EmptyDir: &data.EmptyDirVolumeSource{},
+			},
+		},
+	}
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getReplicationController: func() (*data.ReplicationController, error) {
+			return &data.ReplicationController{
+				Status: data.ReplicationControllerStatus{
+					Replicas: 2,
+				},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(podUnsafeVolumeErr); !ok {
+		t.Errorf("expected podUnsafeVolumeError, but got %T", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyWorkerPodHostPathPersistentVol(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+	pod := getSafePodWithCreatedByRef(t, node.Host, "replicationcontroller")
+	// Setup a pod that is using a volume with a PersistentVolumeClaim
+	// This PVC is bound to a persistent volume that is using HostPath
+	pod.Spec.Volumes = []data.Volume{
+		{
+			VolumeSource: data.VolumeSource{
+				PersistentVolumeClaim: &data.PersistentVolumeClaimVolumeSource{
+					ClaimName: "theClaim",
+				},
+			},
+		},
+	}
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getReplicationController: func() (*data.ReplicationController, error) {
+			return &data.ReplicationController{
+				Status: data.ReplicationControllerStatus{
+					Replicas: 2,
+				},
+			}, nil
+		},
+		getPersistentVolumeClaim: func(name string) (*data.PersistentVolumeClaim, error) {
+			if name == "theClaim" {
+				return &data.PersistentVolumeClaim{
+					Spec: data.PersistentVolumeClaimSpec{
+						VolumeName: "theVolume",
+					},
+				}, nil
+			}
+			return nil, fmt.Errorf("PVC not found")
+		},
+		getPersistentVolume: func(name string) (*data.PersistentVolume, error) {
+			if name == "theVolume" {
+				spec := data.PersistentVolumeSpec{}
+				spec.HostPath = &data.HostPathVolumeSource{}
+				return &data.PersistentVolume{
+					Spec: spec,
+				}, nil
+			}
+			return nil, fmt.Errorf("PV not found")
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(podUnsafePersistentVolumeErr); !ok {
+		t.Errorf("expected podUnsafePersistentVolumeError, but got %T", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyWorkerSingleDaemon(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that was created by a daemonset
+	pod := getSafePodWithCreatedByRef(t, node.Host, "DaemonSet")
+
+	// mock the k8s client to return the pod and an unsafe daemonset
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getDaemonSet: func() (*data.DaemonSet, error) {
+			return &data.DaemonSet{
+				Status: data.DaemonSetStatus{
+					DesiredNumberScheduled: 1,
+				},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(podUnsafeDaemonErr); !ok {
+		t.Errorf("expected podSingleDaemonInstance, but got %T", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyWorkerSafeDaemon(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that was created by a daemonset
+	pod := getSafePodWithCreatedByRef(t, node.Host, "DaemonSet")
+
+	// mock the k8s client to return the pod and an safe daemonset
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getDaemonSet: func() (*data.DaemonSet, error) {
+			return &data.DaemonSet{
+				Status: data.DaemonSetStatus{
+					DesiredNumberScheduled: 2,
+				},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 0 {
+		t.Errorf("Did not expect errors, but got: %v", errs)
+	}
+}
+
+func TestDetectNodeUpgradeSafetyLonePod(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that is not managed by anything
+	pod := getSafePodWithCreatedByRef(t, node.Host, "")
+	delete(pod.Annotations, kubeCreatedBy)
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(unmanagedPodErr); !ok {
+		t.Errorf("Expected a lonePodError, but got %v", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyUnreplicatedController(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that is managed by a replication controller with replicas = 1
+	pod := getSafePodWithCreatedByRef(t, node.Host, "ReplicationController")
+	fmt.Println(pod)
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getReplicationController: func() (*data.ReplicationController, error) {
+			return &data.ReplicationController{
+				Status: data.ReplicationControllerStatus{
+					Replicas: 1,
+				},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(unsafeReplicaCountErr); !ok {
+		t.Errorf("expected unsafeReplicaCountErr, but got %T", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyUnreplicatedReplicaSet(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that is managed by a replication controller with replicas = 1
+	pod := getSafePodWithCreatedByRef(t, node.Host, "ReplicaSet")
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getReplicaSet: func() (*data.ReplicaSet, error) {
+			return &data.ReplicaSet{
+				Status: data.ReplicaSetStatus{
+					Replicas: 1,
+				},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(unsafeReplicaCountErr); !ok {
+		t.Errorf("expected unsafeReplicaCountErr, but got %T", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyUnreplicatedStatefulSet(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that is managed by a statefulset with replicas = 1
+	pod := getSafePodWithCreatedByRef(t, node.Host, "StatefulSet")
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+		getStatefulSet: func() (*data.StatefulSet, error) {
+			return &data.StatefulSet{
+				Status: data.StatefulSetStatus{
+					Replicas: 1,
+				},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(unsafeReplicaCountErr); !ok {
+		t.Errorf("expected unsafeReplicaCountErr, but got %T", errs[0])
+	}
+}
+
+func TestDetectNodeUpgradeSafetyJobRunningOnNode(t *testing.T) {
+	plan := Plan{
+		Worker: NodeGroup{
+			ExpectedCount: 2,
+			Nodes: []Node{
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+				{
+					Host: "foo",
+					IP:   "10.0.0.1",
+				},
+			},
+		},
+	}
+	node := plan.Worker.Nodes[0]
+
+	// Setup a pod that is managed by a job
+	pod := getSafePodWithCreatedByRef(t, node.Host, "Job")
+	k8sClient := fakeUpgradeKubeClient{
+		listPods: func() (*data.PodList, error) {
+			return &data.PodList{
+				Items: []data.Pod{pod},
+			}, nil
+		},
+	}
+	errs := DetectNodeUpgradeSafety(plan, node, k8sClient)
+	if len(errs) != 1 {
+		t.Errorf("Expected %d errors, but got %v", 1, errs)
+	} else if _, ok := errs[0].(podRunningJobErr); !ok {
+		t.Errorf("expected podRunningJobErr, but got %T", errs[0])
+	}
+}


### PR DESCRIPTION
This PR adds support for an online upgrade. During an online upgrade, Kismatic will run a variety of checks to ensure that we are able to perform an upgrade without affecting availability or data loss.

Resolves #256, minus cordon/uncordon of nodes, which will be addressed in #306 

- [x] Online upgrade command
- [x] Online upgrade detection algorithm
- [x] Add stateful set to detection alg