### PR TITLE
Run kube dashboard with 2 replicas

### DIFF
--- a/ansible/roles/kube-dashboard/templates/kubernetes-dashboard.yaml
+++ b/ansible/roles/kube-dashboard/templates/kubernetes-dashboard.yaml
@@ -26,7 +26,7 @@ metadata:
   name: kubernetes-dashboard
   namespace: kube-system
 spec:
-  replicas: 1
+  replicas: {{ [2, groups['worker'] | length] | min }}  # create 2 replicas or the number of worker nodes
   selector:
     matchLabels:
       app: kubernetes-dashboard

--- a/integration/install.go
+++ b/integration/install.go
@@ -43,8 +43,8 @@ func installKismaticMini(node NodeDeets, sshKey string) error {
 		Worker:                   []NodeDeets{node},
 		Ingress:                  []NodeDeets{node},
 		Storage:                  []NodeDeets{node},
-		MasterNodeFQDN:           node.Hostname,
-		MasterNodeShortName:      node.Hostname,
+		MasterNodeFQDN:           node.PublicIP,
+		MasterNodeShortName:      node.PublicIP,
 		SSHKeyFile:               sshKey,
 		SSHUser:                  sshUser,
 		AllowPackageInstallation: true,
@@ -54,7 +54,7 @@ func installKismaticMini(node NodeDeets, sshKey string) error {
 
 func installKismatic(nodes provisionedNodes, installOpts installOptions, sshKey string) error {
 	sshUser := nodes.master[0].SSHUser
-	masterDNS := nodes.master[0].Hostname
+	masterDNS := nodes.master[0].PublicIP
 	if nodes.dnsRecord != nil && nodes.dnsRecord.Name != "" {
 		masterDNS = nodes.dnsRecord.Name
 	}

--- a/integration/install.go
+++ b/integration/install.go
@@ -169,6 +169,20 @@ func completesInTime(dothis func(), howLong time.Duration) bool {
 	}
 }
 
+func canAccessDashboard() error {
+	// Access the dashboard a few times to hit all replicas
+	for i := 0; i < 3; i++ {
+		cmd := exec.Command("./kismatic", "dashboard", "--url", "-f", "kismatic-testing.yaml")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func FailIfError(err error, message ...interface{}) {
 	Expect(err).ToNot(HaveOccurred(), message...)
 }

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -118,12 +118,22 @@ var _ = Describe("kismatic", func() {
 			})
 		})
 
+		// This spec will be used for testing non-destructive kismatic features on
+		// a new cluster.
+		// This spec is open to modification when new assertions have to be made
 		Context("when deploying a skunkworks cluster", func() {
 			ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
 				WithInfrastructure(NodeCount{3, 2, 3, 2, 2}, CentOS7, aws, func(nodes provisionedNodes, sshKey string) {
 					installOpts := installOptions{allowPackageInstallation: true}
 					err := installKismatic(nodes, installOpts, sshKey)
 					Expect(err).ToNot(HaveOccurred())
+
+					sub := SubDescribe("Trying to access the Dashboard")
+					defer sub.Check()
+
+					sub.It("should succeed", func() error {
+						return canAccessDashboard()
+					})
 				})
 			})
 		})


### PR DESCRIPTION
Fixes #352 

Deploy the kubernetes dashboard with 2 replicas, on a single worker the replica count will be 1