### PR TITLE
Transitive ansible dependency now requires make

### DIFF
--- a/vendor-ansible/Dockerfile
+++ b/vendor-ansible/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7.2.1511
 
-RUN yum -y install python-setuptools gcc python-devel libffi-devel openssl-devel
+RUN yum -y install python-setuptools gcc python-devel libffi-devel openssl-devel make
 
 RUN easy_install pip 
 


### PR DESCRIPTION
Ansible does not seem to lock down dependency versions. Specifically, a
new version of Paramiko was released, which itself brings in pynacl.
There is an open issue in the pynacl repo with no resolution yet, but
the recommended workaround is to install make.

See https://github.com/pyca/pynacl/issues/298 for more details.