### PR TITLE
Enclose path to inspector in quotes

### DIFF
--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -101,7 +101,7 @@
   # Run the pre-flights checks, and always stop the checker regardless of result
   - block:
       - name: run pre-flight checks using Kismatic Inspector
-        local_action: command {{ kismatic_preflight_checker_local | default(kismatic_preflight_checker) }} client {{ ansible_host }}:8888 -o json --node-roles {{ ",".join(group_names) }}
+        local_action: command '{{ kismatic_preflight_checker_local | default(kismatic_preflight_checker) }}' client {{ ansible_host }}:8888 -o json --node-roles {{ ",".join(group_names) }}
         register: out
         become: no
     rescue: # Need to repeat because of Ansible bug https://github.com/ansible/ansible/issues/18602


### PR DESCRIPTION
Fixes #185 

Tested manually by running `./kismatic install validate` in a directory called `foo bar baz`