### PR TITLE
Drain nodes before online upgrade

### DIFF
--- a/ansible/_kube-drain-node.yaml
+++ b/ansible/_kube-drain-node.yaml
@@ -1,0 +1,7 @@
+---
+  - name: "Drain Node"
+    hosts: master:worker:ingress:storage
+    serial: 1
+    tasks:
+      - name: "Run kubectl drain"
+        command: "kubectl drain --ignore-daemonsets {{ inventory_hostname }}"

--- a/ansible/_kube-uncordon-node.yaml
+++ b/ansible/_kube-uncordon-node.yaml
@@ -1,0 +1,7 @@
+---
+  - name: "Uncordon Node"
+    hosts: worker
+    serial: 1
+    tasks:
+      - name: "Run kubectl uncordon"
+        command: "kubectl uncordon {{ inventory_hostname }}"

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -1,4 +1,8 @@
 ---
+  # Drain the node before we touch it
+  - include: _kube-drain-node.yaml
+    when: online_upgrade is defined and online_upgrade|bool == true
+    
   - include: _packages-cleanup.yaml
     when: allow_package_installation|bool == true
   - include: _packages.yaml
@@ -19,4 +23,7 @@
   - include: _validate-control-plane-node.yaml
   - include: _kube-proxy.yaml play_name="Upgrade Kubernetes Proxy" serial="1" upgrading=true
 
+  - include: _kube-uncordon-node.yaml
+    when: online_upgrade is defined and online_upgrade|bool == true
+  
   - include: _update-version.yaml

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -58,6 +58,8 @@ type ClusterCatalog struct {
 	VolumeAllowedIPs        string `yaml:"volume_allow_ips"`
 
 	TargetVersion string `yaml:"kismatic_short_version"`
+
+	OnlineUpgrade bool `yaml:"online_upgrade"`
 }
 
 type NFSVolume struct {

--- a/pkg/cli/fakes_test.go
+++ b/pkg/cli/fakes_test.go
@@ -54,7 +54,7 @@ func (fe *fakeExecutor) RunUpgradePreFlightCheck(p *install.Plan) error {
 	return nil
 }
 
-func (fe *fakeExecutor) UpgradeNodes(install.Plan, []install.ListableNode) error {
+func (fe *fakeExecutor) UpgradeNodes(install.Plan, []install.ListableNode, bool) error {
 	return nil
 }
 

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -199,7 +199,7 @@ func upgradeNodes(out io.Writer, plan install.Plan, opts upgradeOpts, toUpgrade 
 	}
 
 	// Run the upgrade on the nodes that need it
-	if err := executor.UpgradeNodes(plan, toUpgrade); err != nil {
+	if err := executor.UpgradeNodes(plan, toUpgrade, opts.online); err != nil {
 		return fmt.Errorf("Failed to upgrade nodes: %v", err)
 	}
 	return nil

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -33,7 +33,7 @@ type Executor interface {
 	AddWorker(*Plan, Node) (*Plan, error)
 	RunPlay(string, *Plan) error
 	AddVolume(*Plan, StorageVolume) error
-	UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode) error
+	UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode, onlineUpgrade bool) error
 	ValidateControlPlane(plan Plan) error
 	UpgradeDockerRegistry(plan Plan) error
 	UpgradeClusterServices(plan Plan) error
@@ -362,7 +362,7 @@ func (ae *ansibleExecutor) AddVolume(plan *Plan, volume StorageVolume) error {
 // which phase of the upgrade we are in. For example, when upgrading a node that is both an etcd and master,
 // the etcd components and the master components will be upgraded when we are in the upgrade etcd nodes
 // phase.
-func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode) error {
+func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode, onlineUpgrade bool) error {
 	// Nodes can have multiple roles. For this reason, we need to keep track of which nodes
 	// have been upgraded to avoid re-upgrading them.
 	upgradedNodes := map[string]bool{}
@@ -371,7 +371,7 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 		for _, role := range nodeToUpgrade.Roles {
 			if role == "etcd" {
 				node := nodeToUpgrade.Node
-				if err := ae.upgradeNode(plan, node); err != nil {
+				if err := ae.upgradeNode(plan, node, onlineUpgrade); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Host, err)
 				}
 				upgradedNodes[node.IP] = true
@@ -388,7 +388,7 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 		for _, role := range nodeToUpgrade.Roles {
 			if role == "master" {
 				node := nodeToUpgrade.Node
-				if err := ae.upgradeNode(plan, node); err != nil {
+				if err := ae.upgradeNode(plan, node, onlineUpgrade); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Host, err)
 				}
 				upgradedNodes[node.IP] = true
@@ -405,7 +405,7 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 		for _, role := range nodeToUpgrade.Roles {
 			if role != "etcd" && role != "master" {
 				node := nodeToUpgrade.Node
-				if err := ae.upgradeNode(plan, node); err != nil {
+				if err := ae.upgradeNode(plan, node, onlineUpgrade); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Host, err)
 				}
 				upgradedNodes[node.IP] = true
@@ -416,12 +416,13 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 	return nil
 }
 
-func (ae *ansibleExecutor) upgradeNode(plan Plan, node Node) error {
+func (ae *ansibleExecutor) upgradeNode(plan Plan, node Node, onlineUpgrade bool) error {
 	inventory := buildInventoryFromPlan(&plan)
 	cc, err := ae.buildClusterCatalog(&plan)
 	if err != nil {
 		return err
 	}
+	cc.OnlineUpgrade = onlineUpgrade
 	t := task{
 		name:           "upgrade-nodes",
 		playbook:       "upgrade-nodes.yaml",


### PR DESCRIPTION
Any node that has a kubelet running is drained before we touch it. If
the upgrade is successful, we uncordon the node only if it's a worker
node.

Fixes #306 