### PR TITLE
Copy etcd certs after upgrades

### DIFF
--- a/ansible/_certs.yaml
+++ b/ansible/_certs.yaml
@@ -8,10 +8,6 @@
       - group_vars/all.yaml
 
     roles:
-      - role: etcd-cert
-        etcd_install_dir: "/etc/etcd_k8s"
-      - role: etcd-cert
-        etcd_install_dir: "/etc/etcd_networking"
       - kubenode-cert
       - role: docker-registry-container-cert
         when: deploy_internal_docker_registry is defined and deploy_internal_docker_registry|bool == true

--- a/ansible/etcd-migrate.yaml
+++ b/ansible/etcd-migrate.yaml
@@ -1,3 +1,4 @@
 ---
   - include: _kube-apiserver-stop.yaml upgrading=true
+  - include: _certs-etcd.yaml upgrading=true
   - include: _etcd-k8s-migrate.yaml upgrading=true

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -47,15 +47,15 @@ kubernetes_master_insecure_port: 8080
 #===============================================================================
 # common variables for etcd
 # etcd-certificates
-etcd_certificates_ca_file: "{{ etcd_install_dir }}/{{ etcd_certificates_ca_file_name }}"
-etcd_certificates_cert_file: "{{ etcd_install_dir }}/{{ etcd_certificates_cert_file_name }}"
-etcd_certificates_key_file: "{{ etcd_install_dir }}/{{ etcd_certificates_key_file_name }}"
-etcd_certificates_ca_file_name: ca.pem
-etcd_certificates_cert_file_name: etcd.pem
-etcd_certificates_key_file_name: etcd-key.pem
-etcd_certificates_owner: root
-etcd_certificates_group: root
-etcd_certificates_mode: 0660
+etcd_certificates:
+  ca: "{{ etcd_install_dir }}/ca.pem"
+  etcd: "{{ etcd_install_dir }}/etcd.pem"
+  etcd_key: "{{ etcd_install_dir }}/etcd-key.pem"
+  etcd_client: "{{ etcd_install_dir }}/etcd-client.pem"
+  etcd_client_key: "{{ etcd_install_dir }}/etcd-client-key.pem"
+  owner: root
+  group: root
+  mode: 0660
 # etcd-install
 etcd_install_executable_owner: 1000
 etcd_install_executable_group: 1000

--- a/ansible/roles/etcd-backup/tasks/main.yaml
+++ b/ansible/roles/etcd-backup/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
   - name: save etcd data to {{etcd_install_dir}}/backup
-    command: "{{ bin_dir }}/{{ etcdctl_install_bin_name }} --endpoint='https://127.0.0.1:{{ etcd_service_client_port }}/' --cert-file={{ etcd_certificates_cert_file }} --key-file={{ etcd_certificates_key_file }} --ca-file={{ etcd_certificates_ca_file }} backup --data-dir {{ etcd_service_data_dir }} --backup-dir {{etcd_install_dir}}/backup/{{ ansible_date_time.iso8601 | regex_replace(':', '-') }}"
+    command: "{{ bin_dir }}/{{ etcdctl_install_bin_name }} --endpoint='https://127.0.0.1:{{ etcd_service_client_port }}/' --cert-file={{ etcd_certificates.etcd_client }} --key-file={{ etcd_certificates.etcd_client_key }} --ca-file={{ etcd_certificates.ca }} backup --data-dir {{ etcd_service_data_dir }} --backup-dir {{etcd_install_dir}}/backup/{{ ansible_date_time.iso8601 | regex_replace(':', '-') }}"

--- a/ansible/roles/etcd-cert/tasks/main.yaml
+++ b/ansible/roles/etcd-cert/tasks/main.yaml
@@ -8,19 +8,21 @@
   - name: copy CA certificate
     copy:
       src: "{{ tls_directory }}/ca.pem"
-      dest: "{{ etcd_certificates_ca_file }}"
-      owner: "{{ etcd_certificates_owner }}"
-      group: "{{ etcd_certificates_group }}"
-      mode: "{{ etcd_certificates_mode }}"
+      dest: "{{ etcd_certificates.ca }}"
+      owner: "{{ etcd_certificates.owner }}"
+      group: "{{ etcd_certificates.group }}"
+      mode: "{{ etcd_certificates.mode }}"
   
   - name: copy etcd server certificate and key
     copy:
       src: "{{ tls_directory }}/{{ item.src }}"
       dest: "{{ item.dest }}"
-      owner: "{{ etcd_certificates_owner }}"
-      group: "{{ etcd_certificates_group }}"
-      mode: "{{ etcd_certificates_mode }}"
+      owner: "{{ etcd_certificates.owner }}"
+      group: "{{ etcd_certificates.group }}"
+      mode: "{{ etcd_certificates.mode }}"
     when: "'etcd' in group_names"
     with_items:
-      - {'src': "{{ inventory_hostname }}-etcd.pem", dest: "{{ etcd_certificates_cert_file }}"}
-      - {'src': "{{ inventory_hostname }}-etcd-key.pem", dest: "{{ etcd_certificates_key_file }}"}
+      - {'src': "{{ inventory_hostname }}-etcd.pem", dest: "{{ etcd_certificates.etcd }}"}
+      - {'src': "{{ inventory_hostname }}-etcd-key.pem", dest: "{{ etcd_certificates.etcd_key }}"}
+      - {'src': "etcd-client.pem", dest: "{{ etcd_certificates.etcd_client }}"}
+      - {'src': "etcd-client-key.pem", dest: "{{ etcd_certificates.etcd_client_key }}"}

