### PR TITLE
Support upgrades from v1.3.0

### DIFF
--- a/ansible/_calico-validate-node.yaml
+++ b/ansible/_calico-validate-node.yaml
@@ -1,0 +1,24 @@
+---
+  - hosts: master:worker:ingress:storage
+    any_errors_fatal: true
+    name: "{{ play_name | default('Validate Network Components') }}"
+    serial: "{{ serial_count | default('100%') }}"
+    remote_user: root
+    become_method: sudo
+    vars_files:
+      - group_vars/all.yaml
+
+    tasks:
+      - name: wait until the calico pod on this node is running
+        shell: kubectl get pods `kubectl get pods -l=k8s-app=calico-node --template {%raw%}'{{range .items}}{{if eq .spec.nodeName{%endraw%} "{{ inventory_hostname }}"{%raw%}}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'{%endraw%} -n kube-system` -n kube-system -o=jsonpath='{.status.phase}'
+        register: calico_pod_name
+        until: calico_pod_name|success and calico_pod_name.stdout == "Running"
+        retries: 10
+        delay: 6
+        failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+        run_once: true
+      - name: fail if the calico pod on this node is not ready
+        fail:
+          msg: "Timed out waiting for calico pod on this node to be ready."
+        run_once: true
+        when: calico_pod_name|failed

--- a/ansible/_calico-validate.yaml
+++ b/ansible/_calico-validate.yaml
@@ -1,0 +1,31 @@
+---
+  - hosts: master:worker:ingress:storage
+    any_errors_fatal: true
+    name: "{{ play_name | default('Validate Network Components') }}"
+    serial: "{{ serial_count | default('100%') }}"
+    remote_user: root
+    become_method: sudo
+    vars_files:
+      - group_vars/all.yaml
+
+    tasks:
+      - name: get desired number of calico pods
+        command: kubectl get ds calico-node -o=jsonpath='{.status.desiredNumberScheduled}' --namespace=kube-system --kubeconfig {{ kubernetes_kubeconfig_path }}
+        register: desiredPods
+        until: desiredPods|success
+        retries: 20
+        delay: 6
+        run_once: true
+      - name: wait until all calico pods are ready
+        command: kubectl get ds calico-node -o=jsonpath='{.status.numberReady}' --namespace=kube-system --kubeconfig {{ kubernetes_kubeconfig_path }}
+        register: readyPods
+        until: desiredPods.stdout|int == readyPods.stdout|int
+        retries: 20
+        delay: 6
+        failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+        run_once: true
+      - name: fail if any calico pods are not ready
+        fail:
+          msg: "Timed out waiting for all calico pods to be ready."
+        run_once: true
+        when: desiredPods.stdout|int != readyPods.stdout|int

--- a/ansible/_kube-apiserver-stop.yaml
+++ b/ansible/_kube-apiserver-stop.yaml
@@ -13,17 +13,36 @@
         command: systemctl is-active -q kube-apiserver.service
         register: status
         failed_when: status.rc !=0 and status.rc != 3 # 0 = running. 3 = stopped/doesn't exist
-        when: upgrading is defined and upgrading|bool == true
 
       - name: stop kube-apiserver service if running
         service:
           name: kube-apiserver.service
           state: stopped
           enabled: no
-        when: upgrading is defined and upgrading|bool == true and status is defined and status.rc == 0 # only stop if it's running
+        when: status is defined and status.rc == 0 # only stop if it's running
 
       # post KET 1.3 clusters
-      - name: remove kube-apiserver.yaml manifest if present
+      - name: create backup static pod manifests directory
         file:
+          path: "{{ kubelet_pod_manifests_backup_dir }}"
+          state: directory
+          mode: 0700
+      - name: determine if kube-apiserver.yaml manifest exists
+        stat:
           path: "{{ kubelet_pod_manifests_dir }}/kube-apiserver.yaml"
