### PR TITLE
Use k8s annotations instead of labels to support easier upgrades

### DIFF
--- a/ansible/roles/addon-network-policy/templates/policy-controller.yaml
+++ b/ansible/roles/addon-network-policy/templates/policy-controller.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     k8s-app: calico-policy
     kubernetes.io/cluster-service: "true"
-    kismaticVersion: "{{ kismatic_short_version }}"
+  annotations:
+    kismatic/version: "{{ kismatic_short_version }}"
 spec:
   replicas: 1
   selector:

--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -68,7 +68,8 @@ metadata:
     tier: control-plane
     component: calico-node
     k8s-app: calico-node
-    kismaticVersion: "{{ kismatic_short_version }}"
+  annotations:
+    kismatic/version: "{{ kismatic_short_version }}"
 spec:
   selector:
     matchLabels:
@@ -203,7 +204,8 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico
-    kismaticVersion: "{{ kismatic_short_version }}"
+  annotations:
+    kismatic/version: "{{ kismatic_short_version }}"
 spec:
   template:
     metadata:

--- a/ansible/roles/glusterfs-k8s/templates/gluster-healthz-daemonset.yaml
+++ b/ansible/roles/glusterfs-k8s/templates/gluster-healthz-daemonset.yaml
@@ -8,7 +8,8 @@ spec:
     metadata:
       labels:
         app: gluster-healthz
-        kismaticVersion: "{{ kismatic_short_version }}"
+      annotations:
+        kismatic/version: "{{ kismatic_short_version }}"
     spec:
       containers:
         - name: tcp-healthz

--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
@@ -4,8 +4,9 @@ metadata:
   labels:
     tier: control-plane
     component: kube-apiserver
+  annotations:
     version: "{{ kubernetes_version }}"
-    kismaticVersion: "{{ kismatic_short_version }}"
+    kismatic/version: "{{ kismatic_short_version }}"
   name: kube-apiserver
   namespace: kube-system
 spec:

--- a/ansible/roles/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/ansible/roles/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -4,8 +4,9 @@ metadata:
   labels:
     tier: control-plane
     component: kube-controller-manager
+  annotations:
     version: "{{ kubernetes_version }}"
-    kismaticVersion: "{{ kismatic_short_version }}"
+    kismatic/version: "{{ kismatic_short_version }}"
   name: kube-controller-manager
   namespace: kube-system
 spec:

--- a/ansible/roles/kube-dashboard/templates/kubernetes-dashboard.yaml
+++ b/ansible/roles/kube-dashboard/templates/kubernetes-dashboard.yaml
@@ -21,8 +21,9 @@ apiVersion: extensions/v1beta1
 metadata:
   labels:
     app: kubernetes-dashboard
+  annotations:
     version: "{{ kubernetes_dashboard_version }}"
-    kismaticVersion: "{{ kismatic_short_version }}"
+    kismatic/version: "{{ kismatic_short_version }}"
   name: kubernetes-dashboard
   namespace: kube-system
 spec:

--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -7,7 +7,6 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "KubeDNS"
-    kismaticVersion: "{{ kismatic_short_version }}"
 spec:
   selector:
     k8s-app: kube-dns
@@ -29,8 +28,10 @@ metadata:
   labels:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
+  annotations:
     version: "{{kubedns_version}}"
-    kismaticVersion: "{{ kismatic_short_version }}"
+  annotations:
+    kismatic/version: "{{ kismatic_short_version }}"
 spec:
   replicas: {{ kube_dns_replicas|int }}  # create 2 replicas or the number of worker nodes
   strategy:

--- a/ansible/roles/kube-ingress/templates/default-backend.yaml
+++ b/ansible/roles/kube-ingress/templates/default-backend.yaml
@@ -9,7 +9,8 @@ spec:
     metadata:
       labels:
         app: default-http-backend
-        kismaticVersion: "{{ kismatic_short_version }}"
+      annotations:
+        kismatic/version: "{{ kismatic_short_version }}"
     spec:
       nodeSelector:
         kismatic/ingress: "true"

--- a/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
+++ b/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
@@ -8,7 +8,8 @@ spec:
     metadata:
       labels:
         name: ingress
-        kismaticVersion: "{{ kismatic_short_version }}"
+      annotations:
+        kismatic/version: "{{ kismatic_short_version }}"
     spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true # required in a CNI networkd

--- a/ansible/roles/kube-proxy/templates/kube-proxy.yaml
+++ b/ansible/roles/kube-proxy/templates/kube-proxy.yaml
@@ -4,8 +4,9 @@ metadata:
   labels:
     tier: control-plane
     component: kube-proxy
+  annotations:
     version: "{{ kubernetes_version }}"
-    kismaticVersion: "{{ kismatic_short_version }}"
+    kismatic/version: "{{ kismatic_short_version }}"
   name: kube-proxy
   namespace: kube-system
 spec:

--- a/ansible/roles/kube-scheduler/templates/kube-scheduler.yaml
+++ b/ansible/roles/kube-scheduler/templates/kube-scheduler.yaml
@@ -4,8 +4,9 @@ metadata:
   labels:
     tier: control-plane
     component: kube-scheduler
+  annotations:
     version: "{{ kubernetes_version }}"
-    kismaticVersion: "{{ kismatic_short_version }}"
+    kismatic/version: "{{ kismatic_short_version }}"
   name: kube-scheduler
   namespace: kube-system
 spec:

--- a/ansible/roles/validate-pod/tasks/validate-pod.yaml
+++ b/ansible/roles/validate-pod/tasks/validate-pod.yaml
@@ -1,7 +1,7 @@
 ---
     # kubeconfig is required becuase this task can be triggered from any k8s node
   - name: wait until {{ item }} pod has the desired version
-    command: kubectl get pods {{ item }} --namespace kube-system -o jsonpath='{.metadata.labels.kismaticVersion}' --kubeconfig {{ kubernetes_kubeconfig_path }}
+    command: kubectl get pods {{ item }} --namespace kube-system -o jsonpath='{.metadata.annotations.kismatic/version}' --kubeconfig {{ kubernetes_kubeconfig_path }}
     register: podVersion
     until: podVersion.stdout == kismatic_short_version
     retries: 20


### PR DESCRIPTION
Fixes #420 

Use annotations instead of labels.