### PR TITLE
Better message when not enough nodes with sufficient disk space for a volume

### DIFF
--- a/ansible/roles/volume-add/tasks/main.yaml
+++ b/ansible/roles/volume-add/tasks/main.yaml
@@ -23,11 +23,10 @@
 
   # Due to 1-node -> 1-disk mapping, we need, at least, replica_count * distribution_count storage nodes
   - name: verify we have enough storage nodes for the requested volume
-    assert:
-      that:
-        - "groups['available_storage_nodes'] is defined"
-        - "groups['available_storage_nodes']|length >= volume_replica_count * volume_distribution_count"
+    fail:
+      msg: "Not enough nodes with sufficient disk space for the requested volume. Required: {{ volume_replica_count * volume_distribution_count }} Available: {% if groups['available_storage_nodes'] is defined %}{{groups['available_storage_nodes']|length}}{% else %}0{% endif %}."
     run_once: true
+    when: "groups['available_storage_nodes'] is not defined or groups['available_storage_nodes']|length < volume_replica_count * volume_distribution_count"
 
   - name: create brick directory
     file:


### PR DESCRIPTION
Fixes #507

Sample output
```
➜  out git:(master) ✗ ./kismatic volume add 100 -r 1

Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [OK]
Validating SSH connectivity to nodes                                            [OK]

Add Persistent Storage Volume=======================================================
Add Gluster Volume                                                              [ERROR]
- Task: verify we have enough storage nodes for the requested volume
  worker001: Not enough nodes with sufficient disk space for the requested volume. Required: 1 Available: 0.[ERROR]
error adding new volume: error running playbook: error running ansible: exit status 2
```