-          state: absent
+        register: pod_stat
+      - name: move kube-apiserver.yaml manifest if present
+        shell: cp {{ kubelet_pod_manifests_dir }}/kube-apiserver.yaml {{ kubelet_pod_manifests_backup_dir }}/kube-apiserver.yaml && rm -f {{ kubelet_pod_manifests_dir }}/kube-apiserver.yaml
+        when: pod_stat is defined and pod_stat.stat.exists
+      - name: wait until kube-apiserver is stopped
+        uri: url="https://127.0.0.1:{{ kubernetes_master_insecure_port }}/heatlhz"  # use the local insecure port
+        when: pod_stat is defined and pod_stat.stat.exists
+        register: healthz
+        failed_when: "healthz|success"  # wait until server is down
+        until: "healthz|failed"
+        retries: 30
+        delay: 1
+      - name: fail if kube-apiserver was not stopped
+        fail:
+          msg: "Timed out waiting for kube-apiserver to be stopped."
+        when: pod_stat is defined and pod_stat.stat.exists and healthz|failed

--- a/ansible/_kube-apiserver-stop.yaml
+++ b/ansible/_kube-apiserver-stop.yaml
@@ -8,6 +8,7 @@
       - group_vars/all.yaml
 
     tasks:
+      # pre KET 1.3 clusters
       - name: check if kube-apiserver service is active
         command: systemctl is-active -q kube-apiserver.service
         register: status
@@ -20,3 +21,9 @@
           state: stopped
           enabled: no
         when: upgrading is defined and upgrading|bool == true and status is defined and status.rc == 0 # only stop if it's running
+
+      # post KET 1.3 clusters
+      - name: remove kube-apiserver.yaml manifest if present
+        file:
+          path: "{{ kubelet_pod_manifests_dir }}/kube-apiserver.yaml"
+          state: absent

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -92,6 +92,7 @@ network_plugin_dir: /etc/cni/net.d
 kubernetes_auth_dir: /etc/kubernetes/auth
 kubelet_lib_dir: /var/lib/kubelet
 kubelet_pod_manifests_dir: /etc/kubernetes/manifests
+kubelet_pod_manifests_backup_dir: /etc/kubernetes/manifests-backup
 kubernetes_kubectl_config_dir: /root/.kube
 # paths
 kubernetes_basic_auth_path: "{{kubernetes_auth_dir}}/basicauth.csv"

--- a/ansible/kubernetes-worker.yaml
+++ b/ansible/kubernetes-worker.yaml
@@ -10,4 +10,5 @@
   - include: _kubelet.yaml
   - include: _kube-proxy.yaml
   - include: _calico.yaml
+  - include: _calico-validate.yaml
   - include: _worker-smoke-test.yaml

--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -28,6 +28,7 @@
   # after installing kube-proxy, there is a dependecy on the API server to validate the static pod
   - include: _kube-proxy.yaml
   - include: _calico.yaml
+  - include: _calico-validate.yaml
   - include: _kube-dns.yaml
   - include: _kube-ingress.yaml
     when: configure_ingress|bool == true

--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -49,24 +49,3 @@
     retries: 20
     delay: 6
     when: calico_pod_name is defined and calico_pod_name.stdout != ""
-
-  - name: get desired number of calico pods
-    command: kubectl get ds calico-node -o=jsonpath='{.status.desiredNumberScheduled}' --namespace=kube-system --kubeconfig {{ kubernetes_kubeconfig_path }}
-    register: desiredPods
-    until: desiredPods|success
-    retries: 20
-    delay: 6
-    run_once: true
-  - name: wait until all calico pods are ready
-    command: kubectl get ds calico-node -o=jsonpath='{.status.numberReady}' --namespace=kube-system --kubeconfig {{ kubernetes_kubeconfig_path }}
-    register: readyPods
-    until: desiredPods.stdout|int == readyPods.stdout|int
-    retries: 20
-    delay: 6
-    failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-    run_once: true
-  - name: fail if any calico pods are not ready
-    fail:
-      msg: "Timed out waiting for all calico pods to be ready."
-    run_once: true
-    when: desiredPods.stdout|int != readyPods.stdout|int

--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -38,7 +38,7 @@
     run_once: true
 
   - name: delete calico pod running on this node
-    command: kubectl delete pod {{ calico_pod_name.stdout }} -n kube-system
+    command: kubectl delete pod {{ calico_pod_name.stdout }} -n kube-system --now
     when: calico_pod_name is defined and calico_pod_name.stdout != ""
 
     # wait for pod to shutdown

