### PR TITLE
Move package_manager to add_ons and helm installation ansible

### DIFF
--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -18,6 +18,10 @@
         command: "kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller"
         register: out
         failed_when: 'out.rc != 0 and out.stderr is defined and "Error from server (AlreadyExists)" not in out.stderr'
+      - name: "add kismatic helm repo"
+        local_action: command ../../helm repo add kismatic https://apprenda.github.io/kismatic-charts/
+        become: no
+        when: disconnected_installation|bool != true
       - name: "run helm init"
         local_action: command ../../helm init --service-account=tiller -i="{{ helm_img }}"
         become: no

--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -1,7 +1,7 @@
 ---
   - hosts: master[0]
     any_errors_fatal: true
-    name: "{{ play_name | default('Create Required RBAC Role for Helm') }}"
+    name: "{{ play_name | default('Initialize Helm and Start Tiller') }}"
     remote_user: root
     become_method: sudo
     run_once: true

--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -29,9 +29,11 @@
   - include: _calico-validate.yaml
   - include: _calico-network-policy.yaml
   - include: _kube-dns.yaml
+  - include: _kube-dashboard.yaml
+  - include: _helm.yaml
+    when: enable_helm|bool == true
   - include: _kube-ingress.yaml
     when: configure_ingress|bool == true
-  - include: _kube-dashboard.yaml
   - include: _storage.yaml
     when: configure_storage|bool == true
   - include: _nfs-volumes.yaml

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -58,9 +58,10 @@ docker_registry:
   address: {{.DockerRegistryIP}}
   port: {{.DockerRegistryPort}}
   CA: {{.DockerRegistryCAPath}}
-features:
+add_ons:
   package_manager:
     enabled: {{.EnableHelm}}
+    provider: helm
 etcd:
   expected_count: {{len .Etcd}}
   nodes:{{range .Etcd}}

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -69,6 +69,8 @@ type ClusterCatalog struct {
 	DockerDirectLVMDeferredDeletionEnabled bool   `yaml:"docker_direct_lvm_deferred_deletion_enabled"`
 
 	LocalKubeconfigDirectory string `yaml:"local_kubeconfig_directory"`
+
+	EnableHelm bool `yaml:"enable_helm"`
 }
 
 type NFSVolume struct {

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
-	"time"
 
 	"github.com/apprenda/kismatic/pkg/install"
 	"github.com/apprenda/kismatic/pkg/util"
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 )
 
@@ -113,27 +110,6 @@ func (c *applyCmd) run() error {
 	// Perform the installation
 	if err := c.executor.Install(plan); err != nil {
 		return fmt.Errorf("error installing: %v", err)
-	}
-
-	// Install Helm
-	if plan.Features.PackageManager.Enabled {
-		util.PrintHeader(c.out, "Installing Helm on the Cluster", '=')
-		home, err := homedir.Dir()
-		if err != nil {
-			return fmt.Errorf("Could not determine helm directory: %v", err)
-		}
-		helmDir := path.Join(home, ".helm")
-		backupDir := fmt.Sprintf("%s.backup-%s", helmDir, time.Now().Format("2006-01-02-15-04-05"))
-		// Backup helm directory if exists
-		if backedup, err := util.BackupDirectory(helmDir, backupDir); err != nil {
-			return fmt.Errorf("error preparing Helm client: %v", err)
-		} else if backedup {
-			util.PrettyPrintOk(c.out, "Backed up %q directory", helmDir)
-		}
-		// Create a new serviceaccount and run helm init
-		if err := c.executor.RunPlay("_helm.yaml", plan); err != nil {
-			return fmt.Errorf("error configuring Helm RBAC: %v", err)
-		}
 	}
 
 	// Run smoketest

--- a/pkg/cli/plan.go
+++ b/pkg/cli/plan.go
@@ -78,8 +78,8 @@ func doPlan(in io.Reader, out io.Writer, planner install.Planner, planFile strin
 		return fmt.Errorf("The number of nfs volumes must be greater than or equal to zero")
 	}
 
-	fmt.Fprintln(out, "Cluster Add-Ons:")
-	packageManagerChoice, err := util.PromptForString(in, out, "Enable package manager (set to 'none' if not required)", install.DefaultPackageManagerProvider(), append(install.PackageManagerProviders(), "none"))
+	fmt.Fprintln(out, "\nSelect Add-Ons:")
+	packageManagerChoice, err := util.PromptForString(in, out, "Enable package manager", install.DefaultPackageManagerProvider, append(install.PackageManagerProviders(), "none"))
 	if err != nil {
 		return fmt.Errorf("Error reading cluster package manager choice: %v", err)
 	}
@@ -96,7 +96,7 @@ func doPlan(in io.Reader, out io.Writer, planner install.Planner, planFile strin
 	if strings.ToLower(packageManagerChoice) == "none" {
 		packageManagerEnabled = "disabled"
 	}
-	fmt.Fprintf(out, "- %s cluster package manager: %s\n", packageManagerEnabled, packageManagerChoice)
+	fmt.Fprintf(out, "- %s cluster package manager with %q\n", packageManagerEnabled, packageManagerChoice)
 	fmt.Fprintln(out)
 
 	template := planTemplate{

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -757,6 +757,13 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		})
 	}
 	cc.EnableGluster = p.Storage.Nodes != nil && len(p.Storage.Nodes) > 0
