### PR TITLE
Fallback to InternalIP/ExternalIP when using hosts file

### DIFF
--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
@@ -21,6 +21,9 @@ ExecStart={{ bin_dir }}/kube-apiserver \
   --etcd-servers={{ etcd_k8s_cluster_ip_list }} \
   --insecure-bind-address=127.0.0.1 \
   --insecure-port=8080 \
+{% if modify_hosts_file is defined and modify_hosts_file|bool == true %}
+  --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname \
+{% endif %}
   --runtime-config=extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true \
   --secure-port=6443 \
   --service-account-key-file={{ kubernetes_certificates.service_account_key }} \

--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
@@ -34,6 +34,9 @@ spec:
       - --etcd-servers={{ etcd_k8s_cluster_ip_list }}
       - --insecure-bind-address=127.0.0.1
       - --insecure-port=8080
+{% if modify_hosts_file is defined and modify_hosts_file|bool == true %}
+      - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+{% endif %}
       - --runtime-config=extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true
       - --secure-port=6443
       - --service-account-key-file={{ kubernetes_certificates.service_account_key }}


### PR DESCRIPTION
Fixes #504 

The reported issue occurs when `update_hosts_files` is enabled. When adding a new worker `/etc/hosts` gets modified but those changes aren't picked up the kube-api server until a restart.

Use new `--kubelet-preferred-address-types` flag in the API server. 

To minimize impact use the default `Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP,LegacyHostIP` unless modifying hostnames.

This is the same config kubeadm uses. 