### PR TITLE
Set hostname field in the cni config

### DIFF
--- a/ansible/_kube-config.yaml
+++ b/ansible/_kube-config.yaml
@@ -1,7 +1,7 @@
 ---
   - hosts: master:worker:ingress:storage
     any_errors_fatal: true
-    name: Generate kubectl config file
+    name: Generate Kubectl Config File
     remote_user: root
     become_method: sudo
     vars_files:

--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -3,7 +3,6 @@
     file:
       path: "{{ calico_dir }}"
       state: directory
-
   - name: copy calico.yaml to remote
     template:
       src: calico.yaml
@@ -41,3 +40,14 @@
       msg: "Timed out waiting for all calico pods to be ready."
     run_once: true
     when: desiredPods.stdout|int != readyPods.stdout|int
+
+    # This must be here otherwise calico pod overwrites the file
+  - name: create {{ network_plugin_dir }} directory
+    file:
+      path: "{{ network_plugin_dir }}"
+      state: directory
+  - name: copy 10-calico.conf to remote
+    template:
+      src: 10-calico.conf
+      dest: "{{ network_plugin_dir }}/10-calico.conf"
+      

--- a/ansible/roles/calico/templates/10-calico.conf
+++ b/ansible/roles/calico/templates/10-calico.conf
@@ -1,0 +1,21 @@
+{
+    "name": "calico-k8s-network",
+    "type": "calico",
+    "etcd_endpoints": "{{ etcd_networking_cluster_ip_list }}",
+    "etcd_cert_file": "{{ kubernetes_certificates_cert_path }}",
+    "etcd_key_file": "{{ kubernetes_certificates_key_path }}",
+    "etcd_ca_cert_file": "{{ kubernetes_certificates_ca_path }}",
+    "hostname": "{{ inventory_hostname }}",
+    "kubernetes": {
+      "kubeconfig": "{{ kubernetes_kubeconfig_path }}"
+    },
+{% if enable_calico_policy is defined and enable_calico_policy|bool == true %}
+    "policy": {
+      "type": "k8s"
+    },
+{% endif %}
+    "ipam": {
+      "type": "calico-ipam"
+    },
+    "log_level": "info"
+}

--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -11,29 +11,6 @@ data:
   # Configure the Calico backend to use.
   calico_backend: "bird"
 
-  # The CNI network configuration to install on each node.
-  cni_network_config: |-
-    {
-        "name": "k8s-pod-network",
-        "type": "calico",
-        "etcd_endpoints": "{{ etcd_networking_cluster_ip_list }}",
-        "etcd_cert_file": "{{ kubernetes_certificates_cert_path }}",
-        "etcd_key_file": "{{ kubernetes_certificates_key_path }}",
-        "etcd_ca_cert_file": "{{ kubernetes_certificates_ca_path }}",
-        "log_level": "info",
-        "ipam": {
-            "type": "calico-ipam"
-        },
-{% if enable_calico_policy is defined and enable_calico_policy|bool == true %}
-        "policy": {
-          "type": "k8s"
-        },
-{% endif %}
-        "kubernetes": {
-            "kubeconfig": "{{ kubernetes_kubeconfig_path }}"
-        }
-    }
-
   # If you're using TLS enabled etcd uncomment the following.
   # You must also populate the Secret below with these files.
   etcd_ca: "{{ kubernetes_certificates_ca_path }}"
@@ -147,12 +124,6 @@ spec:
                 configMapKeyRef:
                   name: calico-config
                   key: etcd_endpoints
-            # The CNI network config to install on each node.
-            - name: CNI_NETWORK_CONFIG
-              valueFrom:
-                configMapKeyRef:
-                  name: calico-config
-                  key: cni_network_config
           securityContext:
             privileged: true
           volumeMounts:

--- a/integration/provision.go
+++ b/integration/provision.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"time"
 
 	"github.com/apprenda/kismatic/integration/aws"
@@ -239,14 +238,10 @@ func (p awsProvisioner) updateNodeWithDeets(nodeID string, node *NodeDeets) erro
 		if err != nil {
 			return err
 		}
+		node.Hostname = awsNode.PrivateDNSName
 		node.PublicIP = awsNode.PublicIP
 		node.PrivateIP = awsNode.PrivateIP
 		node.SSHUser = awsNode.SSHUser
-
-		// Get the hostname from the DNS name
-		re := regexp.MustCompile("[^.]*")
-		hostname := re.FindString(awsNode.PrivateDNSName)
-		node.Hostname = hostname
 		if node.PublicIP != "" && node.Hostname != "" && node.PrivateIP != "" {
 			return nil
 		}
@@ -468,7 +463,7 @@ func (p packetProvisioner) waitForPublicIP(nodeID string) (*packet.Node, error) 
 func waitForSSH(provisionedNodes provisionedNodes, sshKey string) error {
 	nodes := provisionedNodes.allNodes()
 	for _, n := range nodes {
-		if open := WaitUntilSSHOpen(n.PublicIP, n.SSHUser, sshKey, 5 * time.Minute); !open {
+		if open := WaitUntilSSHOpen(n.PublicIP, n.SSHUser, sshKey, 5*time.Minute); !open {
 			return fmt.Errorf("Timed out waiting for SSH at %q", n.PublicIP)
 		}
 	}


### PR DESCRIPTION
Fixes #424 

Move cni config to outside the calico pods, need to be able to dynamically set the `hostname` field for each node and that is not possible when running as k8s pods.

This does not solve the problem that will be faced when a cluster was configured with:
- KET <v1.2.0
- `update_hosts_files=true`
- And provided `host` is different than what the `hostname` command returns

But it will cover all other cases.

The integration tests were modified to use the FQDN, to fix the issue described above.