+	// add_ons.package_manager
+	if p.AddOns.PackageManager.Enabled && p.AddOns.PackageManager.Provider == "helm" {
+		switch p.AddOns.PackageManager.Provider {
+		case "helm":
+			cc.EnableHelm = true
+		}
+	}
 
 	return &cc, nil
 }

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -758,7 +758,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	}
 	cc.EnableGluster = p.Storage.Nodes != nil && len(p.Storage.Nodes) > 0
 	// add_ons.package_manager
-	if p.AddOns.PackageManager.Enabled && p.AddOns.PackageManager.Provider == "helm" {
+	if p.AddOns.PackageManager.Enabled {
 		switch p.AddOns.PackageManager.Provider {
 		case "helm":
 			cc.EnableHelm = true

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -18,6 +18,8 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
+const ket133PackageManagerProvider = "helm"
+
 type stack struct {
 	lock sync.Mutex
 	s    []string
@@ -86,10 +88,10 @@ func (fp *FilePlanner) Read() (*Plan, error) {
 func readDeprecatedFields(p *Plan) {
 	// only set if not already being set by the user
 	// package_manager moved from features: to add_ons: after KET v1.3.3
-	if !p.AddOns.PackageManager.Enabled && p.Features.PackageManager != nil {
+	if !p.AddOns.PackageManager.Enabled && p.Features != nil && p.Features.PackageManager != nil {
 		p.AddOns.PackageManager.Enabled = p.Features.PackageManager.Enabled
 		// KET v1.3.3 did not have a provider field
-		p.AddOns.PackageManager.Provider = DefaultPackageManagerProvider()
+		p.AddOns.PackageManager.Provider = ket133PackageManagerProvider
 	}
 }
 

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -8,3 +8,18 @@ func TestGenerateAlphaNumericPassword(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+func TestReadWtihDeprecated(t *testing.T) {
+	pm := &PackageManager{
+		Enabled:  true,
+		Provider: "helm",
+	}
+	p := &Plan{}
+	p.Features.PackageManager = pm
+	readDeprecatedFields(p)
+
+	// add_ons.package_manager should be set to features.package_manager
+	if !p.AddOns.PackageManager.Enabled || p.AddOns.PackageManager.Provider != "helm" {
+		t.Errorf("Expected add_ons.package_manager to be read from features.package_manager")
+	}
+}

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -9,16 +9,18 @@ func TestGenerateAlphaNumericPassword(t *testing.T) {
 	}
 }
 
-func TestReadWtihDeprecated(t *testing.T) {
+func TestReadWithDeprecated(t *testing.T) {
 	pm := &PackageManager{
 		Enabled:  true,
 		Provider: "helm",
 	}
 	p := &Plan{}
-	p.Features.PackageManager = pm
+	p.Features = &Features{
+		PackageManager: pm,
+	}
 	readDeprecatedFields(p)
 
-	// add_ons.package_manager should be set to features.package_manager
+	// features.package_manager should be set to add_ons.package_manager
 	if !p.AddOns.PackageManager.Enabled || p.AddOns.PackageManager.Provider != "helm" {
 		t.Errorf("Expected add_ons.package_manager to be read from features.package_manager")
 	}

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -8,12 +8,10 @@ import (
 	"github.com/apprenda/kismatic/pkg/ssh"
 )
 
+const DefaultPackageManagerProvider = "helm"
+
 func PackageManagerProviders() []string {
 	return []string{"helm"}
-}
-
-func DefaultPackageManagerProvider() string {
-	return "helm"
 }
 
 // NetworkConfig describes the cluster's networking configuration
@@ -118,7 +116,7 @@ type Plan struct {
 	Docker         Docker
 	DockerRegistry DockerRegistry `yaml:"docker_registry"`
 	AddOns         AddOns         `yaml:"add_ons"`
-	Features       Features
+	Features       *Features      `yaml:"features,omitempty"`
 	Etcd           NodeGroup
 	Master         MasterNodeGroup
 	Worker         NodeGroup
@@ -152,6 +150,8 @@ type AddOns struct {
 	PackageManager PackageManager `yaml:"package_manager"`
 }
 
+// Features is deprecated, required to support KET v1.3.3
+// When writing out a new plan file, this will be nil and will not appear
 type Features struct {
 	PackageManager *PackageManager `yaml:"package_manager,omitempty"`
 }

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -8,6 +8,14 @@ import (
 	"github.com/apprenda/kismatic/pkg/ssh"
 )
 
+func PackageManagerProviders() []string {
+	return []string{"helm"}
+}
+
+func DefaultPackageManagerProvider() string {
+	return "helm"
+}
+
 // NetworkConfig describes the cluster's networking configuration
 type NetworkConfig struct {
 	Type             string
@@ -109,6 +117,7 @@ type Plan struct {
 	Cluster        Cluster
 	Docker         Docker
 	DockerRegistry DockerRegistry `yaml:"docker_registry"`
+	AddOns         AddOns         `yaml:"add_ons"`
 	Features       Features
 	Etcd           NodeGroup
 	Master         MasterNodeGroup
@@ -139,12 +148,17 @@ type SSHConnection struct {
 	Node      *Node
 }
 
-type Features struct {
+type AddOns struct {
 	PackageManager PackageManager `yaml:"package_manager"`
 }
 
+type Features struct {
+	PackageManager *PackageManager `yaml:"package_manager,omitempty"`
+}
+
 type PackageManager struct {
-	Enabled bool
+	Enabled  bool
+	Provider string
 }
 
 // GetUniqueNodes returns a list of the unique nodes that are listed in the plan file.

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/apprenda/kismatic/pkg/ssh"
+	"github.com/apprenda/kismatic/pkg/util"
 )
 
 // TODO: There is need to run validation against anything that is validatable.
@@ -131,7 +132,7 @@ func (p *Plan) validate() (bool, []error) {
 	v.validateWithErrPrefix("Docker", p.Docker)
 	// on a disconnected_installation a registry must be provided
 	v.validate(disconnectedInstallation{cluster: p.Cluster, registryProvided: p.ConfigureDockerWithPrivateRegistry()})
-	v.validate(&p.Features)
+	v.validate(&p.AddOns)
 	v.validateWithErrPrefix("Etcd nodes", &p.Etcd)
 	v.validateWithErrPrefix("Master nodes", &p.Master)
 	v.validateWithErrPrefix("Worker nodes", &p.Worker)
@@ -217,8 +218,19 @@ func (s *SSHConfig) validate() (bool, []error) {
 	return v.valid()
 }
 
-func (f *Features) validate() (bool, []error) {
+func (f *AddOns) validate() (bool, []error) {
 	v := newValidator()
+	v.validate(&f.PackageManager)
+	return v.valid()
+}
+
+func (p *PackageManager) validate() (bool, []error) {
+	v := newValidator()
+	if p.Enabled {
+		if !util.Contains(p.Provider, PackageManagerProviders()) {
+			v.addError(fmt.Errorf("Package Manager %q is not a valid option %v", p.Provider, PackageManagerProviders()))
+		}
+	}
 	return v.valid()
 }
 

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -794,3 +794,52 @@ func TestRepository(t *testing.T) {
 		}
 	}
 }
+
+func TestPackageManagerAddOn(t *testing.T) {
+	tests := []struct {
+		p     PackageManager
+		valid bool
+	}{
+		{
+			p: PackageManager{
+				Enabled:  true,
+				Provider: "helm",
+			},
+			valid: true,
+		},
+		{
+			p: PackageManager{
+				Enabled:  false,
+				Provider: "",
+			},
+			valid: true,
+		},
+		{
+			p: PackageManager{
+				Enabled:  false,
+				Provider: "foo",
+			},
+			valid: true,
+		},
+		{
+			p: PackageManager{
+				Enabled:  true,
+				Provider: "",
+			},
+			valid: false,
+		},
+		{
+			p: PackageManager{
+				Enabled:  true,
+				Provider: "foo",
+			},
+			valid: false,
+		},
+	}
+	for i, test := range tests {
+		ok, _ := test.p.validate()
+		if ok != test.valid {
+			t.Errorf("test %d: expect %t, but got %t", i, test.valid, ok)
+		}
+	}
+}

--- a/pkg/util/collection.go
+++ b/pkg/util/collection.go
@@ -32,3 +32,14 @@ func Intersects(first, second []string) bool {
 	}
 	return false
 }
+
+func Contains(find string, list []string) bool {
+	var found bool
+	for _, s := range list {
+		if find == s {
+			found = true
+			break
+		}
+	}
+	return found
+}

--- a/pkg/util/io.go
+++ b/pkg/util/io.go
@@ -31,6 +31,24 @@ func PromptForInt(in io.Reader, out io.Writer, prompt string, defaultValue int) 
 	return i, nil
 }
 
+func PromptForString(in io.Reader, out io.Writer, prompt string, defaultValue string, choices []string) (string, error) {
+	fmt.Fprintf(out, "=> %s %v: ", prompt, choices)
+	s := bufio.NewScanner(in)
+	// Scan the first token
+	s.Scan()
+	if s.Err() != nil {
+		return defaultValue, fmt.Errorf("error reading string: %v", s.Err())
+	}
+	ans := s.Text()
+	if ans == "" {
+		return defaultValue, nil
+	}
+	if !Contains(ans, choices) {
+		return defaultValue, fmt.Errorf("error, %s is not a valid option %v", ans, choices)
+	}
+	return ans, nil
+}
+
 // CreateDir check if directory exists and create it
 func CreateDir(dir string, perm os.FileMode) error {
 	if _, err := os.Stat(dir); os.IsNotExist(err) {

--- a/pkg/util/io.go
+++ b/pkg/util/io.go
@@ -32,7 +32,7 @@ func PromptForInt(in io.Reader, out io.Writer, prompt string, defaultValue int) 
 }
 
 func PromptForString(in io.Reader, out io.Writer, prompt string, defaultValue string, choices []string) (string, error) {
-	fmt.Fprintf(out, "=> %s %v: ", prompt, choices)
+	fmt.Fprintf(out, "=> %s (options %s, set to 'none' if not required), default [%v]: ", prompt, choices, defaultValue)
 	s := bufio.NewScanner(in)
 	// Scan the first token
 	s.Scan()


### PR DESCRIPTION
Moved `package_manager` from `features` to `add_ons`

A new question are also introduced when running kismatic install plan, 
**An alternative to enabled by default and in the comments specify the options, only "helm" for now**:
```
➜  out git:(monitoring) ✗ ./kismatic install plan
Plan your Kubernetes cluster:
=> Number of etcd nodes [3]:
=> Number of master nodes [2]:
=> Number of worker nodes [3]:
=> Number of ingress nodes (optional, set to 0 if not required) [2]:
=> Number of storage nodes (optional, set to 0 if not required) [0]:
=> Number of existing NFS volumes to be attached [0]:
Cluster Add-Ons:
=> Enable package manager (set to 'none' if not required) [helm none]:

Generating installation plan file template with:
- 3 etcd nodes
- 2 master nodes
- 3 worker nodes
- 2 ingress nodes
- 0 storage nodes
- 0 nfs volumes
- enabled cluster package manager: helm

Wrote plan file template to "kismatic-cluster.yaml"
Edit the plan file to further describe your cluster. Once ready, execute the "install validate" command to proceed.
```
Plan file changes:
```
addons:
  package_manager:
    enabled: true
    provider: helm
```

Helm is now installed in `_kubernetes.yaml` with the other "add-ons" no need for it to be a separate workflow. 

