### PR TITLE
Remove kube-dns rc on upgrade

### DIFF
--- a/ansible/_kube-dns.yaml
+++ b/ansible/_kube-dns.yaml
@@ -11,5 +11,5 @@
 
     post_tasks:
       - name: remove old kube-dns replication controller if exists
-        command: kubectl delete rc kube-dns-v18 kube-dns-v19 -n kube-system
+        command: kubectl delete rc kube-dns kube-dns-v18 kube-dns-v19 -n kube-system
         failed_when: false


### PR DESCRIPTION
Fixes #393 

Forgot to remove `kube-dns` rc from `KET v1.2.2` in the previous PR