### PR TITLE
Fix retry output

### DIFF
--- a/pkg/install/explain/updating.go
+++ b/pkg/install/explain/updating.go
@@ -146,7 +146,7 @@ func (e *updatingExplainer) ExplainEvent(ansibleEvent ansible.Event) {
 	case *ansible.RunnerItemRetryEvent:
 		buf := &bytes.Buffer{}
 		fmt.Fprintln(buf, e.currentPlayName)
-		fmt.Fprintf(buf, "- [%s] Retrying: %s (%d/%d attempts)\n", event.Host, e.currentTask, event.Result.Attempts, event.Result.MaxRetries)
+		fmt.Fprintf(buf, "- [%s] Retrying: %s (%d/%d attempts)\n", event.Host, e.currentTask, event.Result.Attempts, event.Result.MaxRetries-1)
 		e.out.Write(buf.Bytes())
 
 	default:

--- a/pkg/install/explain/verbose.go
+++ b/pkg/install/explain/verbose.go
@@ -136,7 +136,7 @@ func (explainer *verboseExplainer) ExplainEvent(e ansible.Event) {
 
 	// Ignored events
 	case *ansible.RunnerItemRetryEvent:
-		fmt.Fprintf(out, " %s Retrying: %s (%d/%d attempts)\n", event.Host, explainer.currentTask, event.Result.Attempts, event.Result.MaxRetries)
+		fmt.Fprintf(out, " %s Retrying: %s (%d/%d attempts)\n", event.Host, explainer.currentTask, event.Result.Attempts, event.Result.MaxRetries-1)
 	case *ansible.PlaybookStartEvent:
 	default:
 		util.PrintColor(out, util.Orange, "Unhandled event: %T\n", event)


### PR DESCRIPTION
The number we get from ansible is retryCount + 1. Subtracting one so that in case of failure, the final retry is 20/20 instead of 20/21.

