### PR TITLE
[WIP] Support for direct-lvm Docker storage driver

### DIFF
--- a/ansible/_docker.yaml
+++ b/ansible/_docker.yaml
@@ -1,7 +1,7 @@
 ---
   - hosts: master:worker:ingress:storage
     any_errors_fatal: true
-    name: "{{ play_name | default('Start Docker') }}"
+    name: "{{ play_name | default('Install Docker') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
     become_method: sudo
@@ -11,4 +11,6 @@
     roles:
       - role: packages-docker
         when: allow_package_installation|bool == true
-      - docker
+      - role: docker-storage
+        when: docker_direct_lvm_enabled|bool == true
+      - role: docker

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -74,6 +74,13 @@ docker_certificates_key_file_name: docker-key.pem
 docker_certificates_cert_path: "{{ docker_install_dir }}/{{ docker_certificates_cert_file_name }}"
 docker_certificates_key_path: "{{ docker_install_dir }}/{{ docker_certificates_key_file_name }}"
 #===============================================================================
+# docker configuration
+# docker_direct_lvm_enabled: no default
+# docker_direct_lvm_block_device_path: no default
+# docker_direct_lvm_deferred_deletion_enabled: no default
+docker_device_mapper_thin_pool_autoextend_threshold: 80
+docker_device_mapper_thin_pool_autoextend_percent: 20
+#===============================================================================
 # calico
 # directories
 calico_dir: /etc/calico

--- a/ansible/roles/docker-storage/tasks/main.yaml
+++ b/ansible/roles/docker-storage/tasks/main.yaml
@@ -1,21 +1,4 @@
 ---
-  - name: Stat the block device path
-    stat:
-      path: "{{ docker_direct_lvm_block_device_path }}"
-    register: block_device_stat
-  - name: Verify that the block device exists 
-    fail:
-      msg: "Block device specified for docker storage does not exist."
-    when: block_device_stat.stat.exists == False
-  - name: Verify that the provided path is a block device
-    fail:
-      msg: "{{ docker_direct_lvm_block_device_path }} is not a block device."
-    when: block_device_stat.stat.isblk == False
-  - name: Verify that the block device is not mounted
-    fail:
-      msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
-    with_items: ansible_mounts
-    when: item.device == "{{ docker_direct_lvm_block_device_path }}"
   - name: Install lvm2 package
     package:
       name: lvm2

--- a/ansible/roles/docker-storage/tasks/main.yaml
+++ b/ansible/roles/docker-storage/tasks/main.yaml
@@ -1,0 +1,41 @@
+---
+  - name: Stat the block device path
+    stat:
+      path: "{{ docker_direct_lvm_block_device_path }}"
+    register: block_device_stat
+  - name: Verify that the block device exists 
+    fail:
+      msg: "Block device specified for docker storage does not exist."
+    when: block_device_stat.stat.exists == False
+  - name: Verify that the provided path is a block device
+    fail:
+      msg: "{{ docker_direct_lvm_block_device_path }} is not a block device."
+    when: block_device_stat.stat.isblk == False
+  - name: Verify that the block device is not mounted
+    fail:
+      msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
+    with_items: ansible_mounts
+    when: item.device == "{{ docker_direct_lvm_block_device_path }}"
+  - name: Install lvm2 package
+    package:
+      name: lvm2
+      state: present
+  # Not using lvol and lvg ansible modules here as they are in preview
+  - name: Create a physical volume on the block device
+    command: pvcreate {{ docker_direct_lvm_block_device_path }}
+  - name: Create docker volume group
+    command: vgcreate docker {{ docker_direct_lvm_block_device_path }}
+  - name: Create thinpool logical volume
+    command: lvcreate --wipesignatures y -n thinpool docker -l 95%VG
+  - name: Create thinpoolmeta logical volume
+    command: lvcreate --wipesignatures y -n thinpoolmeta docker -l 1%VG
+  - name: Convert the pool to a thin pool
+    command: lvconvert -y --zero n -c 512K --thinpool docker/thinpool --poolmetadata docker/thinpoolmeta
+  - name: Create auto extension profile
+    template:
+      src: docker-thinpool.profile
+      dest: /etc/lvm/profile/docker-thinpool.profile
+  - name: Apply lvm profile
+    command: lvchange --metadataprofile docker-thinpool docker/thinpool
+  - name: Enable monitoring to ensure autoextend executes
+    command: lvchange --metadataprofile docker-thinpool docker/thinpool

