### PR TITLE
Don't include node's internal IP in the cert if it's unset

### DIFF
--- a/pkg/install/pki.go
+++ b/pkg/install/pki.go
@@ -202,7 +202,10 @@ func (lp *LocalPKI) GenerateNodeCertificate(plan *Plan, node Node, ca *tls.CA) e
 	if err != nil {
 		return err
 	}
-	nodeSANs := append(clusterSANs, node.Host, node.IP, node.InternalIP)
+	nodeSANs := append(clusterSANs, node.Host, node.IP)
+	if node.InternalIP != "" {
+		nodeSANs = append(nodeSANs, node.InternalIP)
+	}
 	if isMasterNode(*plan, node) {
 		if plan.Master.LoadBalancedFQDN != "" {
 			nodeSANs = append(nodeSANs, plan.Master.LoadBalancedFQDN)
@@ -247,7 +250,10 @@ func (lp *LocalPKI) validateNodeCertificate(p *Plan, node Node) (valid bool, war
 	if err != nil {
 		return false, nil, err
 	}
-	nodeSANs := append(clusterSANs, node.Host, node.IP, node.InternalIP)
+	nodeSANs := append(clusterSANs, node.Host, node.IP)
+	if node.InternalIP != "" {
+		nodeSANs = append(nodeSANs, node.InternalIP)
+	}
 	if isMasterNode(*p, node) {
 		if p.Master.LoadBalancedFQDN != "" {
 			nodeSANs = append(nodeSANs, p.Master.LoadBalancedFQDN)


### PR DESCRIPTION
The problem was that the internal IP was always being included in the node's certificates. In the case where the internal IP was not provided, we would add the empty string as a SAN in the cert.

Fixes #498 