### PR TITLE
Fix nil panics with heapster

### DIFF
--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -768,7 +768,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 
 	// add_ons
 	// heapster
-	if !p.AddOns.HeapsterMonitoring.Disable {
+	if p.AddOns.HeapsterMonitoring != nil && !p.AddOns.HeapsterMonitoring.Disable {
 		cc.Heapster.Enabled = true
 		cc.Heapster.Options.HeapsterReplicas = p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas
 		cc.Heapster.Options.InfluxDBPVCName = p.AddOns.HeapsterMonitoring.Options.InfluxDBPVCName

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -194,7 +194,9 @@ func WritePlanTemplate(p *Plan, w PlanReadWriter) error {
 
 	// Add-Ons
 	// Heapster
+	p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
 	p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas = 2
+
 	// Package Manager
 	p.AddOns.PackageManager.Provider = "helm"
 

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -228,7 +228,7 @@ func (f *AddOns) validate() (bool, []error) {
 
 func (h *HeapsterMonitoring) validate() (bool, []error) {
 	v := newValidator()
-	if !h.Disable {
+	if h != nil && !h.Disable {
 		if h.Options.HeapsterReplicas <= 0 {
 			v.addError(fmt.Errorf("Heapster replicas %d is not valid, must be greater than 0", h.Options.HeapsterReplicas))
 		}


### PR DESCRIPTION
This fixed failing tests after #617.

It wouldn't panic during normal execution now, only during tests but this is a good example of why using pointers here is not ideal.