### PR TITLE
Don't run a version check after each install test

### DIFF
--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -20,10 +20,6 @@ var _ = Describe("kismatic", func() {
 		os.Chdir(dir)
 	})
 
-	AfterEach(func() {
-		assertClusterVersionIsCurrent()
-	})
-
 	Describe("calling kismatic with no verb", func() {
 		It("should output help text", func() {
 			c := exec.Command("./kismatic")


### PR DESCRIPTION
We use internal IPs in our tests and those won't be reachable from the test machine.

This issue was introduced in https://github.com/apprenda/kismatic/pull/574