--- a/ansible/roles/docker-storage/tasks/main.yaml
+++ b/ansible/roles/docker-storage/tasks/main.yaml
@@ -1,24 +1,33 @@
 ---
-  - name: Install lvm2 package
+  - name: install lvm2 package
     package:
       name: lvm2
       state: present
+    when: "ansible_os_family == 'RedHat'"
   # Not using lvol and lvg ansible modules here as they are in preview
-  - name: Create a physical volume on the block device
+  - name: create a physical volume on the block device
     command: pvcreate {{ docker_direct_lvm_block_device_path }}
-  - name: Create docker volume group
+    when: "ansible_os_family == 'RedHat'"
+  - name: create docker volume group
     command: vgcreate docker {{ docker_direct_lvm_block_device_path }}
-  - name: Create thinpool logical volume
+    when: "ansible_os_family == 'RedHat'"
+  - name: create thinpool logical volume
     command: lvcreate --wipesignatures y -n thinpool docker -l 95%VG
-  - name: Create thinpoolmeta logical volume
+    when: "ansible_os_family == 'RedHat'"
+  - name: create thinpoolmeta logical volume
     command: lvcreate --wipesignatures y -n thinpoolmeta docker -l 1%VG
-  - name: Convert the pool to a thin pool
+    when: "ansible_os_family == 'RedHat'"
+  - name: convert the pool to a thin pool
     command: lvconvert -y --zero n -c 512K --thinpool docker/thinpool --poolmetadata docker/thinpoolmeta
-  - name: Create auto extension profile
+    when: "ansible_os_family == 'RedHat'"
+  - name: create auto extension profile
     template:
       src: docker-thinpool.profile
       dest: /etc/lvm/profile/docker-thinpool.profile
-  - name: Apply lvm profile
+    when: "ansible_os_family == 'RedHat'"
+  - name: apply lvm profile
     command: lvchange --metadataprofile docker-thinpool docker/thinpool
-  - name: Enable monitoring to ensure autoextend executes
+    when: "ansible_os_family == 'RedHat'"
+  - name: enable monitoring to ensure autoextend executes
     command: lvchange --metadataprofile docker-thinpool docker/thinpool
+    when: "ansible_os_family == 'RedHat'"

--- a/ansible/roles/docker-storage/templates/docker-thinpool.profile
+++ b/ansible/roles/docker-storage/templates/docker-thinpool.profile
@@ -1,0 +1,4 @@
+activation {
+thin_pool_autoextend_threshold={{docker_device_mapper_thin_pool_autoextend_threshold}}
+thin_pool_autoextend_percent={{docker_device_mapper_thin_pool_autoextend_percent}}
+}

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,4 +1,13 @@
 ---
+  - name: create /etc/docker directory
+    file:
+      path: /etc/docker
+      state: directory
+  - name: write docker config file
+    template:
+      src: daemon.json
+      dest: /etc/docker/daemon.json
+    when: docker_direct_lvm_enabled|bool == true
   # start and verify that Docker installed succesfully and is running
   - name: start docker service
     service:

--- a/ansible/roles/docker/templates/daemon.json
+++ b/ansible/roles/docker/templates/daemon.json
@@ -1,0 +1,8 @@
+{
+  "storage-driver": "devicemapper",
+   "storage-opts": [
+     "dm.thinpooldev=/dev/mapper/docker-thinpool",
+     "dm.use_deferred_removal=true",
+     "dm.use_deferred_deletion={{docker_direct_lvm_deferred_deletion_enabled}}"
+   ]
+}

