### PR TITLE
Lock golang version by using docker for building binaries

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -2,12 +2,13 @@
 [![Build Status](https://snap-ci.com/ulSrRsof30gMr7eaXZ_eufLs7XQtmS6Lw4eYwkmATn4/build_image)](https://snap-ci.com/apprenda/kismatic/branch/master)
 
 ### Pre-requisites
-- Darwin (OSX) or Linux x86-64
-- Go installed
-- Docker (required for building)
+- make
+- Docker
 
 ### Build using make
 We use `make` to clean, build, and produce our distribution package. Take a look at the Makefile for more details.
+
+Build and test phases happen inside docker containers.
 
 In order to build the Go binaries (e.g. Kismatic CLI):
 ```


### PR DESCRIPTION
With this change, all our binaries are built using the official golang docker image.

Updating the go version is as simple as updating the variable in the Makefile.

We are still running a couple of go-dependent make targets (mainly the integration tests), so this is just an initial step towards not having to install Go in CI or dev machines.

Fixes #327

Notable changes:
* `make` no longer builds the inspector. It only builds kismatic.
* Mac users might observe a slight performance hit when building due to bugs in Docker for Mac (https://forums.docker.com/t/file-access-in-mounted-volumes-extremely-slow-cpu-bound/8076/269).
* Tests are also run inside a container