### PR TITLE
Default heapster settings when not provided

### DIFF
--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -82,6 +82,9 @@ func (fp *FilePlanner) Read() (*Plan, error) {
 	// read deprecated fields and set it the new version of the cluster file
 	readDeprecatedFields(p)
 
+	// set nil values to defaults
+	setDefaults(p)
+
 	return p, nil
 }
 
@@ -96,6 +99,13 @@ func readDeprecatedFields(p *Plan) {
 	// allow_package_installation renamed to disable_package_installation after KET v1.4.0
 	if p.Cluster.AllowPackageInstallation != nil {
 		p.Cluster.DisablePackageInstallation = !*p.Cluster.AllowPackageInstallation
+	}
+}
+
+func setDefaults(p *Plan) {
+	if p.AddOns.HeapsterMonitoring == nil {
+		p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
+		p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas = 2
 	}
 }
 

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -30,3 +30,12 @@ func TestReadWithDeprecated(t *testing.T) {
 		t.Errorf("Expected cluster.allow_package_installation to be read from cluster.disable_package_installation")
 	}
 }
+
+func TestReadWithNil(t *testing.T) {
+	p := &Plan{}
+	setDefaults(p)
+
+	if p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas != 2 {
+		t.Errorf("Expected add_ons.heapster.options.heapster_replicas to equal 2, instead got %d", p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas)
+	}
+}

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -156,8 +156,8 @@ type SSHConnection struct {
 }
 
 type AddOns struct {
-	HeapsterMonitoring HeapsterMonitoring `yaml:"heapster"`
-	PackageManager     PackageManager     `yaml:"package_manager"`
+	HeapsterMonitoring *HeapsterMonitoring `yaml:"heapster"`
+	PackageManager     PackageManager      `yaml:"package_manager"`
 }
 
 // Features is deprecated, required to support KET v1.3.3

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -221,7 +221,7 @@ func (s *SSHConfig) validate() (bool, []error) {
 
 func (f *AddOns) validate() (bool, []error) {
 	v := newValidator()
-	v.validate(&f.HeapsterMonitoring)
+	v.validate(f.HeapsterMonitoring)
 	v.validate(&f.PackageManager)
 	return v.valid()
 }

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -24,7 +24,7 @@ var validPlan = Plan{
 		},
 	},
 	AddOns: AddOns{
-		HeapsterMonitoring: HeapsterMonitoring{
+		HeapsterMonitoring: &HeapsterMonitoring{
 			Options: HeapsterOptions{
 				HeapsterReplicas: 2,
 			},


### PR DESCRIPTION
Fixes #615 

When using an old plan file that is missing the `add_ons` section the validation should not fail and instead use default values.