### PR TITLE
Put kubeconfig in the dir used by kubectl

### DIFF
--- a/ansible/_certs.yaml
+++ b/ansible/_certs.yaml
@@ -12,7 +12,6 @@
         etcd_install_dir: "/etc/etcd_k8s"
       - role: etcd-cert
         etcd_install_dir: "/etc/etcd_networking"
-      - kubeconfig
       - kubenode-cert
       - role: docker-registry-container-cert
         when: setup_internal_docker_registry is defined and setup_internal_docker_registry|bool == true

--- a/ansible/_kube-config.yaml
+++ b/ansible/_kube-config.yaml
@@ -1,0 +1,19 @@
+---
+  - hosts: master:worker:ingress:storage
+    any_errors_fatal: true
+    name: Generate kubectl config file
+    remote_user: root
+    become_method: sudo
+    vars_files:
+      - group_vars/all.yaml
+
+    roles:
+      - kubeconfig
+
+    post_tasks:
+      # Remove old kubeconfig files from old installations during upgrades
+      - name: Remove old kubectl config file
+        file: 
+          # Hard-coded to the right path in case we change kubelet_lib_dir
+          path: /var/lib/kubelet/kubeconfig
+          state: absent

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -93,10 +93,11 @@ network_plugin_dir: /etc/cni/net.d
 kubernetes_auth_dir: /etc/kubernetes/auth
 kubelet_lib_dir: /var/lib/kubelet
 kubelet_pod_manifests_dir: /etc/kubernetes/manifests
+kubernetes_kubectl_config_dir: /root/.kube
 # paths
 kubernetes_basic_auth_path: "{{kubernetes_auth_dir}}/basicauth.csv"
 kubernetes_authorization_policy_path: "{{kubernetes_auth_dir}}/authorization-policy.json"
-kubernetes_kubeconfig_path: "{{kubelet_lib_dir}}/kubeconfig"
+kubernetes_kubeconfig_path: "{{kubernetes_kubectl_config_dir}}/config"
 # file modes
 kubernetes_executable_mode: 0775
 kubernetes_service_mode: 0664

--- a/ansible/kubernetes-worker.yaml
+++ b/ansible/kubernetes-worker.yaml
@@ -3,6 +3,7 @@
   - include: _hosts.yaml
     when: modify_hosts_file|bool == true
   - include: _certs.yaml
+  - include: _kube-config.yaml
   - include: _packages-repo.yaml
     when: allow_package_installation|bool == true
   - include: _docker.yaml

--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -4,6 +4,7 @@
   - include: _hosts.yaml
     when: modify_hosts_file|bool == true
   - include: _certs.yaml
+  - include: _kube-config.yaml
   - include: _certs-etcd.yaml
   - include: _packages-repo.yaml
     when: allow_package_installation|bool == true

--- a/ansible/roles/kubeconfig/tasks/main.yaml
+++ b/ansible/roles/kubeconfig/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
   # setup directories
-  - name: create {{ kubelet_lib_dir }} directory
-    file: path={{ kubelet_lib_dir }} state=directory
+  - name: create {{ kubernetes_kubectl_config_dir }} directory
+    file: path={{ kubernetes_kubectl_config_dir }} state=directory
 
   - name: copy kubeconfig to remote
     template: src=kubeconfig.j2 dest={{ kubernetes_kubeconfig_path }}

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -16,6 +16,7 @@
   - include: _etcd-networking.yaml play_name="Upgrade Network Etcd Cluster" serial="1" upgrading=true
 
   # kubernetes
+  - include: _kube-config.yaml
   - include: _kubelet.yaml play_name="Upgrade Kubernetes Kubelet" serial="1" upgrading=true
   - include: _kube-apiserver.yaml play_name="Upgrade Kubernetes API Server" serial="1" upgrading=true
   - include: _kube-scheduler.yaml play_name="Upgrade Kubernetes Scheduler" serial="1" upgrading=true


### PR DESCRIPTION
Moving the file was not enough, as we this didn't cover the upgrade scenario. 

I decoupled certs from the kubeconfig, and added a post task to remove the old kubeconfig from the old location.

Fixes #411 