### PR TITLE
Remove unused helm variables from the plan

### DIFF
--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -61,7 +61,6 @@ docker_registry:
 features:
   package_manager:
     enabled: {{.EnableHelm}}
-    provider: helm
 etcd:
   expected_count: {{len .Etcd}}
   nodes:{{range .Etcd}}

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -115,7 +115,6 @@ func WritePlanTemplate(p *Plan, w PlanReadWriter) error {
 
 	// Features
 	p.Features.PackageManager.Enabled = true
-	p.Features.PackageManager.Provider = "helm"
 
 	// Set DockerRegistry defaults
 	p.DockerRegistry.Port = 8443

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -143,13 +143,8 @@ type Features struct {
 	PackageManager PackageManager `yaml:"package_manager"`
 }
 
-type BaseFeature struct {
-	Enabled  bool
-	Provider string
-}
-
 type PackageManager struct {
-	BaseFeature `yaml:",inline"`
+	Enabled bool
 }
 
 // GetUniqueNodes returns a list of the unique nodes that are listed in the plan file.

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -219,15 +219,6 @@ func (s *SSHConfig) validate() (bool, []error) {
 
 func (f *Features) validate() (bool, []error) {
 	v := newValidator()
-	v.validate(&f.PackageManager)
-	return v.valid()
-}
-
-func (p *PackageManager) validate() (bool, []error) {
-	v := newValidator()
-	if p.Enabled && p.Provider != "helm" {
-		v.addError(fmt.Errorf("Package Manager valid options are: 'helm'"))
-	}
 	return v.valid()
 }
 

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -794,35 +794,3 @@ func TestRepository(t *testing.T) {
 		}
 	}
 }
-
-func TestPackageManager(t *testing.T) {
-	tests := []struct {
-		pm    PackageManager
-		valid bool
-	}{
-		{
-			pm: PackageManager{
-				BaseFeature{
-					Enabled:  true,
-					Provider: "helm",
-				},
-			},
-			valid: true,
-		},
-		{
-			pm: PackageManager{
-				BaseFeature{
-					Enabled:  true,
-					Provider: "foo",
-				},
-			},
-			valid: false,
-		},
-	}
-	for i, test := range tests {
-		ok, _ := test.pm.validate()
-		if ok != test.valid {
-			t.Errorf("test %d: expect %t, but got %t", i, test.valid, ok)
-		}
-	}
-}


### PR DESCRIPTION
Currently we have a `provider` field for `Features.PackageManager`, there is only one provider, lets not pollute the plan file now and add it later when we actually need it.