### PR TITLE
Remove kube-dns-v18 and v19 rc on upgrade

### DIFF
--- a/ansible/_kube-dns.yaml
+++ b/ansible/_kube-dns.yaml
@@ -8,3 +8,8 @@
 
     roles:
       - kube-dns
+
+    post_tasks:
+      - name: remove old kube-dns replication controller if exists
+        command: kubectl delete rc kube-dns-v18 kube-dns-v19 -n kube-system
+        failed_when: false


### PR DESCRIPTION
Closes #373 

`failed_when: false` is safe in this case since running multiple DNS pods works fine. 