### PR TITLE
Move downloading docker images before stopping service

### DIFF
--- a/ansible/_calico.yaml
+++ b/ansible/_calico.yaml
@@ -9,6 +9,13 @@
       - group_vars/all.yaml
 
     pre_tasks:
+      - name: download networking images
+        command: docker pull {{ item }}
+        with_items:
+          - "{{ calico_node_img }}"
+          - "{{ calico_cni_img }}"
+          - "{{ calico_ctl_img }}"
+
       - name: check if calico-node is active
         command: systemctl is-active -q calico-node.service
         register: status

--- a/ansible/_kube-apiserver.yaml
+++ b/ansible/_kube-apiserver.yaml
@@ -9,6 +9,9 @@
       - group_vars/all.yaml
 
     pre_tasks:
+      - name: download kube-apiserver image
+        command: docker pull {{ kube_apiserver_img }}
+
       - name: check if kube-apiserver service is active
         command: systemctl is-active -q kube-apiserver.service
         register: status

--- a/ansible/_kube-controller-manager.yaml
+++ b/ansible/_kube-controller-manager.yaml
@@ -9,6 +9,9 @@
       - group_vars/all.yaml
 
     pre_tasks:
+      - name: download kube-controller-manager image
+        command: docker pull {{ kube_controller_manager_img }}
+
       - name: check if kube-controller-manager service is active
         command: systemctl is-active -q kube-controller-manager.service
         register: status

--- a/ansible/_kube-proxy.yaml
+++ b/ansible/_kube-proxy.yaml
@@ -9,6 +9,9 @@
       - group_vars/all.yaml
 
     pre_tasks:
+      - name: download kube-proxy image
+        command: docker pull {{ kube_proxy_img }}
+
       - name: check if kube-proxy service is active
         command: systemctl is-active -q kube-proxy.service
         register: status

--- a/ansible/_kube-scheduler.yaml
+++ b/ansible/_kube-scheduler.yaml
@@ -9,6 +9,9 @@
       - group_vars/all.yaml
 
     pre_tasks:
+      - name: download kube-scheduler image
+        command: docker pull {{ kube_scheduler_img }}
+        
       - name: check if kube-scheduler service is active
         command: systemctl is-active -q kube-scheduler.service
         register: status

--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -1,11 +1,4 @@
 ---
-  - name: download networking images
-    command: docker pull {{ item }}
-    with_items:
-      - "{{ calico_node_img }}"
-      - "{{ calico_cni_img }}"
-      - "{{ calico_ctl_img }}"
-
   - name: create /etc/calico directory
     file:
       path: "{{ calico_dir }}"

--- a/ansible/roles/kube-apiserver/tasks/main.yaml
+++ b/ansible/roles/kube-apiserver/tasks/main.yaml
@@ -1,7 +1,4 @@
 ---
-  - name: download kube-apiserver image
-    command: docker pull {{ kube_apiserver_img }}
-
   - name: copy kube-apiserver.yaml manifest
     template:
       src: kube-apiserver.yaml

--- a/ansible/roles/kube-controller-manager/tasks/main.yaml
+++ b/ansible/roles/kube-controller-manager/tasks/main.yaml
@@ -1,7 +1,4 @@
 ---
-  - name: download kube-controller-manager image
-    command: docker pull {{ kube_controller_manager_img }}
-
   - name: copy kube-controller-manager.yaml manifest
     template:
       src: kube-controller-manager.yaml

--- a/ansible/roles/kube-proxy/tasks/main.yaml
+++ b/ansible/roles/kube-proxy/tasks/main.yaml
@@ -1,7 +1,4 @@
 ---
-  - name: download kube-proxy image
-    command: docker pull {{ kube_proxy_img }}
-
   - name: copy kube-proxy.yaml manifest
     template:
       src: kube-proxy.yaml

--- a/ansible/roles/kube-scheduler/tasks/main.yaml
+++ b/ansible/roles/kube-scheduler/tasks/main.yaml
@@ -1,7 +1,4 @@
 ---
-  - name: download kube-scheduler image
-    command: docker pull {{ kube_scheduler_img }}
-
   - name: copy kube-scheduler.yaml manifest
     template:
       src: kube-scheduler.yaml


### PR DESCRIPTION
As recommended in the Calico [docs](http://docs.projectcalico.org/v2.0/getting-started/kubernetes/upgrade) pulling images before stopping the service.

Also doing the same for the k8s control-plane. 