--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -23,6 +23,11 @@
       group: "{{ kubernetes_group }}"
       mode: "{{ network_environment_mode }}"
 
+  - name: get the name of the calico pod running on this node
+    command: kubectl get pods -l=k8s-app=calico-node --template {%raw%}'{{range .items}}{{if eq .spec.nodeName{%endraw%} "{{ inventory_hostname }}"{%raw%}}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'{%endraw%} -n kube-system
+    register: calico_pod_name
+    when: upgrading is defined and upgrading|bool == true
+
     # label nodes that will have have calico isntalled
   - name: label nodes for calico
     command: kubectl label nodes {% for host in play_hosts %}{{ host }} {% endfor %} kismatic/calico=true --overwrite --kubeconfig {{ kubernetes_kubeconfig_path }}
@@ -31,6 +36,19 @@
   - name: start calico containers
     command: kubectl apply -f /etc/calico/calico.yaml --kubeconfig {{ kubernetes_kubeconfig_path }}
     run_once: true
+
+  - name: delete calico pod running on this node
+    command: kubectl delete pod {{ calico_pod_name.stdout }} -n kube-system
+    when: calico_pod_name is defined and calico_pod_name.stdout != ""
+
+    # wait for pod to shutdown
+  - name: wait until the calico pod running on this node is deleted
+    command: kubectl get pods {{ calico_pod_name.stdout }} --ignore-not-found=true -n kube-system
+    register: poddeleted
+    until: poddeleted|success and poddeleted.stdout == ""
+    retries: 20
+    delay: 6
+    when: calico_pod_name is defined and calico_pod_name.stdout != ""
 
   - name: get desired number of calico pods
     command: kubectl get ds calico-node -o=jsonpath='{.status.desiredNumberScheduled}' --namespace=kube-system --kubeconfig {{ kubernetes_kubeconfig_path }}

--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
@@ -61,7 +61,8 @@ spec:
         path: /healthz
         port: 8080
       initialDelaySeconds: 15
-      timeoutSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 8
   volumes:
   - hostPath:
       path: /etc/kubernetes

--- a/ansible/roles/kube-controller-manager/templates/kube-controller-manager.yaml
+++ b/ansible/roles/kube-controller-manager/templates/kube-controller-manager.yaml
@@ -22,7 +22,6 @@ spec:
       - --cluster-name={{ kubernetes_cluster_name }}
       - --kubeconfig={{ kubernetes_kubeconfig_path }}
       - --leader-elect=true
-      - --master={{ kubernetes_master_ip }}
       - --root-ca-file={{ kubernetes_certificates_ca_path }}
       - --service-account-private-key-file={{ kubernetes_certificates_service_account_key_path }}
       - --service-cluster-ip-range={{ kubernetes_services_cidr }}
@@ -33,7 +32,8 @@ spec:
         path: /healthz
         port: 10252
       initialDelaySeconds: 15
-      timeoutSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 8
     volumeMounts:
     - mountPath: "{{ kubernetes_kubeconfig_path }}"
       name: "kubeconfig"

--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -150,7 +150,7 @@ spec:
         - -k
         - --cache-size=1000
         - --log-facility=-
-        - --server=127.0.0.1#10053
+        - --server=/cluster.local/127.0.0.1#10053
         - --server=/in-addr.arpa/127.0.0.1#10053
         - --server=/ip6.arpa/127.0.0.1#10053
         ports:

--- a/ansible/roles/kube-proxy/templates/kube-proxy.yaml
+++ b/ansible/roles/kube-proxy/templates/kube-proxy.yaml
@@ -20,7 +20,6 @@ spec:
       - --cluster-cidr={{ kubernetes_pods_cidr }}
       - --hostname-override={{ inventory_hostname }}
       - --kubeconfig={{ kubernetes_kubeconfig_path }}
-      - --master={{ kubernetes_master_ip }}
       - --proxy-mode=iptables
       - --v=2
     securityContext:
@@ -40,7 +39,8 @@ spec:
         path: /healthz
         port: 10249
       initialDelaySeconds: 15
-      timeoutSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 8
   volumes:
     - name: "ssl-certs"
       hostPath:

