### PR TITLE
Install Anisble dependencies on remote nodes

### DIFF
--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -316,6 +316,19 @@ const defaultRuleSet = `---
   packageName: kubelet
   packageVersion: 1.5.3_1-1
 
+- kind: PackageDependency
+  when: ["ubuntu"]
+  packageName: libselinux-python
+  anyVersion: true
+- kind: PackageDependency
+  when: ["centos"]
+  packageName: libselinux-python
+  anyVersion: true
+- kind: PackageDependency
+  when: ["rhel"]
+  packageName: libselinux-python
+  anyVersion: true
+
 # Gluster packages
 - kind: PackageDependency
   when: ["storage", "centos"]


### PR DESCRIPTION
Fixes #346 

Install `python-simplejson` and `libselinux-python` packages from their [docs](http://docs.ansible.com/ansible/intro_installation.html#managed-node-requirements) 