### PR TITLE
Add other feature tests to be slow

### DIFF
--- a/integration/disconnected_install_test.go
+++ b/integration/disconnected_install_test.go
@@ -17,7 +17,7 @@ var _ = Describe("disconnected install feature", func() {
 
 	Describe("Installing on machines with no internet access", func() {
 		Context("with kismatic packages installed", func() {
-			ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
+			ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
 				WithMiniInfrastructure(CentOS7, aws, func(node NodeDeets, sshKey string) {
 					By("Installing the RPMs on the node")
 					theNode := []NodeDeets{node}

--- a/integration/ingress_test.go
+++ b/integration/ingress_test.go
@@ -15,7 +15,7 @@ var _ = Describe("ingress feature", func() {
 
 	Describe("accessing the ingress point of a cluster", func() {
 		Context("when the cluster has an ingress node", func() {
-			ItOnAWS("should return a successful response", func(aws infrastructureProvisioner) {
+			ItOnAWS("should return a successful response [slow]", func(aws infrastructureProvisioner) {
 				WithMiniInfrastructure(CentOS7, aws, func(node NodeDeets, sshKey string) {
 					By("Installing a cluster with ingress")
 					err := installKismaticMini(node, sshKey)

--- a/integration/storage_test.go
+++ b/integration/storage_test.go
@@ -17,17 +17,17 @@ var _ = Describe("Storage feature", func() {
 
 	Describe("Specifying multiple storage nodes in the plan file", func() {
 		Context("when targetting CentOS", func() {
-			ItOnAWS("should result in a working storage cluster", func(aws infrastructureProvisioner) {
+			ItOnAWS("should result in a working storage cluster [slow]", func(aws infrastructureProvisioner) {
 				testAddVolumeVerifyGluster(aws, CentOS7)
 			})
 		})
 		Context("when targetting Ubuntu", func() {
-			ItOnAWS("should result in a working storage cluster", func(aws infrastructureProvisioner) {
+			ItOnAWS("should result in a working storage cluster [slow]", func(aws infrastructureProvisioner) {
 				testAddVolumeVerifyGluster(aws, Ubuntu1604LTS)
 			})
 		})
 		Context("when targetting RHEL", func() {
-			ItOnAWS("should result in a working storage cluster", func(aws infrastructureProvisioner) {
+			ItOnAWS("should result in a working storage cluster [slow]", func(aws infrastructureProvisioner) {
 				testAddVolumeVerifyGluster(aws, RedHat7)
 			})
 		})


### PR DESCRIPTION
During integration tests we should only test the basic cluster setup.
Any optional features should be part of the `[slow]` test.

This will also speed up the PR merge process with the flakiness of the tests