### PR TITLE
Update kube-dns rc to deployment

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -113,6 +113,7 @@ docker_certificates_group: root
 kubernetes_master_apiserver_count: "{{ groups['master'] | length }}"
 kubernetes_master_ip: https://{{ kubernetes_load_balanced_fqdn }}:{{ kubernetes_master_secure_port }}
 kubernetes_schedulable: "{% if 'worker' in group_names %}true{% else %}false{% endif %}"
+kube_dns_replicas: "{{ [2, groups['worker'] | length] | min }}"
 # kubernetes certificate config
 kubernetes_certificates_ca_file_name: ca.pem
 kubernetes_certificates_cert_file_name: kubenode.pem

--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -7,14 +7,14 @@
     command: kubectl apply -f /tmp/kubernetes-dns.yaml
     register: out
   - name: wait until DNS pods are ready
-    command: kubectl get rc kube-dns --namespace kube-system -o jsonpath='{.status.readyReplicas}'
+    command: kubectl get deployment kube-dns -n kube-system -o jsonpath='{.status.availableReplicas}'
     register: readyReplicas
-    until: readyReplicas.stdout|int > 0
+    until: readyReplicas.stdout|int == kube_dns_replicas|int
     retries: 24
     delay: 10
     failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
   - name: fail if any DNS pods are not ready
     fail:
       msg: "Timed out waiting for DNS pods to be in the ready state."
-    when: readyReplicas.stdout|int < 1
+    when: readyReplicas.stdout|int != kube_dns_replicas|int
   - debug: var=out.stdout_lines

--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -21,26 +21,32 @@ spec:
     protocol: TCP
 ---
 
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: kube-dns
   namespace: kube-system
   labels:
     k8s-app: kube-dns
-    version: "{{kubedns_version}}"
     kubernetes.io/cluster-service: "true"
-spec:
-  replicas: 1
-  selector:
-    k8s-app: kube-dns
     version: "{{kubedns_version}}"
+    kismaticVersion: "{{ kismatic_short_version }}"
+spec:
+  replicas: {{ kube_dns_replicas|int }}  # create 2 replicas or the number of worker nodes
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      k8s-app: kube-dns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        version: "{{kubedns_version}}"
-        kubernetes.io/cluster-service: "true"
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
     spec:
       volumes:
       # Configures DNS to communicate with the master.
@@ -56,14 +62,13 @@ spec:
         image: "{{ kubedns_img }}"
         resources:
           limits:
-            cpu: 100m
-            memory: 200Mi
+            memory: 170Mi
           requests:
             cpu: 100m
-            memory: 100Mi
+            memory: 70Mi
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthz-kubedns
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 60
@@ -77,18 +82,23 @@ spec:
             scheme: HTTP
           # we poll on pod startup for the Kubernetes master service and
           # only setup the /readiness HTTP server once that's available.
-          initialDelaySeconds: 30
+          initialDelaySeconds: 3
           timeoutSeconds: 5
         args:
-        # command = "/kube-dns"
         - --domain=cluster.local
         - --dns-port=10053
         - --kubecfg-file={{ kubernetes_kubeconfig_path }}
+        # This should be set to v=2 only after the new image (cut from 1.5) has
+        # been released, otherwise we will flood the logs.
+        - --v=0
         volumeMounts:
         - mountPath: {{ kubernetes_certificates_ca_path }}
           name: "ssl-certs"
         - mountPath: {{ kubernetes_kubeconfig_path }}
           name: "worker-kubeconfig"
+        # env:
+        # - name: PROMETHEUS_PORT
+        #   value: "10055"
         ports:
         - containerPort: 10053
           name: dns-local
@@ -96,12 +106,25 @@ spec:
         - containerPort: 10053
           name: dns-tcp-local
           protocol: TCP
+        # - containerPort: 10055
+        #   name: metrics
+        #   protocol: TCP
       - name: dnsmasq
         image: "{{ kube_dnsmasq_img }}"
+        livenessProbe:
+          httpGet:
+            path: /healthz-dnsmasq
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
         args:
         - --cache-size=1000
         - --no-resolv
         - --server=127.0.0.1#10053
+        - --log-facility=-
         ports:
         - containerPort: 53
           name: dns
@@ -109,20 +132,51 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
+        # see: https://github.com/kubernetes/kubernetes/issues/29055 for details
+        resources:
+          requests:
+            cpu: 150m
+            memory: 10Mi
+      # - name: dnsmasq-metrics
+      #   image: gcr.io/google_containers/dnsmasq-metrics-amd64:1.0
+      #   livenessProbe:
+      #     httpGet:
+      #       path: /metrics
+      #       port: 10054
+      #       scheme: HTTP
+      #     initialDelaySeconds: 60
+      #     timeoutSeconds: 5
+      #     successThreshold: 1
+      #     failureThreshold: 5
+      #   args:
+      #   - --v=2
+      #   - --logtostderr
+      #   ports:
+      #   - containerPort: 10054
+      #     name: metrics
+      #     protocol: TCP
+      #   resources:
+      #     requests:
+      #       memory: 10Mi
       - name: healthz
         image: "{{ exechealthz_img }}"
         resources:
-          # keep request = limit to keep this container in guaranteed class
           limits:
-            cpu: 10m
-            memory: 20Mi
+            memory: 50Mi
           requests:
             cpu: 10m
-            memory: 20Mi
+            # Note that this container shouldn't really need 50Mi of memory. The
+            # limits are set higher than expected pending investigation on #29688.
+            # The extra memory was stolen from the kubedns container to keep the
+            # net memory requested by the pod constant.
+            memory: 50Mi
         args:
-        - -cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null && nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null
-        - -port=8080
-        - -quiet
+        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1 >/dev/null
+        - --url=/healthz-dnsmasq
+        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1:10053 >/dev/null
+        - --url=/healthz-kubedns
+        - --port=8080
+        - --quiet
         ports:
         - containerPort: 8080
           protocol: TCP


### PR DESCRIPTION
Fixes #351 

Update kube-dns yaml file to a k8s deployment similar to https://github.com/kubernetes/kubernetes/blob/release-1.5/cluster/addons/dns/skydns-rc.yaml.base

There is no image version changes.