### PR TITLE
Place cluster specs in /etc/kubernetes/specs instead of /tmp

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -88,6 +88,7 @@ kubernetes_dns_service_addr: https://{{kubernetes_dns_service_ip}}:{{kubernetes_
 # kubernetes
 # directories
 kubernetes_install_dir: /etc/kubernetes
+kubernetes_spec_dir: /etc/kubernetes/specs
 network_plugin_dir: /etc/cni/net.d
 kubernetes_auth_dir: /etc/kubernetes/auth
 kubelet_lib_dir: /var/lib/kubelet

--- a/ansible/roles/addon-network-policy/tasks/main.yaml
+++ b/ansible/roles/addon-network-policy/tasks/main.yaml
@@ -1,11 +1,15 @@
 ---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
   # TODO notify user of the port, ingress
   - name: copy policy-controller.yaml to remote
     template:
       src: policy-controller.yaml
-      dest: /tmp/policy-controller.yaml
+      dest: "{{ kubernetes_spec_dir }}/policy-controller.yaml"
   - name: start calico policy controller
-    command: kubectl apply -f /tmp/policy-controller.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/policy-controller.yaml
     register: out
 
   - debug: var=out.stdout_lines

--- a/ansible/roles/glusterfs-k8s/tasks/main.yaml
+++ b/ansible/roles/glusterfs-k8s/tasks/main.yaml
@@ -1,15 +1,19 @@
 ---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
   - name: Copy service definition to remote node
     template:
       src: gluster-service.yaml
-      dest: /tmp/gluster-service.yaml
+      dest: "{{ kubernetes_spec_dir }}/gluster-service.yaml"
   - name: Copy daemonset definition to remote node
     template:
       src: gluster-healthz-daemonset.yaml
-      dest: /tmp/gluster-healthz-daemonset.yaml
+      dest: "{{ kubernetes_spec_dir }}/gluster-healthz-daemonset.yaml"
   - name: Label gluster nodes
     command: kubectl label nodes {% for host in groups['storage'] %}{{ host }} {% endfor %} kismatic/storage=true --overwrite
   - name: Create gluster-healthz DaemonSet
-    command: kubectl apply -f /tmp/gluster-healthz-daemonset.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/gluster-healthz-daemonset.yaml
   - name: Create NFS service on the cluster
-    command: kubectl apply -f /tmp/gluster-service.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/gluster-service.yaml

--- a/ansible/roles/kube-dashboard/tasks/main.yaml
+++ b/ansible/roles/kube-dashboard/tasks/main.yaml
@@ -1,10 +1,14 @@
 ---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
   - name: copy kubernetes-dashboard.yaml to remote
     template:
       src: kubernetes-dashboard.yaml
-      dest: /tmp/kubernetes-dashboard.yaml
+      dest: "{{ kubernetes_spec_dir }}/kubernetes-dashboard.yaml"
   - name: start kubernetes-dashboard service
-    command: kubectl apply -f /tmp/kubernetes-dashboard.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/kubernetes-dashboard.yaml
     register: out
 
   - debug: var=out.stdout_lines

--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -1,10 +1,14 @@
 ---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
   - name: copy kubernetes-dns.yaml to remote
     template:
       src: kubernetes-dns.yaml
-      dest: /tmp/kubernetes-dns.yaml
+      dest: "{{ kubernetes_spec_dir }}/kubernetes-dns.yaml"
   - name: start kubernetes-dns service
-    command: kubectl apply -f /tmp/kubernetes-dns.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/kubernetes-dns.yaml
     register: out
   - name: wait until DNS pods are ready
     command: kubectl get rc kube-dns --namespace kube-system -o jsonpath='{.status.readyReplicas}'

--- a/ansible/roles/kube-ingress/tasks/main.yaml
+++ b/ansible/roles/kube-ingress/tasks/main.yaml
@@ -3,19 +3,23 @@
   - name: label ingress nodeSelector
     command: kubectl label nodes {% for host in groups['ingress'] %}{{ host }} {% endfor %} kismatic/ingress=true --overwrite
 
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
   - name: copy default-backend.yaml to remote
     template:
       src: default-backend.yaml
-      dest: /tmp/default-backend.yaml
+      dest: "{{ kubernetes_spec_dir }}/default-backend.yaml"
   - name: start default-backend serivce
-    command: kubectl apply -f /tmp/default-backend.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/default-backend.yaml
 
   - name: copy nginx-ingress-controller.yaml to remote
     template:
       src: nginx-ingress-controller.yaml
-      dest: /tmp/nginx-ingress-controller.yaml
+      dest: "{{ kubernetes_spec_dir }}/nginx-ingress-controller.yaml"
   - name: start nginx-ingress-controller serivce
-    command: kubectl apply -f /tmp/nginx-ingress-controller.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/nginx-ingress-controller.yaml
     register: out
 
   - name: get desired number of ingress pods

--- a/ansible/roles/nfs-volume/tasks/main.yaml
+++ b/ansible/roles/nfs-volume/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
+
   - name: Install all NFS shares as PersistentVolumes
     include: "new-share.yaml"
     with_indexed_items: nfs_volumes

--- a/ansible/roles/nfs-volume/tasks/new-share.yaml
+++ b/ansible/roles/nfs-volume/tasks/new-share.yaml
@@ -38,7 +38,7 @@
 - name: copy PV.yaml to remote
   template:
     src: add-persistent-volume.yaml
-    dest: /tmp/add-persistent-volume-{{nfs_index}}.yaml
+    dest: "{{ kubernetes_spec_dir }}/add-persistent-volume-{{nfs_index}}.yaml"
 
 - name: create pv pv{{ nfs_index }}
-  command: kubectl apply -f /tmp/add-persistent-volume-{{nfs_index}}.yaml
+  command: kubectl apply -f {{ kubernetes_spec_dir }}/add-persistent-volume-{{nfs_index}}.yaml

--- a/ansible/roles/persistent-volume/tasks/main.yaml
+++ b/ansible/roles/persistent-volume/tasks/main.yaml
@@ -7,10 +7,15 @@
     set_fact:
       storage_cluster_ip: "{{ out.stdout }}"
 
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
+      
   - name: copy pv.yaml to remote
     template:
         src: pv.yaml
-        dest: /tmp/pv.yaml
+        dest: "{{ kubernetes_spec_dir }}/pv.yaml"
 
   - name: create persistent volume {{ volume_name }}
-    command: kubectl apply -f /tmp/pv.yaml
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/pv.yaml


### PR DESCRIPTION
Closes #350 

Moving specs generated by the installer to `/etc/kubernetes/specs`.
The `/tmp` directory is not a good place to store them.