### PR TITLE
Add --ignore-safety-checks to online upgrade

### DIFF
--- a/ansible/_kube-drain-node.yaml
+++ b/ansible/_kube-drain-node.yaml
@@ -4,4 +4,5 @@
     serial: 1
     tasks:
       - name: "Run kubectl drain"
-        command: "kubectl drain --ignore-daemonsets {{ inventory_hostname|lower }}"
+        command: "kubectl drain --ignore-daemonsets --force --delete-local-data {{ inventory_hostname|lower }}"
+        # --force is required for static pods, --delete-local-data is required for pods with emptyDir

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -6,7 +6,6 @@
     tasks: []
   # Drain the node before we touch it
   - include: _kube-drain-node.yaml
-    when: online_upgrade is defined and online_upgrade|bool == true
 
   - include: _packages-cleanup.yaml
     when: allow_package_installation|bool == true
@@ -36,6 +35,5 @@
   - include: _calico-validate-node.yaml play_name="Validate Cluster Network" upgrading=true
 
   - include: _kube-uncordon-node.yaml
-    when: online_upgrade is defined and online_upgrade|bool == true
 
   - include: _update-version.yaml

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -117,7 +117,8 @@ func (c *applyCmd) run() error {
 		return fmt.Errorf("error running smoke test: %v", err)
 	}
 
-	util.PrintColor(c.out, util.Green, "\nThe cluster was installed successfully!\n\n")
+	util.PrintColor(c.out, util.Green, "\nThe cluster was installed successfully!\n")
+	fmt.Fprintln(c.out)
 
 	msg := "- To use the generated kubeconfig file with kubectl:" +
 		"\n    * use \"./kubectl --kubeconfig %s/kubeconfig\"" +
@@ -125,6 +126,7 @@ func (c *applyCmd) run() error {
 	util.PrintColor(c.out, util.Blue, msg, c.generatedAssetsDir)
 	util.PrintColor(c.out, util.Blue, "- To view the Kubernetes dashboard: \"./kismatic dashboard\"\n")
 	util.PrintColor(c.out, util.Blue, "- To SSH into a cluster node: \"./kismatic ssh etcd|master|worker|storage|$node.host\"\n")
+	fmt.Fprintln(c.out)
 
 	return nil
 }

--- a/pkg/cli/kismatic.go
+++ b/pkg/cli/kismatic.go
@@ -27,7 +27,7 @@ more documentation is availble at https://github.com/apprenda/kismatic`,
 	cmd.AddCommand(NewCmdDashboard(out))
 	cmd.AddCommand(NewCmdSSH(out))
 	cmd.AddCommand(NewCmdInfo(out))
-	cmd.AddCommand(NewCmdUpgrade(out))
+	cmd.AddCommand(NewCmdUpgrade(in, out))
 	cmd.AddCommand(NewCmdDiagnostic(out))
 
 	return cmd, nil

--- a/pkg/util/io.go
+++ b/pkg/util/io.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 )
 
 // PromptForInt read command line input
@@ -32,7 +33,7 @@ func PromptForInt(in io.Reader, out io.Writer, prompt string, defaultValue int) 
 }
 
 func PromptForString(in io.Reader, out io.Writer, prompt string, defaultValue string, choices []string) (string, error) {
-	fmt.Fprintf(out, "=> %s (options %s, set to 'none' if not required), default [%v]: ", prompt, choices, defaultValue)
+	fmt.Fprintf(out, "=> %s [%s]: ", prompt, strings.Join(choices, "/"))
 	s := bufio.NewScanner(in)
 	// Scan the first token
 	s.Scan()


### PR DESCRIPTION
Fixes #636 , Fixes #619, Fixes #458 

* Added `--skip-safety-checks` flag to online upgrades. The safety-checks will still run however the upgrade will continue even if the tests fail.
* Always drain nodes, even on offline upgrade.
* Added integration tests for online upgrades.