--- a/ansible/roles/etcd-migrate/tasks/main.yaml
+++ b/ansible/roles/etcd-migrate/tasks/main.yaml
@@ -25,7 +25,7 @@
 
   # test etcd
   - name: verify {{ etcd_install_bin_name }} cluster health
-    command: "{{ bin_dir }}/{{ etcdctl_install_bin_name }} --endpoint='https://127.0.0.1:{{ etcd_service_client_port }}/' --cert-file={{ etcd_certificates_cert_file }} --key-file={{ etcd_certificates_key_file }} --ca-file={{ etcd_certificates_ca_file }} cluster-health"
+    command: "{{ bin_dir }}/{{ etcdctl_install_bin_name }} --endpoint='https://127.0.0.1:{{ etcd_service_client_port }}/' --cert-file={{ etcd_certificates.etcd_client }} --key-file={{ etcd_certificates.etcd_client_key }} --ca-file={{ etcd_certificates.ca }} cluster-health"
     register: result
     until: result|success
     retries: 3

--- a/ansible/roles/etcd-version/tasks/main.yaml
+++ b/ansible/roles/etcd-version/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
   - name: get etcd server version
-    command: curl --cert {{ etcd_certificates_cert_file }} --key {{ etcd_certificates_key_file }} --cacert {{ etcd_certificates_ca_file }} https://{{ inventory_hostname }}:{{ etcd_service_client_port }}/version
+    command: curl --cert {{ etcd_certificates.etcd_client }} --key {{ etcd_certificates.etcd_client_key }} --cacert {{ etcd_certificates.ca }} https://{{ inventory_hostname }}:{{ etcd_service_client_port }}/version
     register: current_etcd_version
 
   - name: check if etcd needs to be upgraded

--- a/ansible/roles/etcd/tasks/main.yaml
+++ b/ansible/roles/etcd/tasks/main.yaml
@@ -44,7 +44,7 @@
 
   # test etcd
   - name: verify {{ etcd_install_bin_name }} cluster health
-    command: "{{ bin_dir }}/{{ etcdctl_install_bin_name }} --endpoint='https://127.0.0.1:{{ etcd_service_client_port }}/' --cert-file={{ etcd_certificates_cert_file }} --key-file={{ etcd_certificates_key_file }} --ca-file={{ etcd_certificates_ca_file }} cluster-health"
+    command: "{{ bin_dir }}/{{ etcdctl_install_bin_name }} --endpoint='https://127.0.0.1:{{ etcd_service_client_port }}/' --cert-file={{ etcd_certificates.etcd_client }} --key-file={{ etcd_certificates.etcd_client_key }} --ca-file={{ etcd_certificates.ca }} cluster-health"
     register: result
     until: result|success
     retries: 3

--- a/ansible/roles/etcd/templates/etcd.service
+++ b/ansible/roles/etcd/templates/etcd.service
@@ -7,9 +7,9 @@ User=root
 Type=notify
 Environment=ETCD_NAME={{ inventory_hostname }}
 Environment=ETCD_DATA_DIR={{ etcd_service_data_dir }}
-Environment=CERT_FILE={{ etcd_certificates_cert_file }}
-Environment=KEY_FILE={{ etcd_certificates_key_file }}
-Environment=CA_FILE={{ etcd_certificates_ca_file }}
+Environment=CERT_FILE={{ etcd_certificates.etcd }}
+Environment=KEY_FILE={{ etcd_certificates.etcd_key }}
+Environment=CA_FILE={{ etcd_certificates.ca }}
 Environment=IP={{ internal_ipv4 }}
 Environment=PEER_PORT={{ etcd_service_peer_port }}
 Environment=CLIENT_PORT={{ etcd_service_client_port }}

--- a/ansible/upgrade-etcd2-node.yaml
+++ b/ansible/upgrade-etcd2-node.yaml
@@ -3,4 +3,5 @@
     when: allow_package_installation|bool == true
 
   #etcd
+  - include: _certs-etcd.yaml upgrading=true
   - include: _etcd-transition.yaml upgrading=true

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -14,6 +14,7 @@
     when: allow_package_installation|bool == true
 
   - include: _certs.yaml upgrading=true
+  - include: _certs-etcd.yaml upgrading=true
 
   # docker
   - include: _docker.yaml play_name="Upgrade Docker" upgrading=true


### PR DESCRIPTION
Fixes #630 
Fixes #569  
Fixes #604 
Fixes https://github.com/projectcalico/k8s-policy/issues/91

Starting in KET `v1.3.4` a new version of [k8s-policy](https://github.com/projectcalico/k8s-policy/releases/tag/v0.6.0) version was used which had a stricter requirement on SANs in the etcd certificate. 

For any cluster that was installed prior to KET `v1.3.0` without both a private and a public IP in the plan file there was an empty SAN entry in the certs and the policy-controller pod would not startup after upgrading to `v1.3.4`.

In KET `v1.4.0` the certs were reworked and no longer include an empty SAN fields, however these certs were not being copied over to the cluster and the policy-controller pod was failing.

This PR fixes copying over the new certs and using client certs when using `etcdctl` during the upgrade/backup steps.

I tested this manually from KET `v1.2.2` with both 1 etcd and 3 etcd nodes and the upgrade succeeded.