### PR TITLE
Switch to using a different services CIDR from Docker’s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ HOST_GOARCH = $(shell go env GOARCH)
 # Versions of external dependencies
 GLIDE_VERSION = v0.11.1
 ANSIBLE_VERSION = 2.1.4.0
-PROVISIONER_VERSION = v1.1.1
-KUBERANG_VERSION = v1.1.2
+PROVISIONER_VERSION = v1.2.0
+KUBERANG_VERSION = v1.1.3
 GO_VERSION = 1.8.0
 
 ifeq ($(origin GLIDE_GOOS), undefined)

--- a/docs/PLAN.md
+++ b/docs/PLAN.md
@@ -204,7 +204,7 @@ Thus, your pod network must be sized so that:
 
 Our default CIDR block for a pod is **172.16.0.0/16**, which would allow for a maximum of roughly 65k pods in total or roughly 1000 nodes with 64 pods per node or fewer.
 
-Similarly, the service network needs to be large enough to handle all of the Services that might be created on the cluster. Our default is **172.17.0.0/16**, which would allow for 65k services and that ought to be enough for anybody.
+Similarly, the service network needs to be large enough to handle all of the Services that might be created on the cluster. Our default is **172.20.0.0/16**, which would allow for 65k services and that ought to be enough for anybody.
 
 Care should be taken that the IP addresses under management by Kubernetes do not collide with IP addresses on the local network, including omitting these ranges from control of  DHCP.
 

--- a/integration/disconnected_install_test.go
+++ b/integration/disconnected_install_test.go
@@ -66,8 +66,8 @@ func disableInternetAccess(nodes []NodeDeets, sshKey string) error {
 		fmt.Sprintf("sudo iptables -A OUTPUT -p tcp --match multiport --dports %s -j ACCEPT", allowDestPorts),   // allow internal traffic for: inspector, etcd, docker registry
 		"sudo iptables -A OUTPUT -s 172.16.0.0/16 -j ACCEPT",
 		"sudo iptables -A OUTPUT -d 172.16.0.0/16 -j ACCEPT", // Allow pod network
-		"sudo iptables -A OUTPUT -s 172.17.0.0/16 -j ACCEPT",
-		"sudo iptables -A OUTPUT -d 172.17.0.0/16 -j ACCEPT", // Allow pod service network
+		"sudo iptables -A OUTPUT -s 172.20.0.0/16 -j ACCEPT",
+		"sudo iptables -A OUTPUT -d 172.20.0.0/16 -j ACCEPT", // Allow pod service network
 		"sudo iptables -P OUTPUT DROP",                       // drop everything else
 	}
 	return runViaSSH(cmd, nodes, sshKey, 1*time.Minute)

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -34,7 +34,7 @@ const planAWSOverlay = `cluster:
   networking:
     type: overlay
     pod_cidr_block: 172.16.0.0/16
-    service_cidr_block: 172.17.0.0/16
+    service_cidr_block: 172.20.0.0/16
     policy_enabled: false
     update_hosts_files: {{.ModifyHostsFiles}}
   certificates:

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -107,7 +107,7 @@ func WritePlanTemplate(p *Plan, w PlanReadWriter) error {
 	// Set Networking defaults
 	p.Cluster.Networking.Type = "overlay"
 	p.Cluster.Networking.PodCIDRBlock = "172.16.0.0/16"
-	p.Cluster.Networking.ServiceCIDRBlock = "172.17.0.0/16"
+	p.Cluster.Networking.ServiceCIDRBlock = "172.20.0.0/16"
 	p.Cluster.Networking.UpdateHostsFiles = false
 	p.Cluster.Networking.PolicyEnabled = false
 

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -12,7 +12,7 @@ var validPlan = Plan{
 		Networking: NetworkConfig{
 			Type:             "overlay",
 			PodCIDRBlock:     "172.16.0.0/16",
-			ServiceCIDRBlock: "172.17.0.0/16",
+			ServiceCIDRBlock: "172.20.0.0/16",
 		},
 		Certificates: CertsConfig{
 			Expiry: "17250h",


### PR DESCRIPTION
Fixes #492, #487 

Switch to using `172.20.0.0/16` services CIDR