--- a/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
+++ b/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
@@ -1,0 +1,18 @@
+---
+  - name: Stat the block device path
+    stat:
+      path: "{{ docker_direct_lvm_block_device_path }}"
+    register: block_device_stat
+  - name: Verify that the block device exists 
+    fail:
+      msg: "Block device specified for docker storage does not exist."
+    when: block_device_stat.stat.exists == False
+  - name: Verify that the provided path is a block device
+    fail:
+      msg: "{{ docker_direct_lvm_block_device_path }} is not a block device."
+    when: block_device_stat.stat.isblk == False
+  - name: Verify that the block device is not mounted
+    fail:
+      msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
+    with_items: ansible_mounts
+    when: item.device == "{{ docker_direct_lvm_block_device_path }}"

--- a/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
+++ b/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
@@ -1,17 +1,17 @@
 ---
-  - name: Stat the block device path
+  - name: stat the block device path
     stat:
       path: "{{ docker_direct_lvm_block_device_path }}"
     register: block_device_stat
-  - name: Verify that the block device exists 
+  - name: fail if the block device does not exists
     fail:
       msg: "Block device specified for docker storage does not exist."
     when: block_device_stat.stat.exists == False
-  - name: Verify that the provided path is a block device
+  - name: fail if the provided path is not a block device
     fail:
       msg: "{{ docker_direct_lvm_block_device_path }} is not a block device."
     when: block_device_stat.stat.isblk == False
-  - name: Verify that the block device is not mounted
+  - name: fail if the block device is already mounted
     fail:
       msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
     with_items: ansible_mounts

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -73,6 +73,10 @@
       loop_var: outer_item # Define this (even thought we don't use it) so that ansible doesn't complain.
     when: "'worker' in group_names"
 
+  - name: Validate devicemapper direct-lvm block device
+    include: direct_lvm_preflight.yaml
+    when: "docker_direct_lvm_enabled|bool == true and ('master' in group_names or 'worker' in group_names or 'ingress' in group_names or 'storage' in group_names)"
+
   # setup Kismatic Inspector
   - name: copy Kismatic Inspector to node
     copy:

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -75,7 +75,7 @@
 
   - name: Validate devicemapper direct-lvm block device
     include: direct_lvm_preflight.yaml
-    when: "docker_direct_lvm_enabled|bool == true and ('master' in group_names or 'worker' in group_names or 'ingress' in group_names or 'storage' in group_names)"
+    when: "ansible_os_family == 'RedHat' and docker_direct_lvm_enabled|bool == true and ('master' in group_names or 'worker' in group_names or 'ingress' in group_names or 'storage' in group_names)"
 
   # setup Kismatic Inspector
   - name: copy Kismatic Inspector to node

--- a/integration/install.go
+++ b/integration/install.go
@@ -36,6 +36,7 @@ type installOptions struct {
 	dockerRegistryPort          int
 	dockerRegistryCAPath        string
 	modifyHostsFiles            bool
+	useDirectLVM                bool
 }
 
 func installKismaticMini(node NodeDeets, sshKey string) error {
@@ -82,6 +83,7 @@ func buildPlan(nodes provisionedNodes, installOpts installOptions, sshKey string
 		DockerRegistryIP:             installOpts.dockerRegistryIP,
 		DockerRegistryPort:           installOpts.dockerRegistryPort,
 		ModifyHostsFiles:             installOpts.modifyHostsFiles,
+		UseDirectLVM:                 installOpts.useDirectLVM,
 	}
 	return plan
 }

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -119,6 +119,44 @@ var _ = Describe("kismatic", func() {
 			})
 		})
 
