### PR TITLE
Set hostname to lower when using nodenames and static pods

### DIFF
--- a/ansible/_calico-validate-node.yaml
+++ b/ansible/_calico-validate-node.yaml
@@ -10,7 +10,7 @@
 
     tasks:
       - name: wait until the calico pod on this node is running
-        shell: kubectl get pods `kubectl get pods -l=k8s-app=calico-node --template {%raw%}'{{range .items}}{{if eq .spec.nodeName{%endraw%} "{{ inventory_hostname }}"{%raw%}}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'{%endraw%} -n kube-system` -n kube-system -o=jsonpath='{.status.phase}'
+        shell: kubectl get pods `kubectl get pods -l=k8s-app=calico-node --template {%raw%}'{{range .items}}{{if eq .spec.nodeName{%endraw%} "{{ inventory_hostname|lower }}"{%raw%}}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'{%endraw%} -n kube-system` -n kube-system -o=jsonpath='{.status.phase}'
         register: calico_pod_name
         until: calico_pod_name|success and calico_pod_name.stdout == "Running"
         retries: 10

--- a/ansible/_kube-drain-node.yaml
+++ b/ansible/_kube-drain-node.yaml
@@ -4,4 +4,4 @@
     serial: 1
     tasks:
       - name: "Run kubectl drain"
-        command: "kubectl drain --ignore-daemonsets {{ inventory_hostname }}"
+        command: "kubectl drain --ignore-daemonsets {{ inventory_hostname|lower }}"

--- a/ansible/_kube-uncordon-node.yaml
+++ b/ansible/_kube-uncordon-node.yaml
@@ -4,4 +4,4 @@
     serial: 1
     tasks:
       - name: "Run kubectl uncordon"
-        command: "kubectl uncordon {{ inventory_hostname }}"
+        command: "kubectl uncordon {{ inventory_hostname|lower }}"

--- a/ansible/roles/calico/tasks/main.yaml
+++ b/ansible/roles/calico/tasks/main.yaml
@@ -24,13 +24,13 @@
       mode: "{{ network_environment_mode }}"
 
   - name: get the name of the calico pod running on this node
-    command: kubectl get pods -l=k8s-app=calico-node --template {%raw%}'{{range .items}}{{if eq .spec.nodeName{%endraw%} "{{ inventory_hostname }}"{%raw%}}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'{%endraw%} -n kube-system
+    command: kubectl get pods -l=k8s-app=calico-node --template {%raw%}'{{range .items}}{{if eq .spec.nodeName{%endraw%} "{{ inventory_hostname|lower }}"{%raw%}}}{{.metadata.name}}{{"\n"}}{{end}}{{end}}'{%endraw%} -n kube-system
     register: calico_pod_name
     when: upgrading is defined and upgrading|bool == true
 
     # label nodes that will have have calico isntalled
   - name: label nodes for calico
-    command: kubectl label nodes {% for host in play_hosts %}{{ host }} {% endfor %} kismatic/calico=true --overwrite --kubeconfig {{ kubernetes_kubeconfig_path }}
+    command: kubectl label nodes {% for host in play_hosts %}{{ host|lower }} {% endfor %} kismatic/calico=true --overwrite --kubeconfig {{ kubernetes_kubeconfig_path }}
     run_once: true
 
   - name: start calico containers

--- a/ansible/roles/glusterfs-k8s/tasks/main.yaml
+++ b/ansible/roles/glusterfs-k8s/tasks/main.yaml
@@ -12,7 +12,7 @@
       src: gluster-healthz-daemonset.yaml
       dest: "{{ kubernetes_spec_dir }}/gluster-healthz-daemonset.yaml"
   - name: Label gluster nodes
-    command: kubectl label nodes {% for host in groups['storage'] %}{{ host }} {% endfor %} kismatic/storage=true --overwrite
+    command: kubectl label nodes {% for host in groups['storage'] %}{{ host|lower }} {% endfor %} kismatic/storage=true --overwrite
   - name: Create gluster-healthz DaemonSet
     command: kubectl apply -f {{ kubernetes_spec_dir }}/gluster-healthz-daemonset.yaml
   - name: Create NFS service on the cluster

--- a/ansible/roles/kube-ingress/tasks/main.yaml
+++ b/ansible/roles/kube-ingress/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
   # add ingress label to nodes
   - name: label ingress nodeSelector
