### PR TITLE
Rename add-ons disabled to disable for consistency

### DIFF
--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -64,12 +64,12 @@ docker_registry:
   CA: {{.DockerRegistryCAPath}}
 add_ons:
   heapster:
-    disabled: false
+    disable: false
     options:
       heapster_replicas: {{if eq .HeapsterReplicas 0}}2{{else}}{{.HeapsterReplicas}}{{end}}
       influxdb_pvc_name: {{.HeapsterInfluxdbPVC}}
   package_manager:
-    disabled: {{.DisableHelm}}
+    disable: {{.DisableHelm}}
     provider: helm
 etcd:
   expected_count: {{len .Etcd}}

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -762,13 +762,13 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 
 	// add_ons
 	// heapster
-	if !p.AddOns.HeapsterMonitoring.Disabled {
+	if !p.AddOns.HeapsterMonitoring.Disable {
 		cc.Heapster.Enabled = true
 		cc.Heapster.Options.HeapsterReplicas = p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas
 		cc.Heapster.Options.InfluxDBPVCName = p.AddOns.HeapsterMonitoring.Options.InfluxDBPVCName
 	}
 	// package_manager
-	if !p.AddOns.PackageManager.Disabled {
+	if !p.AddOns.PackageManager.Disable {
 		// Currently only helm is supported
 		switch p.AddOns.PackageManager.Provider {
 		case "helm":

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -89,7 +89,7 @@ func readDeprecatedFields(p *Plan) {
 	// only set if not already being set by the user
 	// package_manager moved from features: to add_ons: after KET v1.3.3
 	if p.Features != nil && p.Features.PackageManager != nil {
-		p.AddOns.PackageManager.Disabled = !p.Features.PackageManager.Enabled
+		p.AddOns.PackageManager.Disable = !p.Features.PackageManager.Enabled
 		// KET v1.3.3 did not have a provider field
 		p.AddOns.PackageManager.Provider = ket133PackageManagerProvider
 	}

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -22,7 +22,7 @@ func TestReadWithDeprecated(t *testing.T) {
 	readDeprecatedFields(p)
 
 	// features.package_manager should be set to add_ons.package_manager
-	if p.AddOns.PackageManager.Disabled || p.AddOns.PackageManager.Provider != "helm" {
+	if p.AddOns.PackageManager.Disable || p.AddOns.PackageManager.Provider != "helm" {
 		t.Errorf("Expected add_ons.package_manager to be read from features.package_manager")
 	}
 	// cluster.disable_package_installation shoule be set to cluster.allow_package_installation

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -160,8 +160,8 @@ type Features struct {
 }
 
 type HeapsterMonitoring struct {
-	Disabled bool
-	Options  HeapsterOptions `yaml:"options"`
+	Disable bool
+	Options HeapsterOptions `yaml:"options"`
 }
 
 type HeapsterOptions struct {
@@ -170,7 +170,7 @@ type HeapsterOptions struct {
 }
 
 type PackageManager struct {
-	Disabled bool
+	Disable  bool
 	Provider string
 }
 

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -227,7 +227,7 @@ func (f *AddOns) validate() (bool, []error) {
 
 func (h *HeapsterMonitoring) validate() (bool, []error) {
 	v := newValidator()
-	if !h.Disabled {
+	if !h.Disable {
 		if h.Options.HeapsterReplicas <= 0 {
 			v.addError(fmt.Errorf("Heapster replicas %d is not valid, must be greater than 0", h.Options.HeapsterReplicas))
 		}
@@ -237,7 +237,7 @@ func (h *HeapsterMonitoring) validate() (bool, []error) {
 
 func (p *PackageManager) validate() (bool, []error) {
 	v := newValidator()
-	if !p.Disabled {
+	if !p.Disable {
 		if !util.Contains(p.Provider, PackageManagerProviders()) {
 			v.addError(fmt.Errorf("Package Manager %q is not a valid option %v", p.Provider, PackageManagerProviders()))
 		}

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -878,35 +878,35 @@ func TestPackageManagerAddOn(t *testing.T) {
 	}{
 		{
 			p: PackageManager{
-				Disabled: false,
+				Disable:  false,
 				Provider: "helm",
 			},
 			valid: true,
 		},
 		{
 			p: PackageManager{
-				Disabled: true,
+				Disable:  true,
 				Provider: "",
 			},
 			valid: true,
 		},
 		{
 			p: PackageManager{
-				Disabled: true,
+				Disable:  true,
 				Provider: "foo",
 			},
 			valid: true,
 		},
 		{
 			p: PackageManager{
-				Disabled: false,
+				Disable:  false,
 				Provider: "",
 			},
 			valid: true,
 		},
 		{
 			p: PackageManager{
-				Disabled: false,
+				Disable:  false,
 				Provider: "foo",
 			},
 			valid: false,


### PR DESCRIPTION
Renamed `disabled` to `disable`
```
add_ons:
  heapster:
    disable: false
    options:
      heapster_replicas: 2
      influxdb_pvc_name: ""              # Provide the name of the persistent volume claim that you will create after installation. If not specified, the data will be stored in ephemeral storage.
  package_manager:
    disable: false
    provider: helm                       # Options: 'helm'
```