### PR TITLE
Refactor test setup, and add upgrade test

### DIFF
--- a/integration/add_worker_test.go
+++ b/integration/add_worker_test.go
@@ -9,7 +9,8 @@ import (
 
 var _ = Describe("kismatic install add-worker tests", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("adding a worker to an existing cluster", func() {

--- a/integration/disconnected_install_test.go
+++ b/integration/disconnected_install_test.go
@@ -11,7 +11,8 @@ import (
 
 var _ = Describe("disconnected install feature", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("Installing on machines with no internet access", func() {

--- a/integration/docker_registry_test.go
+++ b/integration/docker_registry_test.go
@@ -9,7 +9,8 @@ import (
 
 var _ = Describe("kismatic docker registry feature", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("enabling the internal docker registry feature", func() {

--- a/integration/hosts_file_test.go
+++ b/integration/hosts_file_test.go
@@ -9,7 +9,8 @@ import (
 
 var _ = Describe("hosts file modification feature", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("enabling the hosts file modification feature", func() {

--- a/integration/ingress_test.go
+++ b/integration/ingress_test.go
@@ -9,7 +9,8 @@ import (
 
 var _ = Describe("ingress feature", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("accessing the ingress point of a cluster", func() {

--- a/integration/install_released_test.go
+++ b/integration/install_released_test.go
@@ -11,19 +11,10 @@ const previousKismaticVersion = "v1.2.0"
 
 // Test a specific released version of Kismatic
 var _ = Describe("Installing with previous version of Kismatic", func() {
-	var kisReleasedPath string
 	BeforeEach(func() {
 		// setup previous version of Kismatic
-		var err error
-		kisReleasedPath, err = DownloadKismaticRelease(previousKismaticVersion)
-		Expect(err).ToNot(HaveOccurred(), "Failed to download kismatic release")
-		os.Chdir(kisReleasedPath)
-	})
-
-	AfterEach(func() {
-		if !leaveIt() {
-			os.RemoveAll(kisReleasedPath)
-		}
+		tmp := setupTestWorkingDirWithVersion(previousKismaticVersion)
+		os.Chdir(tmp)
 	})
 
 	installOpts := installOptions{

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -15,7 +15,8 @@ import (
 
 var _ = Describe("kismatic", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("calling kismatic with no verb", func() {

--- a/integration/master_ha_test.go
+++ b/integration/master_ha_test.go
@@ -10,7 +10,8 @@ import (
 
 var _ = Describe("control plane high availability feature", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("running kuberang against an HA cluster", func() {

--- a/integration/nfsshare_test.go
+++ b/integration/nfsshare_test.go
@@ -8,7 +8,8 @@ import (
 
 var _ = Describe("NFS Shares", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Context("Specifying valid NFS shares in the plan file", func() {

--- a/integration/prepare.go
+++ b/integration/prepare.go
@@ -3,13 +3,8 @@ package integration
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
-	"os/exec"
-	"path"
 	"path/filepath"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/apprenda/kismatic/integration/retry"
@@ -61,43 +56,6 @@ var rhel7FamilyPrep = nodePrep{
 	CommandsToInstallK8sMaster: []string{installDockerYum, installKubeletYum, installKubectlYum},
 	CommandsToInstallK8s:       []string{installDockerYum, installKubeletYum},
 	CommandsToInstallOffline:   []string{installKismaticOfflineYum},
-}
-
-func ExtractKismaticToTemp() (string, error) {
-	tmpDir, err := ioutil.TempDir("", "kisint-dev-")
-	if err != nil {
-		log.Fatal("Error making temp dir: ", err)
-	}
-	By(fmt.Sprintf("Extracting Kismatic to temp directory %q", tmpDir))
-	cmd := exec.Command("tar", "-zxf", "../out/kismatic.tar.gz", "-C", tmpDir)
-	_, err = cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("error extracting kismatic to temp dir: %v", err)
-	}
-	return tmpDir, nil
-}
-
-func DownloadKismaticRelease(version string) (string, error) {
-	tmpDir, err := ioutil.TempDir("", fmt.Sprintf("kisint-%s-", strings.Replace(version, ".", "_", -1)))
-	if err != nil {
-		log.Fatal("Error making temp dir: ", err)
-	}
-	By(fmt.Sprintf("Downloading Kismatic %s to temp directory %q", version, tmpDir))
-	var url string
-	if runtime.GOOS == "darwin" {
-		url = fmt.Sprintf("https://github.com/apprenda/kismatic/releases/download/%[1]s/kismatic-%[1]s-darwin-amd64.tar.gz", version)
-	} else if runtime.GOOS == "linux" {
-		url = fmt.Sprintf("https://github.com/apprenda/kismatic/releases/download/%[1]s/kismatic-%[1]s-linux-amd64.tar.gz", version)
-	} else {
-		return "", fmt.Errorf("Unsupported OS: %s", runtime.GOOS)
-	}
-	if err := exec.Command("wget", url, "-O", path.Join(tmpDir, "kismatic-release.tar.gz")).Run(); err != nil {
-		return "", err
-	}
-	if err := exec.Command("tar", "-zxf", path.Join(tmpDir, "kismatic-release.tar.gz"), "-C", tmpDir).Run(); err != nil {
-		return "", err
-	}
-	return tmpDir, nil
 }
 
 func InstallKismaticPackages(nodes provisionedNodes, distro linuxDistro, sshKey string, disconnected bool) {

--- a/integration/step_test.go
+++ b/integration/step_test.go
@@ -10,7 +10,8 @@ import (
 
 var _ = Describe("install step commands", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("Running the api server play against an existing cluster", func() {

--- a/integration/storage_test.go
+++ b/integration/storage_test.go
@@ -11,7 +11,8 @@ import (
 
 var _ = Describe("Storage feature", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("Specifying multiple storage nodes in the plan file", func() {

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -1,0 +1,67 @@
+package integration
+
+import (
+	"os"
+	"os/exec"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("kismatic upgrade tests", func() {
+	BeforeEach(func() {
+		dir := setupTestWorkingDirWithVersion("v1.2.2")
+		os.Chdir(dir)
+	})
+
+	Describe("Doing an offline upgrade of a kubernetes cluster", func() {
+		Context("Using a minikube layout", func() {
+			Context("Using Ubuntu 16.04", func() {
+				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
+					WithMiniInfrastructure(Ubuntu1604LTS, aws, func(node NodeDeets, sshKey string) {
+						// Install previous version cluster
+						err := installKismaticMini(node, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Extract current version of kismatic
+						pwd, err := os.Getwd()
+						Expect(err).ToNot(HaveOccurred())
+						err = extractCurrentKismatic(pwd)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Perform upgrade
+						cmd := exec.Command("./kismatic", "upgrade", "offline", "-f", "kismatic-testing.yaml", "--skip-preflight")
+						cmd.Stderr = os.Stderr
+						cmd.Stdout = os.Stdout
+						err = cmd.Run()
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+
+			PContext("Using CentOS 7", func() {
+				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
+					WithMiniInfrastructure(CentOS7, aws, func(node NodeDeets, sshKey string) {
+						// Install previous version cluster
+						err := installKismaticMini(node, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Extract new version of kismatic
+						pwd, err := os.Getwd()
+						Expect(err).ToNot(HaveOccurred())
+						err = extractCurrentKismatic(pwd)
+						Expect(err).ToNot(HaveOccurred())
+
+						// Perform upgrade
+						cmd := exec.Command("./kismatic", "upgrade", "offline", "-f", "kismatic-testing.yaml", "--skip-preflight")
+						cmd.Stderr = os.Stderr
+						cmd.Stdout = os.Stdout
+						err = cmd.Run()
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+	})
+})

--- a/integration/validate_test.go
+++ b/integration/validate_test.go
@@ -8,7 +8,8 @@ import (
 
 var _ = Describe("kismatic install validate tests", func() {
 	BeforeEach(func() {
-		os.Chdir(kisPath)
+		dir := setupTestWorkingDir()
+		os.Chdir(dir)
 	})
 
 	Describe("Running validation with package installation disabled", func() {


### PR DESCRIPTION
Initial set of tests for upgrades. Upgrading on CentOS is currently broken, so I have disabled that spec in the suite.

In this PR, I also ensure that each test gets a pristine copy of kismatic. We have been able to get away with not doing this because the number of parallel test runners was higher than the number of tests. This meant that each runner was getting it's own temp directory. Conversely, each test was getting it's own copy of kismatic.

