### PR TITLE
Dockerize kismatic installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,25 @@ dist: vendor-ansible/out vendor-provision/out vendor-kuberang/$(KUBERANG_VERSION
 	tar -czf kismatic.tar.gz -C out .
 	mv kismatic.tar.gz out
 
+docker: GOOS=linux
+docker: vendor-ansible/out vendor-provision/out vendor-kuberang/$(KUBERANG_VERSION) build-inspector
+	@$(MAKE) GOOS=linux bin/linux/kismatic
+	mkdir -p out-docker
+	cp bin/linux/kismatic out-docker
+	mkdir -p out-docker/ansible
+	cp -r vendor-ansible/out/* out-docker/ansible
+	rm -rf out-docker/ansible/playbooks
+	cp -r ansible out-docker/ansible/playbooks
+	mkdir -p out-docker/ansible/playbooks/inspector
+	cp -r bin/inspector/* out-docker/ansible/playbooks/inspector
+	rm -rf out-docker/ansible/playbooks/inspector/darwin
+	mkdir -p out-docker/ansible/playbooks/kuberang/linux/amd64/
+	cp vendor-kuberang/$(KUBERANG_VERSION)/kuberang-linux-amd64 out-docker/ansible/playbooks/kuberang/linux/amd64/kuberang
+	cp docker/Dockerfile.kismatic out-docker/Dockerfile.kismatic
+	docker build -f out-docker/Dockerfile.kismatic -t apprenda/kismatic:dev out-docker
+	docker tag apprenda/kismatic:dev apprenda/kismatic:$(VERSION)
+	rm -rf out-docker
+
 integration/vendor: tools/glide
 	go get github.com/onsi/ginkgo/ginkgo
 	cd integration && ../tools/glide install

--- a/docker/Dockerfile.kismatic
+++ b/docker/Dockerfile.kismatic
@@ -1,0 +1,11 @@
+FROM python:2-slim
+
+WORKDIR /workdir
+
+ADD kismatic /usr/bin/kismatic
+RUN chmod +x /usr/bin/kismatic
+
+ADD /ansible/ /ansible/
+
+ENTRYPOINT ["/usr/bin/kismatic"]
+CMD ["--help"]

--- a/pkg/ansible/runner.go
+++ b/pkg/ansible/runner.go
@@ -117,24 +117,17 @@ func (r *runner) startPlaybook(playbookFile string, inv Inventory, cc ClusterCat
 	if err != nil {
 		return nil, fmt.Errorf("error writing cluster catalog data to yaml: %v", err)
 	}
-	clusterCatalogFile := filepath.Join(r.ansibleDir, "clustercatalog.yaml")
-	if err = ioutil.WriteFile(clusterCatalogFile, yamlBytes, 0644); err != nil {
+	clusterCatalogFile := filepath.Join(r.runDir, "clustercatalog.yaml")
+	if err := ioutil.WriteFile(clusterCatalogFile, yamlBytes, 0644); err != nil {
 		return nil, fmt.Errorf("error writing cluster catalog file to %q: %v", clusterCatalogFile, err)
 	}
 
-	inventoryFile := filepath.Join(r.ansibleDir, "inventory.ini")
+	inventoryFile := filepath.Join(r.runDir, "inventory.ini")
 	if err := ioutil.WriteFile(inventoryFile, inv.ToINI(), 0644); err != nil {
 		return nil, fmt.Errorf("error writing inventory file to %q: %v", inventoryFile, err)
 	}
 
-	if err := copyFileContents(clusterCatalogFile, filepath.Join(r.runDir, "clustercatalog.yaml")); err != nil {
-		return nil, fmt.Errorf("error copying clustercatalog.yaml to %q: %v", r.runDir, err)
-	}
-	if err := copyFileContents(inventoryFile, filepath.Join(r.runDir, "inventory.ini")); err != nil {
-		return nil, fmt.Errorf("error copying inventory.ini to %q: %v", r.runDir, err)
-	}
-
-	cmd := exec.Command(filepath.Join(r.ansibleDir, "bin", "ansible-playbook"), "-i", inventoryFile, "-s", playbook, "--extra-vars", "@"+clusterCatalogFile)
+	cmd := exec.Command(filepath.Join(r.ansibleDir, "bin", "ansible-playbook"), "-i", filepath.Join(r.runDir, "inventory.ini"), "-s", playbook, "--extra-vars", "@"+filepath.Join(r.runDir, "clustercatalog.yaml"))
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
 

--- a/pkg/cli/dashboard.go
+++ b/pkg/cli/dashboard.go
@@ -62,7 +62,9 @@ func doDashboard(out io.Writer, planner install.Planner, opts *dashboardOpts) er
 		return fmt.Errorf("Error verifying connectivity to cluster dashboard: %v", err)
 	}
 	// Dashboard is accessible.. take action
-	if opts.dashboardURLMode {
+	// In URL mode or
+	// Running in a docker container, can't open a browser from here
+	if opts.dashboardURLMode || util.RunningInDocker() {
 		fmt.Fprintln(out, unauthURL)
 		return nil
 	}

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -1,10 +1,21 @@
 package install
 
-import "testing"
+import (
+	"path/filepath"
+	"testing"
+)
 
 func TestGenerateAlphaNumericPassword(t *testing.T) {
 	_, err := generateAlphaNumericPassword()
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+// the test will run either in a container or locally, should always be absolute path
+func TestGetSSHKey(t *testing.T) {
+	key := getSSHKey()
+	if !filepath.IsAbs(key) {
+		t.Errorf("Expected key to be an absolute path, instead got %s", key)
 	}
 }

--- a/pkg/util/docker.go
+++ b/pkg/util/docker.go
@@ -1,0 +1,9 @@
+package util
+
+import "os"
+
+// RunningInDocker stat /.dockerenv file that should be available in all docker containers
+func RunningInDocker() bool {
+	_, err := os.Stat("/.dockerenv")
+	return err == nil
+}


### PR DESCRIPTION
First steps in dockerizing `kismatic`

This does not include any work related to the provisioner.

For OSX and Linux place something like below in your $PATH, `/usr/local/bin/kismatic` should work:
```
#!/bin/bash
docker run -it $KISMATIC_EXTRA_MOUNTS -v "$(pwd)":/workdir -v "$HOME/.ssh/kismaticuser.key":/root/.ssh/kismaticuser.key -w /workdir apprenda/kismatic "$@"
```

This will mount the `$HOME/.ssh/kismaticuser.key` and the current path in the container.   
If you need to reference any other local directory use just `export KISMATIC_EXTRA_MOUNTS` with the mounts.