### PR TITLE
Fix kube-dns deployment

### DIFF
--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -171,9 +171,9 @@ spec:
             # net memory requested by the pod constant.
             memory: 50Mi
         args:
-        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1 >/dev/null
         - --url=/healthz-dnsmasq
-        - --cmd=nslookup kubernetes.default.svc.$DNS_DOMAIN 127.0.0.1:10053 >/dev/null
+        - --cmd=nslookup kubernetes.default.svc.cluster.local 127.0.0.1:10053 >/dev/null
         - --url=/healthz-kubedns
         - --port=8080
         - --quiet


### PR DESCRIPTION
Fixes #408 

This was an error when switched to the new deployment method.

I do wonder how it ever works though with the wrong domain.