### PR TITLE
Fix certificate generation, and stop adding "Apprenda" subject

### DIFF
--- a/pkg/install/pki.go
+++ b/pkg/install/pki.go
@@ -11,11 +11,6 @@ import (
 )
 
 const (
-	certOrganization             = "Apprenda"
-	certOrgUnit                  = "Kismatic"
-	certCountry                  = "US"
-	certState                    = "NY"
-	certLocality                 = "Troy"
 	adminUser                    = "admin"
 	adminGroup                   = "system:masters"
 	dockerRegistryCertFilename   = "docker"
@@ -81,16 +76,9 @@ func (lp *LocalPKI) GenerateClusterCA(p *Plan) (*tls.CA, error) {
 		return lp.GetClusterCA()
 	}
 
+	// CA keypair doesn't exist, generate one
 	util.PrettyPrintOk(lp.Log, "Generating cluster Certificate Authority")
-	// It doesn't exist, generate one
-	caSubject := tls.Subject{
-		Organization:       certOrganization,
-		OrganizationalUnit: certOrgUnit,
-		Country:            certCountry,
-		State:              certState,
-		Locality:           certLocality,
-	}
-	key, cert, err := tls.NewCACert(lp.CACsr, p.Cluster.Name, caSubject)
+	key, cert, err := tls.NewCACert(lp.CACsr, p.Cluster.Name)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CA Cert: %v", err)
 	}
@@ -102,22 +90,13 @@ func (lp *LocalPKI) GenerateClusterCA(p *Plan) (*tls.CA, error) {
 	return ca, nil
 }
 
-// GenerateClusterCertificates creates a Certificates for all nodes on the cluster
+// GenerateClusterCertificates creates all certificates required for the cluster
+// described in the plan file.
 func (lp *LocalPKI) GenerateClusterCertificates(p *Plan, ca *tls.CA) error {
 	if lp.Log == nil {
 		lp.Log = ioutil.Discard
 	}
-	nodes := []Node{}
-	nodes = append(nodes, p.Etcd.Nodes...)
-	nodes = append(nodes, p.Master.Nodes...)
-	nodes = append(nodes, p.Worker.Nodes...)
-	if p.Ingress.Nodes != nil {
-		nodes = append(nodes, p.Ingress.Nodes...)
-	}
-	if p.Storage.Nodes != nil {
-		nodes = append(nodes, p.Storage.Nodes...)
-	}
-
+	nodes := p.getAllNodes()
 	seenNodes := map[string]bool{}
 	for _, n := range nodes {
 		// Only generate certs once for each node, nodes can be in more than one group
@@ -151,14 +130,8 @@ func (lp *LocalPKI) ValidateClusterCertificates(p *Plan) (warn []error, err []er
 	if lp.Log == nil {
 		lp.Log = ioutil.Discard
 	}
-	nodes := []Node{}
-	nodes = append(nodes, p.Etcd.Nodes...)
-	nodes = append(nodes, p.Master.Nodes...)
-	nodes = append(nodes, p.Worker.Nodes...)
-	if p.Ingress.Nodes != nil {
-		nodes = append(nodes, p.Ingress.Nodes...)
-	}
-
+	// Validate node certificates
+	nodes := p.getAllNodes()
 	seenNodes := map[string]bool{}
 	for _, n := range nodes {
 		// Only generate certs once for each node, nodes can be in more than one group
@@ -172,7 +145,7 @@ func (lp *LocalPKI) ValidateClusterCertificates(p *Plan) (warn []error, err []er
 			err = append(err, nodeErr)
 		}
 	}
-	// Create certs for docker registry if it's missing
+	// Validate docker registry cert
 	if p.DockerRegistry.SetupInternal {
 		_, dockerWarn, dockerErr := lp.validateDockerRegistryCert(p)
 		warn = append(warn, dockerWarn...)
@@ -180,7 +153,7 @@ func (lp *LocalPKI) ValidateClusterCertificates(p *Plan) (warn []error, err []er
 			err = append(err, dockerErr)
 		}
 	}
-	// Create key for service account signing
+	// Validate service account certificate
 	_, saWarn, saErr := lp.validateServiceAccountCert()
 	warn = append(warn, saWarn...)
 	if err != nil {
@@ -386,16 +359,10 @@ func generateCert(ca *tls.CA, commonName string, hostList []string, organization
 			A: "rsa",
 			S: 2048,
 		},
-		Hosts: hostList,
-		Names: []csr.Name{
-			{
-				O:  certOrganization,
-				OU: certOrgUnit,
-				C:  certCountry,
-				ST: certState,
-				L:  certLocality,
-			},
-		},
+	}
+
+	if len(hostList) > 0 {
+		req.Hosts = hostList
 	}
 
 	for _, org := range organizations {

--- a/pkg/install/pki.go
+++ b/pkg/install/pki.go
@@ -397,6 +397,12 @@ func generateCert(ca *tls.CA, commonName string, hostList []string, organization
 			},
 		},
 	}
+
+	for _, org := range organizations {
+		name := csr.Name{O: org}
+		req.Names = append(req.Names, name)
+	}
+
 	key, cert, err = tls.NewCert(ca, req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating certs for %q: %v", commonName, err)

--- a/pkg/install/pki_test.go
+++ b/pkg/install/pki_test.go
@@ -2,7 +2,6 @@ package install
 
 import (
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -87,29 +86,28 @@ func getPlan() *Plan {
 				},
 			},
 		},
+		Ingress: OptionalNodeGroup{
+			Nodes: []Node{
+				Node{
+					Host:       "ingress",
+					IP:         "99.99.99.99",
+					InternalIP: "88.88.88.88",
+				},
+			},
+		},
+		Storage: OptionalNodeGroup{
+			Nodes: []Node{
+				Node{
+					Host:       "storage",
+					IP:         "99.99.99.99",
+					InternalIP: "88.88.88.88",
+				},
+			},
+		},
 	}
 }
 
