### PR TITLE
Use correct hostnames in integration tests and verify in preflight

### DIFF
--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
+  - name: verify hostname
+    fail: msg="provided hostname does not match reported hostname of {{ ansible_nodename }}"
+    when: "inventory_hostname != ansible_nodename"
+    changed_when: false
+
   - name: verify systemd
     fail: msg="systemd is required"
     when: ansible_service_mgr != "systemd"

--- a/integration/aws/client.go
+++ b/integration/aws/client.go
@@ -40,6 +40,7 @@ type Node struct {
 	PublicIP       string
 	SSHUser        string
 	State          string
+	ImageID        string
 }
 
 // DNSRecord in Router53 on AWS
@@ -211,6 +212,10 @@ func (c Client) GetNode(id string) (*Node, error) {
 	}
 	instance := resp.Reservations[0].Instances[0]
 
+	var imageID string
+	if instance.ImageId != nil {
+		imageID = *instance.ImageId
+	}
 	var privateDNSName string
 	if instance.PrivateDnsName != nil {
 		privateDNSName = *instance.PrivateDnsName
@@ -225,6 +230,7 @@ func (c Client) GetNode(id string) (*Node, error) {
 	}
 
 	return &Node{
+		ImageID:        imageID,
 		PrivateDNSName: privateDNSName,
 		PrivateIP:      privateIP,
 		PublicIP:       publicIP,

--- a/integration/glide.lock
+++ b/integration/glide.lock
@@ -1,14 +1,6 @@
-hash: 3571c3de47e367a5cd9e8fcc70ad6e342a2c6c6edb2212927f2112e858f04d0f
-updated: 2017-01-27T08:49:41.231448598-05:00
+hash: 64c41a43d9c64f3281ff232b53743620ee7760c65c1ce5e8c43a84d37fb15071
+updated: 2017-03-16T16:04:00.730822735-04:00
 imports:
-- name: github.com/apprenda/kismatic
-  version: 9ba0fa11895cb243cefcb78663c9e48ca3c8b5f3
-  subpackages:
-  - integration/aws
-  - integration/packet
-  - integration/retry
-  - integration/tls
-  - pkg/retry
 - name: github.com/aws/aws-sdk-go
   version: 1355b456f6ba4a8453249e0dc7743f16ccac362d
   subpackages:

--- a/integration/glide.yaml
+++ b/integration/glide.yaml
@@ -1,4 +1,6 @@
 package: github.com/apprenda/kismatic/integration
+ignore:
+- github.com/apprenda/kismatic
 import:
 - package: github.com/aws/aws-sdk-go
   version: 1.6.2

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -92,7 +92,7 @@ var _ = Describe("kismatic", func() {
 			})
 		})
 
-		Context("when deploying a mini-kube style cluster", func() {
+		Context("when targetting CentOS", func() {
 			ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
 				WithMiniInfrastructure(CentOS7, aws, func(node NodeDeets, sshKey string) {
 					err := installKismaticMini(node, sshKey)

--- a/integration/provision.go
+++ b/integration/provision.go
@@ -19,13 +19,11 @@ const (
 	CentOS7       = linuxDistro("centos7")
 	RedHat7       = linuxDistro("rhel7")
 
-	AWSTargetRegion     = "us-east-1"
-	AWSSubnetID         = "subnet-25e13d08"
-	AWSKeyName          = "kismatic-integration-testing"
-	AWSSecurityGroupID  = "sg-d1dc4dab"
-	AMIUbuntu1604USEAST = "ami-29f96d3e"
-	AMICentos7UsEast    = "ami-6d1c2007"
-	AWSHostedZoneID     = "Z1LNBHSE28OF08"
+	AWSTargetRegion    = "us-east-1"
+	AWSSubnetID        = "subnet-25e13d08"
+	AWSKeyName         = "kismatic-integration-testing"
+	AWSSecurityGroupID = "sg-d1dc4dab"
+	AWSHostedZoneID    = "Z1LNBHSE28OF08"
 )
 
 type infrastructureProvisioner interface {
@@ -246,6 +244,10 @@ func (p awsProvisioner) updateNodeWithDeets(nodeID string, node *NodeDeets) erro
 		// Get the hostname from the DNS name
 		re := regexp.MustCompile("[^.]*")
 		hostname := re.FindString(awsNode.PrivateDNSName)
+		// RedHat uses FQDN as the hostname
+		if awsNode.ImageID == string(aws.RedHat7East) {
+			hostname = awsNode.PrivateDNSName
+		}
 		node.Hostname = hostname
 		if node.PublicIP != "" && node.Hostname != "" && node.PrivateIP != "" {
 			return nil
@@ -468,7 +470,7 @@ func (p packetProvisioner) waitForPublicIP(nodeID string) (*packet.Node, error) 
 func waitForSSH(provisionedNodes provisionedNodes, sshKey string) error {
 	nodes := provisionedNodes.allNodes()
 	for _, n := range nodes {
-		if open := WaitUntilSSHOpen(n.PublicIP, n.SSHUser, sshKey, 5 * time.Minute); !open {
+		if open := WaitUntilSSHOpen(n.PublicIP, n.SSHUser, sshKey, 5*time.Minute); !open {
 			return fmt.Errorf("Timed out waiting for SSH at %q", n.PublicIP)
 		}
 	}


### PR DESCRIPTION
Fixes #424 

We were using incorrect hostnames in some integration tests.
In `KET v1.2.x` we were setting the Calico `hostname` flag instead of relying on the OS reported one. Fo Calico upgrade to work correctly the planfile node name should be the correct `hostname`