### PR TITLE
Show node roles when running online upgrade checks

### DIFF
--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -220,7 +220,7 @@ func upgradeNodes(out io.Writer, plan install.Plan, opts upgradeOpts, nodesNeedU
 		}
 		kubeClient := data.RemoteKubectl{SSHClient: client}
 		for _, node := range nodesNeedUpgrade {
-			util.PrettyPrint(out, "Node %q", node.Node.Host)
+			util.PrettyPrint(out, "%s %v", node.Node.Host, node.Roles)
 			errs := install.DetectNodeUpgradeSafety(plan, node.Node, kubeClient)
 			if len(errs) != 0 {
 				util.PrintError(out)


### PR DESCRIPTION
Fixes #435 

Sample:

```
Validate Online Upgrade=============================================================
node001 [master etcd worker ingress]                                            [ERROR]
- This is the only master node in the cluster. Upgrading it will make the cluster unavailable.
- This node is acting as the load balanced endpoint for the master nodes. Upgrading it will make the cluster unavailable
- This node is part of an etcd cluster that has less than 3 members. Upgrading it will make the cluster unavailable.
```