--- a/ansible/roles/kube-scheduler/templates/kube-scheduler.yaml
+++ b/ansible/roles/kube-scheduler/templates/kube-scheduler.yaml
@@ -19,7 +19,6 @@ spec:
       - kube-scheduler
       - --kubeconfig={{ kubernetes_kubeconfig_path }}
       - --leader-elect=true
-      - --master={{ kubernetes_master_ip }}
       - --v=2
     volumeMounts:
       - mountPath: "{{ kubernetes_kubeconfig_path }}"
@@ -34,7 +33,8 @@ spec:
         path: /healthz
         port: 10251
       initialDelaySeconds: 15
-      timeoutSeconds: 5
+      timeoutSeconds: 15
+      failureThreshold: 8
   volumes:
     - name: "kubeconfig"
       hostPath:

--- a/ansible/roles/upgrade-preflight/tasks/main.yaml
+++ b/ansible/roles/upgrade-preflight/tasks/main.yaml
@@ -1,4 +1,9 @@
 ---
+  - name: verify hostname
+    fail: msg="provided hostname does not match reported hostname of {{ ansible_nodename }}"
+    when: "inventory_hostname != ansible_nodename"
+    changed_when: false
+
   - name: copy Kismatic Inspector to node
     copy:
       src: "{{ kismatic_preflight_checker }}"

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -24,6 +24,7 @@
   - include: _validate-control-plane-node.yaml serial_count="1" upgrading=true
   - include: _kube-proxy.yaml play_name="Upgrade Kubernetes Proxy" upgrading=true
   - include: _calico.yaml play_name="Upgrade Cluster Network" upgrading=true