-    command: kubectl label nodes {% for host in groups['ingress'] %}{{ host }} {% endfor %} kismatic/ingress=true --overwrite
+    command: kubectl label nodes {% for host in groups['ingress'] %}{{ host|lower }} {% endfor %} kismatic/ingress=true --overwrite
 
   - name: create /etc/kubernetes/specs directory
     file:

--- a/ansible/roles/kube-proxy/tasks/main.yaml
+++ b/ansible/roles/kube-proxy/tasks/main.yaml
@@ -15,4 +15,4 @@
       group: "{{ kubernetes_group }}"
       mode: "{{ kubernetes_service_mode }}"
 
-  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-proxy-{{ inventory_hostname }}"
+  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-proxy-{{ inventory_hostname|lower }}"

--- a/ansible/roles/validate-control-plane-node/tasks/main.yaml
+++ b/ansible/roles/validate-control-plane-node/tasks/main.yaml
@@ -1,4 +1,4 @@
 ---
-  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-apiserver-{{ inventory_hostname }}"
-  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-scheduler-{{ inventory_hostname }}"
-  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-controller-manager-{{ inventory_hostname }}"
+  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-apiserver-{{ inventory_hostname|lower }}"
+  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-scheduler-{{ inventory_hostname|lower }}"
+  - include: ../validate-pod/tasks/validate-pod.yaml item="kube-controller-manager-{{ inventory_hostname|lower }}"

--- a/ansible/roles/worker-smoke-test/tasks/main.yaml
+++ b/ansible/roles/worker-smoke-test/tasks/main.yaml
@@ -1,3 +1,3 @@
 ---
   - name: verify node registered with API server
-    command: kubectl get nodes {{ worker_node }} --kubeconfig {{ kubernetes_kubeconfig_path }}
+    command: kubectl get nodes {{ worker_node|lower }} --kubeconfig {{ kubernetes_kubeconfig_path }}

--- a/integration/hosts_file_test.go
+++ b/integration/hosts_file_test.go
@@ -16,14 +16,17 @@ var _ = Describe("hosts file modification feature", func() {
 
 	Describe("enabling the hosts file modification feature", func() {
 		ItOnAWS("should result in a functional cluster [slow]", func(aws infrastructureProvisioner) {
-			WithInfrastructure(NodeCount{1, 1, 2, 0, 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
+			WithInfrastructure(NodeCount{1, 1, 4, 0, 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 				By("Setting the hostnames to be different than the actual ones")
 
+				// test hostname feature and unusual hostname formats
 				loadBalancedFQDN := nodes.master[0].PublicIP
 				nodes.etcd[0].Hostname = "etcd01"
-				nodes.master[0].Hostname = "master01"
-				nodes.worker[0].Hostname = "worker01"
-				nodes.worker[1].Hostname = "worker02"
+				nodes.master[0].Hostname = "MASTER01"
+				nodes.worker[0].Hostname = "WORKER01"
+				nodes.worker[1].Hostname = "worker02.test"
+				nodes.worker[2].Hostname = "Worker-03"
+				nodes.worker[3].Hostname = "WORKER04"
 				// change the hostnames on the machines
 				for _, n := range nodes.allNodes() {
 					err := runViaSSH([]string{fmt.Sprintf("sudo hostnamectl set-hostname %s", n.Hostname)}, []NodeDeets{n}, sshKey, 1*time.Minute)
@@ -35,7 +38,9 @@ var _ = Describe("hosts file modification feature", func() {
 					Master:              nodes.master,
 					MasterNodeFQDN:      loadBalancedFQDN,
 					MasterNodeShortName: loadBalancedFQDN,
-					Worker:              nodes.worker[0:1],
+					Worker:              nodes.worker[0:3],
+					Ingress:             nodes.worker[0:3],
+					Storage:             nodes.worker[0:3],
 					SSHKeyFile:          sshKey,
 					SSHUser:             nodes.master[0].SSHUser,
 					ModifyHostsFiles:    true,
@@ -46,7 +51,7 @@ var _ = Describe("hosts file modification feature", func() {
 				FailIfError(err)
 
 				By("Adding a worker with a bogus hostname that is added to hosts files")
-				err = addWorkerToCluster(nodes.worker[1])
+				err = addWorkerToCluster(nodes.worker[3])
 				FailIfError(err)
 			})
 		})


### PR DESCRIPTION
The kubelet uses the nodes hostname in a few places, however it sets any uppercase to lowercase. We need to follow the same strategy when interacting with the cluster. Specifically the nodename and the name of a static pod.

Also modified an existing integration test to cover this scenario.

Fixes #634 