### PR TITLE
Update released_test to use v1.3.0

### DIFF
--- a/integration/install_released_test.go
+++ b/integration/install_released_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const previousKismaticVersion = "v1.2.0"
+const previousKismaticVersion = "v1.3.0"
 
 // Test a specific released version of Kismatic
 var _ = Describe("Installing with previous version of Kismatic", func() {


### PR DESCRIPTION
Fixes #241 
Fixes #464 

This test used an outdated version of KET `v1.2.0`, the package installation plays were changed in the newest release. They are all tasks instead of handlers and will fail.