+  - include: _calico-validate-node.yaml play_name="Validate Cluster Network" upgrading=true
 
   - include: _kube-uncordon-node.yaml
     when: online_upgrade is defined and online_upgrade|bool == true

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -11,6 +11,34 @@ import (
 
 var _ = Describe("Upgrade", func() {
 	Describe("Upgrading a cluster using offline mode", func() {
+		Describe("From KET version v1.3.0", func() {
+			BeforeEach(func() {
+				dir := setupTestWorkingDirWithVersion("v1.3.0")
+				os.Chdir(dir)
+			})
+			Context("Using a larger cluster layout with CentOS 7", func() {
+				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
+					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 1, Ingress: 0, Storage: 0}, RedHat7, aws, func(nodes provisionedNodes, sshKey string) {
+						installAndUpgrade(nodes, sshKey)
+					})
+				})
+			})
+		})
+
+		Describe("From KET version v1.3.0-beta.0", func() {
+			BeforeEach(func() {
+				dir := setupTestWorkingDirWithVersion("v1.3.0-beta.0")
+				os.Chdir(dir)
+			})
+			Context("Using a larger cluster layout with CentOS 7", func() {
+				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
+					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 1, Ingress: 0, Storage: 0}, RedHat7, aws, func(nodes provisionedNodes, sshKey string) {
+						installAndUpgrade(nodes, sshKey)
+					})
+				})
+			})
+		})
+
 		Describe("From KET version v1.2.2", func() {
 			BeforeEach(func() {
 				dir := setupTestWorkingDirWithVersion("v1.2.2")

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -16,9 +16,9 @@ var _ = Describe("Upgrade", func() {
 				dir := setupTestWorkingDirWithVersion("v1.3.0")
 				os.Chdir(dir)
 			})
-			Context("Using a larger cluster layout with CentOS 7", func() {
+			Context("Using a larger cluster layout with Ubuntu 16.04", func() {
 				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
-					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 1, Ingress: 0, Storage: 0}, RedHat7, aws, func(nodes provisionedNodes, sshKey string) {
+					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 2, Ingress: 0, Storage: 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 						installAndUpgrade(nodes, sshKey)
 					})
 				})
@@ -30,9 +30,9 @@ var _ = Describe("Upgrade", func() {
 				dir := setupTestWorkingDirWithVersion("v1.3.0-beta.0")
 				os.Chdir(dir)
 			})
-			Context("Using a larger cluster layout with CentOS 7", func() {
+			Context("Using a larger cluster layout with Ubuntu 16.04", func() {
 				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
-					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 1, Ingress: 0, Storage: 0}, RedHat7, aws, func(nodes provisionedNodes, sshKey string) {
+					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 2, Ingress: 0, Storage: 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 						installAndUpgrade(nodes, sshKey)
 					})
 				})

--- a/pkg/install/about.go
+++ b/pkg/install/about.go
@@ -2,8 +2,6 @@ package install
 
 import (
 	"fmt"
-	"strconv"
-	"strings"
 
 	"github.com/apprenda/kismatic/pkg/ssh"
 	"github.com/apprenda/kismatic/pkg/util"
@@ -70,24 +68,13 @@ func IsLessThanVersion(this semver.Version, that string) bool {
 
 func parseVersion(versionString string) (semver.Version, error) {
 	// Support a 'v' prefix
-	v, err := semver.ParseTolerant(versionString)
+	verString := versionString
+	if versionString[0] == 'v' {
+		verString = versionString[1:len(versionString)]
+	}
+	v, err := semver.Make(verString)
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("Unable to parse version %q: %v", versionString, err)
-	}
-	// convert git tag to semver
-	// v1.3.0-1-abcd1234 is first commit after v1.3.0
-	// but in semver it is NOT greater than v1.3.0
-	// split Pre[0] on "-"
-	// if first part of Pre[0] is numeric bump patch version
-	if len(v.Pre) == 0 {
-		return v, nil
-	}
-	splitPre := strings.Split(v.Pre[0].String(), "-")
-	if len(splitPre) > 0 {
-		// don't care about the commit number, just increment patch
-		if _, err := strconv.Atoi(splitPre[0]); err == nil {
-			v.Patch++
-		}
+		return semver.Version{}, fmt.Errorf("Unable to parse version %q: %v", verString, err)
 	}
 	return v, nil
 }

--- a/pkg/install/about_test.go
+++ b/pkg/install/about_test.go
@@ -65,11 +65,10 @@ func TestIsOlderVersion(t *testing.T) {
 	}
 }
 
-// Bump patch version for git describe
 func TestGitDescribeVersion(t *testing.T) {
 	ver := mustParseVersion("v1.2.2-69-g51dfe53-dirty")
-	if ver.Major != 1 || ver.Minor != 2 || ver.Patch != 3 {
-		t.Errorf("didn't parse to version 1.2.3, instead got %v", ver)
+	if ver.Major != 1 || ver.Minor != 2 || ver.Patch != 2 {
+		t.Errorf("didn't parse to version 1.2.2, instead got %v", ver)
 	}
 	if ver.Pre[0].VersionStr != "69-g51dfe53-dirty" {
 		t.Errorf("didn't parse pre-release to 69-g51dfe53-dirty, instead got %s", ver.Pre[0])

--- a/pkg/install/about_test.go
+++ b/pkg/install/about_test.go
@@ -65,10 +65,11 @@ func TestIsOlderVersion(t *testing.T) {
 	}
 }
 
+// Bump patch version for git describe
 func TestGitDescribeVersion(t *testing.T) {
 	ver := mustParseVersion("v1.2.2-69-g51dfe53-dirty")
-	if ver.Major != 1 || ver.Minor != 2 || ver.Patch != 2 {
-		t.Errorf("didn't parse to version 1.2.2, instead got %v", ver)
+	if ver.Major != 1 || ver.Minor != 2 || ver.Patch != 3 {
+		t.Errorf("didn't parse to version 1.2.3, instead got %v", ver)
 	}
 	if ver.Pre[0].VersionStr != "69-g51dfe53-dirty" {
 		t.Errorf("didn't parse pre-release to 69-g51dfe53-dirty, instead got %s", ver.Pre[0])


### PR DESCRIPTION
To support upgrading from `v1.3.0` including alpha and beta

* ~~Git tags are not valid semver and future dev builds `v1.3.0-#-alphanum` are not greater than `v1.3.0`, bumping patch version when detecting its a dev git tag~~
* Skip etcd2 upgrade for `alpha` and `beta` versions
* Skip etcdv3 migration for `v1.3.0` 
* Increase probes on control-plane components to match that of kubeadm