### PR TITLE
Fix v1.3.x integration tests with a bad CIDR

### DIFF
--- a/integration/install.go
+++ b/integration/install.go
@@ -37,6 +37,7 @@ type installOptions struct {
 	dockerRegistryCAPath        string
 	modifyHostsFiles            bool
 	useDirectLVM                bool
+	serviceCIDR                 string
 }
 
 func installKismaticMini(node NodeDeets, sshKey string) error {
@@ -84,6 +85,7 @@ func buildPlan(nodes provisionedNodes, installOpts installOptions, sshKey string
 		DockerRegistryPort:           installOpts.dockerRegistryPort,
 		ModifyHostsFiles:             installOpts.modifyHostsFiles,
 		UseDirectLVM:                 installOpts.useDirectLVM,
+		ServiceCIDR:                  installOpts.serviceCIDR,
 	}
 	return plan
 }

--- a/integration/install_released_test.go
+++ b/integration/install_released_test.go
@@ -19,6 +19,7 @@ var _ = Describe("Installing with previous version of Kismatic", func() {
 
 	installOpts := installOptions{
 		allowPackageInstallation: true,
+		serviceCIDR:              "172.16.0.0/16",
 	}
 
 	Context("using Ubuntu 16.04 LTS", func() {

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -24,6 +24,7 @@ type PlanAWS struct {
 	DockerRegistryCAPath         string
 	ModifyHostsFiles             bool
 	UseDirectLVM                 bool
+	ServiceCIDR                  string
 }
 
 const planAWSOverlay = `cluster:
@@ -34,7 +35,7 @@ const planAWSOverlay = `cluster:
   networking:
     type: overlay
     pod_cidr_block: 172.16.0.0/16
-    service_cidr_block: 172.20.0.0/16
+    service_cidr_block: {{if .ServiceCIDR}}{{.ServiceCIDR}}{{else}}172.20.0.0/16{{end}}
     policy_enabled: false
     update_hosts_files: {{.ModifyHostsFiles}}
   certificates:

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -25,20 +25,6 @@ var _ = Describe("Upgrade", func() {
 			})
 		})
 
-		Describe("From KET version v1.3.0-beta.0", func() {
-			BeforeEach(func() {
-				dir := setupTestWorkingDirWithVersion("v1.3.0-beta.0")
-				os.Chdir(dir)
-			})
-			Context("Using a larger cluster layout with Ubuntu 16.04", func() {
-				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
-					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 2, Ingress: 0, Storage: 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
-						installAndUpgrade(nodes, sshKey)
-					})
-				})
-			})
-		})
-
 		Describe("From KET version v1.2.2", func() {
 			BeforeEach(func() {
 				dir := setupTestWorkingDirWithVersion("v1.2.2")
@@ -195,12 +181,12 @@ var _ = Describe("Upgrade", func() {
 						})
 					})
 				})
-			})
 
-			Context("Using a larger cluster layout with Ubuntu 16.04", func() {
-				ItOnAWS("should result in an upgraded cluster [slow] [upgrade]", func(aws infrastructureProvisioner) {
-					WithInfrastructureAndDNS(NodeCount{Etcd: 3, Master: 2, Worker: 3, Ingress: 0, Storage: 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
-						installAndUpgrade(nodes, sshKey)
+				Context("Using Ubuntu 16.04", func() {
+					ItOnAWS("should be upgraded [slow] [upgrade]", func(aws infrastructureProvisioner) {
+						WithMiniInfrastructure(Ubuntu1604LTS, aws, func(node NodeDeets, sshKey string) {
+							installAndUpgradeMinikube(node, sshKey)
+						})
 					})
 				})
 			})
@@ -218,7 +204,9 @@ func installAndUpgradeMinikube(node NodeDeets, sshKey string) {
 
 func installAndUpgrade(nodes provisionedNodes, sshKey string) {
 	// Standup cluster with previous version
-	opts := installOptions{allowPackageInstallation: true}
+	// Using CIDR to pass tests on KET v1.3.x
+	// These versions used a version of kuberang with a bad test
+	opts := installOptions{allowPackageInstallation: true, serviceCIDR: "172.16.0.0/16"}
 	err := installKismatic(nodes, opts, sshKey)
 	FailIfError(err)
 


### PR DESCRIPTION
A few tests were failing when using KET v1.3.x, need to use the old `172.16.0.0/16` CIDR for these tests.