### PR TITLE
Move kismatic-offline installation to docker-registry-images play whe…

### DIFF
--- a/ansible/_docker-registry-images.yaml
+++ b/ansible/_docker-registry-images.yaml
@@ -1,9 +1,11 @@
 ---
   - hosts: master[0]
-    name: Load Docker Images Into Private Registry 
+    name: Load Docker Images Into Private Registry
     remote_user: root
     become_method: sudo
     run_once: true
 
     roles:
+      - role: packages-offline
+        when: allow_package_installation|bool == true and disconnected_installation|bool == true
       - role: docker-registry-images

--- a/ansible/_kubelet.yaml
+++ b/ansible/_kubelet.yaml
@@ -10,6 +10,4 @@
     roles:
       - role: packages-kubernetes
         when: allow_package_installation|bool == true
-      - role: packages-offline
-        when: allow_package_installation|bool == true and disconnected_installation|bool == true
       - kubelet


### PR DESCRIPTION
Closes #333 

Move `kismatic-offline` package installation closer to where its used.

Cleanup will already be performed in `_packages-cleanup` when upgrading node.