### PR TITLE
Fix issue where a long line logged by ansible would result in KET getting stuck

### DIFF
--- a/pkg/ansible/event_stream_test.go
+++ b/pkg/ansible/event_stream_test.go
@@ -9,15 +9,21 @@ func TestEventStreamSingleEvent(t *testing.T) {
 	in := bytes.NewBufferString(`{"eventType":"PLAY_START", "eventData": {"name":"somePlay"}}`)
 	es := EventStream(in)
 
+	gotEvent := false
 	for e := range es {
 		switch event := e.(type) {
 		default:
+			gotEvent = true
 			t.Error("Invalid event type received")
 		case *PlayStartEvent:
+			gotEvent = true
 			if event.Name != "somePlay" {
 				t.Errorf("Expected play name %q, but got %q", "somePlay", event.Name)
 			}
 		}
+	}
+	if !gotEvent {
+		t.Errorf("Did not get the event")
 	}
 
 }
@@ -41,6 +47,30 @@ func TestEventStreamMultipleEvents(t *testing.T) {
 	}
 
 	if i != 3 {
-		t.Errorf("invalid number of events received")
+		t.Errorf("invalid number of events received. expected 3, got %d", i)
+	}
+}
+
+func TestEventStreamNoEvents(t *testing.T) {
+	es := EventStream(bytes.NewBufferString(""))
+	for e := range es {
+		t.Errorf("got an unexpected event: %v", e)
+	}
+}
+
+func TestEventStreamBadEventIsIgnored(t *testing.T) {
+	in := bytes.NewBufferString(`{"eventType":"PLAY_START", "eventData": {"name":"somePlay"}}
+{"eventType":"BAD_EVENT", "eventData": {"name":"somePlay"}}
+someBadStuffHere...
+{"eventType":"PLAY_START", "eventData": {"name":"somePlay"}}
+`)
+	es := EventStream(in)
+	expectedGoodEvents := 2
+	gotEvents := 0
+	for _ = range es {
+		gotEvents++
+	}
+	if gotEvents != expectedGoodEvents {
+		t.Errorf("got %d events, but expected %d", gotEvents, expectedGoodEvents)
 	}
 }

--- a/pkg/util/linereader.go
+++ b/pkg/util/linereader.go
@@ -1,0 +1,32 @@
+package util
+
+import (
+	"bufio"
+	"io"
+)
+
+// LineReader provides a way to read lines of text with arbitrary length.
+// The line is buffered in memory.
+type LineReader struct {
+	reader *bufio.Reader
+}
+
+// NewLineReader returns a LineReader to read from r. It wraps the reader
+// with a buffered reader that has a buffer of size bufSizeBytes.
+func NewLineReader(r io.Reader, bufSizeBytes int) LineReader {
+	return LineReader{bufio.NewReaderSize(r, bufSizeBytes)}
+}
+
+// Read an entire line from the reader.
+func (lr LineReader) Read() ([]byte, error) {
+	var (
+		isPrefix       bool  = true
+		err            error = nil
+		line, fullLine []byte
+	)
+	for isPrefix && err == nil { // read until we have the whole line, or we get an err
+		line, isPrefix, err = lr.reader.ReadLine()
+		fullLine = append(fullLine, line...)
+	}
+	return fullLine, err
+}

--- a/pkg/util/linereader_test.go
+++ b/pkg/util/linereader_test.go
@@ -1,0 +1,88 @@
+package util
+
+import (
+	"bytes"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func TestLineReaderReadEmptyString(t *testing.T) {
+	lr := NewLineReader(bytes.NewBufferString(""), 64)
+	line, err := lr.Read()
+	if err != io.EOF {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(line) != "" {
+		t.Errorf("unexpected line: %v", err)
+	}
+}
+
+func TestLineReaderReadLine(t *testing.T) {
+	expectedLine := "foo"
+	r := bytes.NewBufferString(expectedLine)
+	lr := NewLineReader(r, 64)
+	line, err := lr.Read()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(line) != expectedLine {
+		t.Errorf("got %s, but wanted %s", line, expectedLine)
+	}
+}
+
+func TestLineReaderReadLongLine(t *testing.T) {
+	expectedLine := `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum sed tellus sit amet ligula cursus pretium feugiat ut lorem. In eu vestibulum turpis. Sed et mauris ut massa finibus pharetra. Suspendisse blandit eu est vitae congue. Praesent elementum blandit sapien et convallis. Sed quam nibh, vestibulum eu varius quis, consectetur in purus. Vestibulum ac justo in leo tempus pellentesque et in metus. Sed in est sed magna consequat hendrerit non et lectus. Sed sodales dictum tortor vel gravida. Phasellus egestas metus nec massa imperdiet, non gravida ligula cursus. Ut non diam sit amet ante porttitor tristique auctor vel leo. Morbi lectus tortor, scelerisque a laoreet id, aliquet sit amet nibh. Sed ullamcorper lectus dictum tellus ultrices iaculis. Integer rutrum, est eu mattis laoreet, eros tellus interdum tortor, a pharetra eros metus et lectus.`
+	r := bytes.NewBufferString(expectedLine)
+	lr := NewLineReader(r, 64)
+	line, err := lr.Read()
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if string(line) != expectedLine {
+		t.Errorf("got %s, but wanted %s", line, expectedLine)
+	}
+}
+
+func TestLineReaderReadLineEOFWhenDone(t *testing.T) {
+	lr := NewLineReader(bytes.NewBufferString("foo"), 64)
+	l, err := lr.Read()
+	if string(l) != "foo" {
+		t.Errorf("unexpected line: %v", l)
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	_, err = lr.Read()
+	if err != io.EOF {
+		t.Errorf("got %v but wanted %v", err, io.EOF)
+	}
+}
+
+func TestLineReaderReadLineMultipleLines(t *testing.T) {
+	lines := `foo
+bar
+baz`
+
+	lr := NewLineReader(bytes.NewBufferString(lines), 64)
+	var (
+		gotLines []string
+		line     []byte
+		err      error
+	)
+	for {
+		line, err = lr.Read()
+		if err != nil {
+			break
+		}
+		gotLines = append(gotLines, string(line))
+	}
+	if err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedLines := []string{"foo", "bar", "baz"}
+	if !reflect.DeepEqual(gotLines, expectedLines) {
+		t.Log(len(gotLines))
+		t.Errorf("got %v, but expected %v", gotLines, expectedLines)
+	}
+}


### PR DESCRIPTION
The problem here was that ansible would, under certain (unknown) conditions, log a line that was larger than the Scanner's default buffer size. This resulted in the Scanner giving up, which in turn resulted in ansible getting blocked writing to the FIFO pipe.

Fixes #633 