### PR TITLE
SSH and info usability changes

### DIFF
--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/apprenda/kismatic/pkg/install"
 	"github.com/apprenda/kismatic/pkg/util"
@@ -21,7 +23,7 @@ func NewCmdInfo(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "info",
 		Short: "Display info about nodes in the cluster",
-		Long: `will list the external IP addresses of nodes that make up the cluster, along with their current versions & roles.
+		Long: `will list the nodes that make up the cluster, along with their current versions & roles.
 
 This will retreived by connecting to each node via ssh`,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -60,11 +62,11 @@ func list(out io.Writer, opts *infoOpts) error {
 		if err != nil {
 			return fmt.Errorf("error marshalling struct: %v", err)
 		}
-		fmt.Fprintf(out, string(b))
+		fmt.Fprintln(out, string(b))
 		return nil
 	}
 
-	fmt.Fprintf(out, "Cluster: ")
+	fmt.Fprintf(out, "Cluster Version: ")
 	if lv.IsTransitioning {
 		fmt.Fprintf(out, "Transitioning from v%v to v%v\n", lv.EarliestVersion, lv.LatestVersion)
 	} else {
@@ -72,9 +74,10 @@ func list(out io.Writer, opts *infoOpts) error {
 	}
 	fmt.Fprintln(out)
 	fmt.Fprintf(out, "Nodes:\n")
+	w := tabwriter.NewWriter(out, 0, 0, 3, ' ', 0)
+	fmt.Fprint(w, "Name\tIP\tRoles\tKismatic Version\n")
 	for _, listNode := range lv.Nodes {
-		fmt.Fprintf(out, "  - %v: v%v %v\n", listNode.Node.IP, listNode.Version, listNode.Roles)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", listNode.Node.Host, listNode.Node.IP, strings.Join(listNode.Roles, ","), listNode.Version)
 	}
-
-	return err
+	return w.Flush()
 }

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/apprenda/kismatic/pkg/ssh"
 )
@@ -154,10 +155,19 @@ func (p *Plan) getNodeWithIP(ip string) (*Node, error) {
 func (p *Plan) GetSSHConnection(host string) (*SSHConnection, error) {
 	nodes := p.getAllNodes()
 
+	var isIP bool
+	if ip := net.ParseIP(host); ip != nil {
+		isIP = true
+	}
+
 	// try to find the node with the provided hostname
 	var foundNode *Node
 	for _, node := range nodes {
-		if node.Host == host {
+		nodeAddress := node.Host
+		if isIP {
+			nodeAddress = node.IP
+		}
+		if nodeAddress == host {
 			foundNode = &node
 			break
 		}
@@ -179,7 +189,11 @@ func (p *Plan) GetSSHConnection(host string) (*SSHConnection, error) {
 	}
 
 	if foundNode == nil {
-		return nil, fmt.Errorf("node %q not found in the plan", host)
+		notFoundErr := fmt.Errorf("node %q not found in the plan", host)
+		if isIP {
+			notFoundErr = fmt.Errorf("node with IP %q not found in the plan", host)
+		}
+		return nil, notFoundErr
 	}
 
 	return &SSHConnection{&p.Cluster.SSH, foundNode}, nil


### PR DESCRIPTION
Fixes #472 

The `info` command should print the `hostnames` instead of IPs as the IPs are not really used anywhere. The `hostnames` are used for k8s node names.

Support public IPs in `ssh` command, sometimes the user may know the public IP instead of the hostname.