+		Context("when using direct-lvm docker storage", func() {
+			installOpts := installOptions{
+				allowPackageInstallation: true,
+				useDirectLVM:             true,
+			}
+			Context("when targetting CentOS", func() {
+				ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
+					WithMiniInfrastructureAndBlockDevice(CentOS7, aws, func(node NodeDeets, sshKey string) {
+						theNode := []NodeDeets{node}
+						nodes := provisionedNodes{
+							etcd:    theNode,
+							master:  theNode,
+							worker:  theNode,
+							ingress: theNode,
+						}
+						err := installKismatic(nodes, installOpts, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+
+			Context("when targetting RHEL", func() {
+				ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
+					WithMiniInfrastructureAndBlockDevice(RedHat7, aws, func(node NodeDeets, sshKey string) {
+						theNode := []NodeDeets{node}
+						nodes := provisionedNodes{
+							etcd:    theNode,
+							master:  theNode,
+							worker:  theNode,
+							ingress: theNode,
+						}
+						err := installKismatic(nodes, installOpts, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
 		// This spec will be used for testing non-destructive kismatic features on
 		// a new cluster.
 		// This spec is open to modification when new assertions have to be made

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -23,6 +23,7 @@ type PlanAWS struct {
 	DockerRegistryPort           int
 	DockerRegistryCAPath         string
 	ModifyHostsFiles             bool
+	UseDirectLVM                 bool
 }
 
 const planAWSOverlay = `cluster:
@@ -44,7 +45,13 @@ const planAWSOverlay = `cluster:
   ssh:
     user: {{.SSHUser}}
     ssh_key: {{.SSHKeyFile}}
-    ssh_port: 22
+    ssh_port: 22{{if .UseDirectLVM}}
+docker:
+  storage:
+    direct_lvm:
+      enabled: true
+      block_device: "/dev/xvdb"
+      enable_deferred_deletion: false{{end}}
 docker_registry:
   setup_internal: {{.AutoConfiguredDockerRegistry}}
   address: {{.DockerRegistryIP}}

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -63,6 +63,10 @@ type ClusterCatalog struct {
 
 	DiagnosticsDirectory string `yaml:"diagnostics_dir"`
 	DiagnosticsDateTime  string `yaml:"diagnostics_date_time"`
+
+	DockerDirectLVMEnabled                 bool   `yaml:"docker_direct_lvm_enabled"`
+	DockerDirectLVMBlockDevicePath         string `yaml:"docker_direct_lvm_block_device_path"`
+	DockerDirectLVMDeferredDeletionEnabled bool   `yaml:"docker_direct_lvm_deferred_deletion_enabled"`
 }
 
 type NFSVolume struct {

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -243,10 +243,6 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
-  when: ["master","centos"]
-  packageName: lvm2
-  anyVersion: true
-- kind: PackageDependency
   when: ["master","centos", "disconnected"]
   packageName: kismatic-offline
   packageVersion: 1.6.0_1-1
@@ -255,25 +251,13 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: lvm2
-  anyVersion: true
-- kind: PackageDependency
   when: ["ingress","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: lvm2
-  anyVersion: true
-- kind: PackageDependency
   when: ["storage","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: lvm2
-  anyVersion: true
 - kind: PackageDependency
   when: ["worker","centos"]
   packageName: kubelet
@@ -304,10 +288,6 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
-  when: ["master", "rhel"]
-  packageName: lvm2
-  anyVersion: true
-- kind: PackageDependency
   when: ["master","rhel", "disconnected"]
   packageName: kismatic-offline
   packageVersion: 1.6.0_1-1
@@ -316,25 +296,13 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
-  when: ["worker", "rhel"]
-  packageName: lvm2
-  anyVersion: true
-- kind: PackageDependency
   when: ["ingress","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
-  when: ["ingress", "rhel"]
-  packageName: lvm2
-  anyVersion: true
-- kind: PackageDependency
   when: ["storage","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
-- kind: PackageDependency
-  when: ["storage", "rhel"]
-  packageName: lvm2
-  anyVersion: true
 - kind: PackageDependency
   when: ["worker","rhel"]
   packageName: kubelet

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -243,6 +243,10 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
+  when: ["master","centos"]
+  packageName: lvm2
+  anyVersion: true
+- kind: PackageDependency
   when: ["master","centos", "disconnected"]
   packageName: kismatic-offline
   packageVersion: 1.6.0_1-1
@@ -251,13 +255,25 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
+  when: ["worker","centos"]
+  packageName: lvm2
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
+  when: ["ingress","centos"]
+  packageName: lvm2
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
+- kind: PackageDependency
+  when: ["storage","centos"]
+  packageName: lvm2
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","centos"]
   packageName: kubelet
@@ -288,6 +304,10 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
+  when: ["master", "rhel"]
+  packageName: lvm2
+  anyVersion: true
+- kind: PackageDependency
   when: ["master","rhel", "disconnected"]
   packageName: kismatic-offline
   packageVersion: 1.6.0_1-1
@@ -296,13 +316,25 @@ const defaultRuleSet = `---
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
+  when: ["worker", "rhel"]
+  packageName: lvm2
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
 - kind: PackageDependency
+  when: ["ingress", "rhel"]
+  packageName: lvm2
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","centos"]
   packageName: docker-engine
   packageVersion: 1.11.2-1.el7.centos
+- kind: PackageDependency
+  when: ["storage", "rhel"]
+  packageName: lvm2
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","rhel"]
   packageName: kubelet

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -697,6 +697,12 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		cc.DockerRegistryPort = "8443"
 	} // Else just use DockerHub
 
+	// Setup docker options
+	cc.DockerDirectLVMEnabled = p.Docker.Storage.DirectLVM.Enabled
+	if cc.DockerDirectLVMEnabled {
+		cc.DockerDirectLVMBlockDevicePath = p.Docker.Storage.DirectLVM.BlockDevice
+		cc.DockerDirectLVMDeferredDeletionEnabled = p.Docker.Storage.DirectLVM.EnableDeferredDeletion
+	}
 	if ae.options.RestartServices {
 		cc.EnableRestart()
 	}

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -218,4 +218,7 @@ var commentMap = map[string]string{
 	"nfs":                      "A set of NFS volumes for use by on-cluster persistent workloads, managed by Kismatic.",
 	"nfs_host":                 "The host name or ip address of an NFS server.",
 	"mount_path":               "The mount path of an NFS share. Must start with /",
+	"direct_lvm":               "Configure devicemapper in direct-lvm mode (RHEL/CentOS only).",
+	"block_device":             "Path to the block device that will be used for direct-lvm mode. This device will be wiped and used exclusively by docker.",
+	"enable_deferred_deletion": "Set to true if you want to enable deferred deletion when using direct-lvm mode.",
 }

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -79,9 +79,33 @@ type DockerRegistry struct {
 	CAPath        string `yaml:"CA"`
 }
 
+// Docker includes the configuration for the docker installation owned by KET.
+type Docker struct {
+	// Storage includes the storage-specific configuration for docker
+	Storage DockerStorage
+}
+
+// DockerStorage includes the storage-specific configuration for docker.
+type DockerStorage struct {
+	// DirectLVM is the configuration required for setting up device mapper in direct-lvm mode
+	DirectLVM DockerStorageDirectLVM `yaml:"direct_lvm"`
+}
+
+// DockerStorageDirectLVM includes the configuration required for setting up
+// device mapper in direct-lvm mode
+type DockerStorageDirectLVM struct {
+	// Determines whether direct-lvm mode is enabled
+	Enabled bool
+	// BlockDevice is the path to the block device that will be used. E.g. /dev/sdb
+	BlockDevice string `yaml:"block_device"`
+	// EnableDeferredDeletion determines whether deferred deletion should be enabled
+	EnableDeferredDeletion bool `yaml:"enable_deferred_deletion"`
+}
+
 // Plan is the installation plan that the user intends to execute
 type Plan struct {
 	Cluster        Cluster
+	Docker         Docker
 	DockerRegistry DockerRegistry `yaml:"docker_registry"`
 	Etcd           NodeGroup
 	Master         MasterNodeGroup

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -389,7 +389,7 @@ func (dlvm DockerStorageDirectLVM) validate() (bool, []error) {
 		if dlvm.BlockDevice == "" {
 			v.addError(errors.New("DirectLVM is enabled, but no block device was specified"))
 		}
-		if dlvm.BlockDevice != "" && dlvm.BlockDevice[0] != '/' {
+		if !filepath.IsAbs(dlvm.BlockDevice) {
 			v.addError(errors.New("Path to the block device must be absolute"))
 		}
 	}

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -127,6 +127,7 @@ func (p *Plan) validate() (bool, []error) {
 
 	v.validate(&p.Cluster)
 	v.validate(&p.DockerRegistry)
+	v.validateWithErrPrefix("Docker", p.Docker)
 	// on a disconnected_installation a registry must be provided
 	v.validate(disconnectedInstallation{cluster: p.Cluster, registryProvided: p.DockerRegistryProvided()})
 	v.validateWithErrPrefix("Etcd nodes", &p.Etcd)
@@ -366,6 +367,31 @@ func (dr *DockerRegistry) validate() (bool, []error) {
 	}
 	if _, err := os.Stat(dr.CAPath); dr.CAPath != "" && os.IsNotExist(err) {
 		v.addError(fmt.Errorf("Docker Registry CA file was not found at %q", dr.CAPath))
+	}
+	return v.valid()
+}
+
+func (d Docker) validate() (bool, []error) {
+	v := newValidator()
+	v.validateWithErrPrefix("Storage", d.Storage)
+	return v.valid()
+}
+
+func (ds DockerStorage) validate() (bool, []error) {
+	v := newValidator()
+	v.validateWithErrPrefix("Direct LVM", ds.DirectLVM)
+	return v.valid()
+}
+
+func (dlvm DockerStorageDirectLVM) validate() (bool, []error) {
+	v := newValidator()
+	if dlvm.Enabled {
+		if dlvm.BlockDevice == "" {
+			v.addError(errors.New("DirectLVM is enabled, but no block device was specified"))
+		}
+		if dlvm.BlockDevice != "" && dlvm.BlockDevice[0] != '/' {
+			v.addError(errors.New("Path to the block device must be absolute"))
+		}
 	}
 	return v.valid()
 }

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -699,3 +699,43 @@ func TestDisconnectedInstallationPrereq(t *testing.T) {
 		fmt.Println(errs)
 	}
 }
+
+func TestValidateDockerStorageDirectLVM(t *testing.T) {
+	tests := []struct {
+		config DockerStorageDirectLVM
+		valid  bool
+	}{
+		{
+			config: DockerStorageDirectLVM{
+				Enabled: false,
+			},
+			valid: true,
+		},
+		{
+			config: DockerStorageDirectLVM{
+				Enabled: true,
+			},
+			valid: false,
+		},
+		{
+			config: DockerStorageDirectLVM{
+				Enabled:     true,
+				BlockDevice: "foo",
+			},
+			valid: false,
+		},
+		{
+			config: DockerStorageDirectLVM{
+				Enabled:     true,
+				BlockDevice: "/dev/sdb",
+			},
+			valid: true,
+		},
+	}
+	for i, test := range tests {
+		ok, _ := test.config.validate()
+		if ok != test.valid {
+			t.Errorf("test %d: expect valid, but got invalid", i)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #109 

This PR introduces support for setting up devicemapper in direct-lvm mode. The user is expected to provide a block device that will be used specifically for docker's storage needs.

The plan file now has a new section for configuring this:
```
docker:
  storage:
    direct_lvm:                          # Configure devicemapper in direct-lvm mode (RHEL/CentOS only).
      enabled: true
      block_device: "/dev/xvdb"                   # Path to the block device that will be used for direct-lvm mode. This device will be wiped and used exclusively by docker.
      enable_deferred_deletion: false    # Set to true if you want to enable deferred deletion when using direct-lvm mode.
```

TODO:
- [x] Automated test
- [ ] Look into making the play idempotent
- [ ] Run package checks conditionally, or remove current pkg checks and document limitation.
- [ ] Figure out why tasks are being printer instead of skipping