### PR TITLE
Improve failure message when calico or DNS fail to start up

### DIFF
--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -36,8 +36,29 @@
     delay: 6
     failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
     run_once: true
+  - name: get calico-node daemonset if calico pods are not ready
+    command: kubectl get ds calico-node --namespace=kube-system
+    register: get_calico_node_ds
+    run_once: true
+    when: desiredPods.stdout|int != readyPods.stdout|int
+  - name: get all calico-node pods if calico pods are not ready
+    command: kubectl get pods -l k8s-app=calico-node --namespace=kube-system 
+    register: get_calico_node_pods
+    run_once: true
+    when: desiredPods.stdout|int != readyPods.stdout|int
   - name: fail if any calico pods are not ready
     fail:
-      msg: "Timed out waiting for all calico pods to be ready."
+      msg: |
+          Timed out waiting for all calico pods to be ready.
+          
+          ---- calico-node daemonset ----
+          {{ get_calico_node_ds.stdout }}
+
+          ------ calico-node pods -------
+          {{ get_calico_node_pods.stdout }}
+
+          See https://github.com/apprenda/kismatic/blob/master/docs/TROUBLESHOOTING.md
+          for troubleshooting documentation.
+          
     run_once: true
     when: desiredPods.stdout|int != readyPods.stdout|int

--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -17,8 +17,25 @@
     retries: 24
     delay: 10
     failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-  - name: fail if any DNS pods are not ready
-    fail:
-      msg: "Timed out waiting for DNS pods to be in the ready state."
+  - name: get DNS deployment if DNS pods are not ready
+    command: kubectl get deployment kube-dns -n kube-system
+    register: get_dns_deployment
     when: readyReplicas.stdout|int != kube_dns_replicas|int
-  - debug: var=out.stdout_lines
+  - name: get DNS pods if DNS pods are not ready
+    command: kubectl get pods -l k8s-app=kube-dns -n kube-system
+    register: get_dns_pods
+    when: readyReplicas.stdout|int != kube_dns_replicas|int
+  - name: fail if DNS pods are not ready
+    fail:
+      msg: |
+          Timed out waiting for DNS pods to be in the ready state.
+
+          ---- kube-dns deployment ----
+          {{ get_dns_deployment.stdout }}
+
+          ------- kube-dns pods -------
+          {{ get_dns_pods.stdout }}
+          
+          See https://github.com/apprenda/kismatic/blob/master/docs/TROUBLESHOOTING.md
+          for troubleshooting documentation.
+    when: readyReplicas.stdout|int != kube_dns_replicas|int


### PR DESCRIPTION
Fixes #423 

Getting the actual logs is challenging because we don't exactly what failed. However, listing the deployments and pods might help the user find the issue.