### PR TITLE
Fix etcd-version bug

### DIFF
--- a/ansible/roles/etcd-version/tasks/main.yaml
+++ b/ansible/roles/etcd-version/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
   - name: get etcd server version
-    command: curl --cert {{ etcd_certificates_cert_file }} --key {{ etcd_certificates_key_file }} --cacert {{ etcd_certificates_ca_file }} https://127.0.0.1:{{ etcd_service_client_port }}/version
+    command: curl --cert {{ etcd_certificates_cert_file }} --key {{ etcd_certificates_key_file }} --cacert {{ etcd_certificates_ca_file }} https://{{ inventory_hostname }}:{{ etcd_service_client_port }}/version
     register: etcd_version
 
   - name: check if etcd needs to be upgraded

--- a/ansible/roles/etcd-version/tasks/main.yaml
+++ b/ansible/roles/etcd-version/tasks/main.yaml
@@ -1,8 +1,8 @@
 ---
   - name: get etcd server version
     command: curl --cert {{ etcd_certificates_cert_file }} --key {{ etcd_certificates_key_file }} --cacert {{ etcd_certificates_ca_file }} https://{{ inventory_hostname }}:{{ etcd_service_client_port }}/version
-    register: etcd_version
+    register: current_etcd_version
 
   - name: check if etcd needs to be upgraded
     set_fact:
-      etcd_needs_upgrade: "{{ (etcd_version.stdout | from_json)['etcdserver'] != etcd_version }}"
+      etcd_needs_upgrade: "{{ (current_etcd_version.stdout | from_json)['etcdserver'] != etcd_version }}"


### PR DESCRIPTION
I noticed that on an Ubuntu Vagrant image running curl returned an error:
```
- Running task: get etcd server version
  etcd001                                                                       [ERROR]
---- STDERR ----
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (51) SSL: certificate subject name (etcd001) does not match target host name '127.0.0.1'
```