### PR TITLE
Use kubeconfig with FQDN in calico conf file

### DIFF
--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -25,7 +25,7 @@ data:
         },
         "policy": {
             "type": "k8s",
-            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "k8s_api_root": "{{ kubernetes_master_ip }}",
             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
         },
         "kubernetes": {


### PR DESCRIPTION
Fixe #594 

Use the same cni conf file that was used prior to v1.3.3.
The conf file contains the `kubeconfig` that points to the FQDN instead of the local service IP.