-// Validate the certificate subject information
-func validateCertSubject(t *testing.T, cert *x509.Certificate, p *Plan) {
-	if cert.Subject.Country[0] != certCountry {
-		t.Errorf("country mismatch: expected %q, but got %q", certCountry, cert.Subject.Country[0])
-	}
-	if cert.Subject.Locality[0] != certLocality {
-		t.Errorf("locality mismatch: expected %q, but got %q", certLocality, cert.Subject.Locality[0])
-	}
-	if cert.Subject.Province[0] != certState {
-		t.Errorf("province mismatch: expected %q, but got %q", certState, cert.Subject.Province[0])
-	}
-	if cert.Subject.Organization[0] != certOrganization {
-		t.Errorf("invalid organization in generated cert. Expected %q but got %q", certOrganization, cert.Subject.Organization[0])
-	}
-	if cert.Subject.OrganizationalUnit[0] != certOrgUnit {
-		t.Errorf("invalid organizational unit in generated cert. Expected %q but got %q", certOrgUnit, cert.Subject.OrganizationalUnit[0])
-	}
-}
-
-func TestGeneratedClusterCASubject(t *testing.T) {
+func TestGeneratedClusterCACommonNameMatchesClusterName(t *testing.T) {
 	pki := getPKI(t)
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
@@ -125,7 +123,6 @@ func TestGeneratedClusterCASubject(t *testing.T) {
 	if !caCert.IsCA {
 		t.Errorf("generated cert is not CA")
 	}
-	validateCertSubject(t, caCert, p)
 
 	if caCert.Subject.CommonName != p.Cluster.Name {
 		t.Errorf("common name mismatch: expected %q, got %q", p.Cluster.Name, caCert.Subject.CommonName)
@@ -199,7 +196,7 @@ func TestClusterCAExistsGenerationSkipped(t *testing.T) {
 	}
 }
 
-func TestGenerateClusterCertificatesNodeCert(t *testing.T) {
+func TestGenerateClusterCertificatesNodeCertIsValid(t *testing.T) {
 	pki := getPKI(t)
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
@@ -220,7 +217,6 @@ func TestGenerateClusterCertificatesNodeCert(t *testing.T) {
 		t.Errorf("common name mismatch: got %q, expected %q", cert.Subject.CommonName, node.Host)
 	}
 
-	validateCertSubject(t, cert, p)
 	// Validate DNS names
 	nameFound := false
 	for _, name := range cert.DNSNames {
@@ -263,6 +259,8 @@ func TestNodeCertExistsSkipGeneration(t *testing.T) {
 	node := p.Worker.Nodes[0]
 	p.Master = MasterNodeGroup{}
 	p.Etcd = NodeGroup{}
+	p.Ingress = OptionalNodeGroup{}
+	p.Storage = OptionalNodeGroup{}
 
 	// Create the node cert and key file
 	certFile := filepath.Join(pki.GeneratedCertsDirectory, node.Host+".pem")
@@ -299,7 +297,12 @@ func TestNodeCertExistsSkipGeneration(t *testing.T) {
 	}
 
 	// Assert no other files were created
-	expectedFiles := []string{"ca.pem", "ca-key.pem", node.Host + ".pem", node.Host + "-key.pem", "admin.pem", "admin-key.pem", "service-account.pem", "service-account-key.pem"}
+	expectedFiles := []string{
+		"ca.pem", "ca-key.pem",
+		node.Host + ".pem", node.Host + "-key.pem",
+		"admin.pem", "admin-key.pem",
+		"service-account.pem", "service-account-key.pem",
+	}
 	files, err := ioutil.ReadDir(pki.GeneratedCertsDirectory)
 	if err != nil {
 		t.Fatalf("error getting generated dir contents: %v", err)
@@ -342,6 +345,8 @@ func TestGenerateClusterCertificatesMultipleNodes(t *testing.T) {
 		"master.pem", "master-key.pem",
 		"etcd.pem", "etcd-key.pem",
 		"worker.pem", "worker-key.pem",
+		"ingress.pem", "ingress-key.pem",
+		"storage.pem", "storage-key.pem",
 		"admin.pem", "admin-key.pem",
 		"service-account.pem", "service-account-key.pem",
 	}
@@ -365,7 +370,7 @@ func TestGenerateClusterCertificatesMultipleNodes(t *testing.T) {
 	}
 }
 
-func TestLoadBalancedNamesInMasterCert(t *testing.T) {
+func TestGeneratedMasterCertContainsLoadBalancedNames(t *testing.T) {
 	pki := getPKI(t)
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
@@ -498,37 +503,37 @@ func TestLoadBalancedNamesNotInEtcdCert(t *testing.T) {
 	}
 }
 
-func TestGenerateClusterCertificatesUserSubject(t *testing.T) {
+func TestGenerateClusterCertificatesValidateAdminCertificate(t *testing.T) {
 	pki := getPKI(t)
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
 	p := getPlan()
-	p.Worker = NodeGroup{}
 
 	ca, err := pki.GenerateClusterCA(p)
 	if err != nil {
 		t.Fatalf("error generating CA for test: %v", err)
 	}
-	users := []string{"admin"}
 	if err = pki.GenerateClusterCertificates(p, ca); err != nil {
 		t.Fatalf("failed to generate certs: %v", err)
 	}
 	certFile := filepath.Join(pki.GeneratedCertsDirectory, "admin.pem")
 	userCert := mustReadCertFile(certFile, t)
 
-	if userCert.Subject.CommonName != users[0] {
-		t.Errorf("common name mismatch: got %q, expected %q", userCert.Subject.CommonName, users[0])
+	// Validate CommonName
+	if userCert.Subject.CommonName != "admin" {
+		t.Errorf("common name mismatch: got %q, expected %q", userCert.Subject.CommonName, "admin")
 	}
 
-	adminGroupMissing := true
+	// Validate organizations
+	AdminOrgMissing := true
 	for _, org := range userCert.Subject.Organization {
 		if org == adminGroup {
-			adminGroupMissing = false
+			AdminOrgMissing = false
 		}
 	}
 
-	if adminGroupMissing {
-		t.Errorf("the system:masters group is not part of the admin's certificate")
+	if AdminOrgMissing {
+		t.Errorf("the system:masters organization is not part of the admin's certificate")
 	}
 }
 
@@ -551,9 +556,8 @@ func TestGenerateClusterCertificatesDockerCert(t *testing.T) {
 	mustReadCertFile(certFile, t)
 }
 
-func TestBadNodeCertificate(t *testing.T) {
+func TestInvalidNodeCertificateShouldFailValidation(t *testing.T) {
 	pki := getPKI(t)
-	pki.Log = os.Stdout
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
 	p := getPlan()
@@ -572,7 +576,6 @@ func TestBadNodeCertificate(t *testing.T) {
 		InternalIP: "22.33.44.55",
 	}
 
-	fmt.Println("Regenerating Certs")
 	err = pki.GenerateClusterCertificates(p, ca)
 	if err == nil {
 		t.Fatalf("expected an error, got nil")
@@ -581,7 +584,6 @@ func TestBadNodeCertificate(t *testing.T) {
 
 func TestInvalidUserCertificateShouldError(t *testing.T) {
 	pki := getPKI(t)
-	pki.Log = os.Stdout
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
 	p := getPlan()
@@ -608,7 +610,6 @@ func TestInvalidUserCertificateShouldError(t *testing.T) {
 		t.Fatalf("error renaming test certificate")
 	}
 
-	fmt.Println("Regenerating Certs")
 	err = pki.GenerateClusterCertificates(p, ca)
 	if err == nil {
 		t.Fatalf("expected an error, got nil")
@@ -617,7 +618,6 @@ func TestInvalidUserCertificateShouldError(t *testing.T) {
 
 func TestBadServiceAccountCertificate(t *testing.T) {
 	pki := getPKI(t)
-	pki.Log = os.Stdout
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
 	p := getPlan()
@@ -633,7 +633,6 @@ func TestBadServiceAccountCertificate(t *testing.T) {
 	os.Remove(file)
 	os.Create(file)
 
-	fmt.Println("Regenerating Certs")
 	err = pki.GenerateClusterCertificates(p, ca)
 	if err == nil {
 		t.Fatalf("expected an error, got nil")
@@ -642,7 +641,6 @@ func TestBadServiceAccountCertificate(t *testing.T) {
 
 func TestBadDockerCertificate(t *testing.T) {
 	pki := getPKI(t)
-	pki.Log = os.Stdout
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
 	p := getPlan()
@@ -669,7 +667,6 @@ func TestBadDockerCertificate(t *testing.T) {
 
 func TestGenerateNodeCertNoEmptyDNSNames(t *testing.T) {
 	pki := getPKI(t)
-	pki.Log = os.Stdout
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
 	p := getPlan()
@@ -695,9 +692,8 @@ func TestGenerateNodeCertNoEmptyDNSNames(t *testing.T) {
 	}
 }
 
-func TestGenerateNodeCertWithInternalIP(t *testing.T) {
+func TestGeneratedNodeCertContainsInternalIP(t *testing.T) {
 	pki := getPKI(t)
-	pki.Log = os.Stdout
 	defer cleanup(pki.GeneratedCertsDirectory, t)
 
 	p := getPlan()

--- a/pkg/install/pki_test.go
+++ b/pkg/install/pki_test.go
@@ -519,6 +519,17 @@ func TestGenerateClusterCertificatesUserSubject(t *testing.T) {
 	if userCert.Subject.CommonName != users[0] {
 		t.Errorf("common name mismatch: got %q, expected %q", userCert.Subject.CommonName, users[0])
 	}
+
+	adminGroupMissing := true
+	for _, org := range userCert.Subject.Organization {
+		if org == adminGroup {
+			adminGroupMissing = false
+		}
+	}
+
+	if adminGroupMissing {
+		t.Errorf("the system:masters group is not part of the admin's certificate")
+	}
 }
 
 func TestGenerateClusterCertificatesDockerCert(t *testing.T) {

--- a/pkg/tls/ca.go
+++ b/pkg/tls/ca.go
@@ -26,7 +26,7 @@ type Subject struct {
 }
 
 // NewCACert creates a new Certificate Authority and returns it's private key and public certificate.
-func NewCACert(csrFile string, commonName string, subject Subject) (key, cert []byte, err error) {
+func NewCACert(csrFile string, commonName string) (key, cert []byte, err error) {
 	// Open CSR file
 	f, err := os.Open(csrFile)
 	if os.IsNotExist(err) {
@@ -43,15 +43,6 @@ func NewCACert(csrFile string, commonName string, subject Subject) (key, cert []
 	if err != nil {
 		return nil, nil, fmt.Errorf("error decoding CSR: %v", err)
 	}
-	// Set the subject information
-	name := csr.Name{
-		C:  subject.Country,
-		ST: subject.State,
-		L:  subject.Locality,
-		O:  subject.Organization,
-		OU: subject.OrganizationalUnit,
-	}
-	caCSR.Names = []csr.Name{name}
 	caCSR.CN = commonName
 	// Generate CA Cert according to CSR
 	cert, _, key, err = initca.New(caCSR)

--- a/pkg/tls/ca_test.go
+++ b/pkg/tls/ca_test.go
@@ -9,11 +9,7 @@ import (
 )
 
 func TestNewCACert(t *testing.T) {
-	subject := Subject{
-		Organization:       "someOrg",
-		OrganizationalUnit: "someOrgUnit",
-	}
-	_, cert, err := NewCACert("test/ca-csr.json", "someCommonName", subject)
+	_, cert, err := NewCACert("test/ca-csr.json", "someCommonName")
 	if err != nil {
 		t.Fatalf("error creating CA cert: %v", err)
 	}
@@ -30,14 +26,6 @@ func TestNewCACert(t *testing.T) {
 	expectedCN := "someCommonName"
 	if parsedCert.Subject.CommonName != expectedCN {
 		t.Errorf("CN mismatch: expected %q, found %q", expectedCN, parsedCert.Subject.CommonName)
-	}
-
-	if parsedCert.Subject.Organization[0] != subject.Organization {
-		t.Errorf("Organization mismatch: expected %q, found %q", subject.Organization, parsedCert.Subject.Organization[0])
-	}
-
-	if parsedCert.Subject.OrganizationalUnit[0] != subject.OrganizationalUnit {
-		t.Errorf("OrganizationalUnit mismatch: expected %q, found %q", subject.OrganizationalUnit, parsedCert.Subject.OrganizationalUnit[0])
 	}
 
 	if !reflect.DeepEqual(parsedCert.Issuer, parsedCert.Subject) {

--- a/pkg/tls/cert_test.go
+++ b/pkg/tls/cert_test.go
@@ -16,15 +16,7 @@ import (
 )
 
 func TestGenerateNewCertificate(t *testing.T) {
-	// Create CA Cert
-	subject := Subject{
-		Country:            "someCountry",
-		State:              "someState",
-		Locality:           "someLocality",
-		Organization:       "someOrganization",
-		OrganizationalUnit: "someOrgUnit",
-	}
-	key, caCert, err := NewCACert("test/ca-csr.json", "someCN", subject)
+	key, caCert, err := NewCACert("test/ca-csr.json", "someCN")
 	if err != nil {
 		t.Fatalf("error creating CA: %v", err)
 	}
@@ -274,15 +266,7 @@ func TestCertValid(t *testing.T) {
 	}
 	defer cleanup(tempDir, t)
 
-	// Create CA Cert
-	subject := Subject{
-		Country:            "someCountry",
-		State:              "someState",
-		Locality:           "someLocality",
-		Organization:       "someOrganization",
-		OrganizationalUnit: "someOrgUnit",
-	}
-	key, caCert, err := NewCACert("test/ca-csr.json", "someCN", subject)
+	key, caCert, err := NewCACert("test/ca-csr.json", "someCN")
 	if err != nil {
 		t.Fatalf("error creating CA: %v", err)
 	}


### PR DESCRIPTION
Fixes #530 

With this change, we stop adding the unnecessary subject fields on the generated certificates. This also fixes a bug where the organizations passed to the `generateCert` method were not being added to the certificate.