### PR TITLE
Addon CNI

### DIFF
--- a/ansible/_calico-validate-node.yaml
+++ b/ansible/_calico-validate-node.yaml
@@ -1,7 +1,7 @@
 ---
   - hosts: master:worker:ingress:storage
     any_errors_fatal: true
-    name: "{{ play_name | default('Validate Network Components') }}"
+    name: "{{ play_name | default('Validate Calico Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
     become: yes
     vars_files:

--- a/ansible/_calico-validate.yaml
+++ b/ansible/_calico-validate.yaml
@@ -1,7 +1,7 @@
 ---
   - hosts: master:worker:ingress:storage
     any_errors_fatal: true
-    name: "{{ play_name | default('Validate Network Components') }}"
+    name: "{{ play_name | default('Validate Calico Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
     become: yes
     vars_files:

--- a/ansible/_calico.yaml
+++ b/ansible/_calico.yaml
@@ -1,7 +1,7 @@
 ---
   - hosts: master:worker:ingress:storage
     any_errors_fatal: true
-    name: "{{ play_name | default('Start Network Components') }}"
+    name: "{{ play_name | default('Start Calico Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
     become: yes
     vars_files:

--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -24,14 +24,17 @@
         local_action: command ../../helm repo add kismatic https://apprenda.github.io/kismatic-charts/
         become: no
         when: disconnected_installation|bool != true
-      - name: wait until the tiller pod is ready
-        command: kubectl get deployment tiller-deploy -n kube-system -o jsonpath='{.status.availableReplicas}'
-        register: readyReplicas
-        until: readyReplicas.stdout|int == 1
-        retries: 24
-        delay: 10
-        failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-      - name: fail if the tiller pod is not ready
-        fail:
-          msg: "Timed out waiting for the tiller pod to be in the ready state."
-        when: readyReplicas.stdout|int != 1
+
+      - block:
+        - name: wait until the tiller pod is ready
+          command: kubectl get deployment tiller-deploy -n kube-system -o jsonpath='{.status.availableReplicas}'
+          register: readyReplicas
+          until: readyReplicas.stdout|int == 1
+          retries: 24
+          delay: 10
+          failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+        - name: fail if the tiller pod is not ready
+          fail:
+            msg: "Timed out waiting for the tiller pod to be in the ready state."
+          when: readyReplicas.stdout|int != 1
+        when: run_validation|bool == true 

--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -37,4 +37,4 @@
           fail:
             msg: "Timed out waiting for the tiller pod to be in the ready state."
           when: readyReplicas.stdout|int != 1
-        when: run_validation|bool == true 
+        when: run_pod_validation|bool == true 

--- a/ansible/kubernetes-worker.yaml
+++ b/ansible/kubernetes-worker.yaml
@@ -10,6 +10,8 @@
   - include: _kubelet.yaml
   - include: _kube-proxy.yaml
   - include: _calico.yaml
+    when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _calico-validate.yaml
+    when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _update-version.yaml
   - include: _worker-smoke-test.yaml

--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -11,6 +11,7 @@
   # etcd
   - include: _etcd-k8s.yaml
   - include: _etcd-networking.yaml
+    when: cni.enabled|bool == true and cni.provider == "calico"
   # docker
   - include: _docker.yaml
   - include: _docker-registry.yaml
@@ -26,8 +27,11 @@
   # after installing kube-proxy, there is a dependecy on the API server to validate the static pod
   - include: _kube-proxy.yaml
   - include: _calico.yaml
+    when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _calico-validate.yaml
+    when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _calico-network-policy.yaml
+    when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _kube-dns.yaml
     when: dns.enabled|bool == true
   - include: _heapster.yaml

--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -104,7 +104,7 @@ spec:
             - name: CALICO_IPV4POOL_CIDR
               value: "{{ kubernetes_pods_cidr }}"
             - name: CALICO_IPV4POOL_IPIP
-              value: {% if calico_network_type == 'overlay' %}"always"{% else %}"off"{% endif %}
+              value: {% if cni.options.calico.mode == 'overlay' %}"always"{% else %}"off"{% endif %}
             # Location of the CA certificate for etcd.
             - name: ETCD_CA_CERT_FILE
               valueFrom:

--- a/ansible/roles/heapster/tasks/main.yaml
+++ b/ansible/roles/heapster/tasks/main.yaml
@@ -28,4 +28,4 @@
     - name: validate heapster pods  # don't verify if user is going to create their own PVC/PV
       include: validate.yaml
       when: heapster.options.influxdb_pvc_name is not defined or heapster.options.influxdb_pvc_name == ''
-    when: run_validation|bool == true 
+    when: run_pod_validation|bool == true 

--- a/ansible/roles/heapster/tasks/main.yaml
+++ b/ansible/roles/heapster/tasks/main.yaml
@@ -24,6 +24,8 @@
   - name: start heapster controller
     command: kubectl apply -f {{ kubernetes_spec_dir }}/heapster.yaml
 
-  - name: validate heapster pods  # don't verify if user is going to create their own PVC/PV
-    include: validate.yaml
-    when: heapster.options.influxdb_pvc_name is not defined or heapster.options.influxdb_pvc_name == ''
+  - block:
+    - name: validate heapster pods  # don't verify if user is going to create their own PVC/PV
+      include: validate.yaml
+      when: heapster.options.influxdb_pvc_name is not defined or heapster.options.influxdb_pvc_name == ''
+    when: run_validation|bool == true 

--- a/ansible/roles/kube-dashboard/tasks/main.yaml
+++ b/ansible/roles/kube-dashboard/tasks/main.yaml
@@ -23,4 +23,4 @@
       fail:
         msg: "Timed out waiting for kubernetes-dashboard pods to be in the ready state."
       when: readyReplicas.stdout|int != [2, groups['worker'] | length] | min
-    when: run_validation|bool == true 
+    when: run_pod_validation|bool == true 

--- a/ansible/roles/kube-dashboard/tasks/main.yaml
+++ b/ansible/roles/kube-dashboard/tasks/main.yaml
@@ -10,16 +10,17 @@
   - name: start kubernetes-dashboard service
     command: kubectl apply -f {{ kubernetes_spec_dir }}/kubernetes-dashboard.yaml
     register: out
-  - name: wait until kubernetes-dashboard pods are ready
-    command: kubectl get deployment kubernetes-dashboard -n kube-system -o jsonpath='{.status.availableReplicas}'
-    register: readyReplicas
-    until: readyReplicas.stdout|int == [2, groups['worker'] | length] | min
-    retries: 24
-    delay: 10
-    failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-  - name: fail if any kubernetes-dashboard pods are not ready
-    fail:
-      msg: "Timed out waiting for kubernetes-dashboard pods to be in the ready state."
-    when: readyReplicas.stdout|int != [2, groups['worker'] | length] | min
 
-  - debug: var=out.stdout_lines
+  - block:
+    - name: wait until kubernetes-dashboard pods are ready
+      command: kubectl get deployment kubernetes-dashboard -n kube-system -o jsonpath='{.status.availableReplicas}'
+      register: readyReplicas
+      until: readyReplicas.stdout|int == [2, groups['worker'] | length] | min
+      retries: 24
+      delay: 10
+      failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+    - name: fail if any kubernetes-dashboard pods are not ready
+      fail:
+        msg: "Timed out waiting for kubernetes-dashboard pods to be in the ready state."
+      when: readyReplicas.stdout|int != [2, groups['worker'] | length] | min
+    when: run_validation|bool == true 

--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -10,15 +10,17 @@
   - name: start kubernetes-dns service
     command: kubectl apply -f {{ kubernetes_spec_dir }}/kubernetes-dns.yaml
     register: out
-  - name: wait until DNS pods are ready
-    command: kubectl get deployment kube-dns -n kube-system -o jsonpath='{.status.availableReplicas}'
-    register: readyReplicas
-    until: readyReplicas.stdout|int == kube_dns_replicas|int
-    retries: 24
-    delay: 10
-    failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-  - name: fail if any DNS pods are not ready
-    fail:
-      msg: "Timed out waiting for DNS pods to be in the ready state."
-    when: readyReplicas.stdout|int != kube_dns_replicas|int
-  - debug: var=out.stdout_lines
+  
+  - block:
+    - name: wait until DNS pods are ready
+      command: kubectl get deployment kube-dns -n kube-system -o jsonpath='{.status.availableReplicas}'
+      register: readyReplicas
+      until: readyReplicas.stdout|int == kube_dns_replicas|int
+      retries: 24
+      delay: 10
+      failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+    - name: fail if any DNS pods are not ready
+      fail:
+        msg: "Timed out waiting for DNS pods to be in the ready state."
+      when: readyReplicas.stdout|int != kube_dns_replicas|int
+    when: run_validation|bool == true 

--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -23,4 +23,4 @@
       fail:
         msg: "Timed out waiting for DNS pods to be in the ready state."
       when: readyReplicas.stdout|int != kube_dns_replicas|int
-    when: run_validation|bool == true 
+    when: run_pod_validation|bool == true 

--- a/ansible/roles/kube-ingress/tasks/main.yaml
+++ b/ansible/roles/kube-ingress/tasks/main.yaml
@@ -22,18 +22,20 @@
     command: kubectl apply -f {{ kubernetes_spec_dir }}/nginx-ingress-controller.yaml
     register: out
 
-  - name: get desired number of ingress pods
-    shell: "kubectl get ds ingress --namespace=kube-system -o=jsonpath='{.status.desiredNumberScheduled}'"
-    register: desiredPods
+  - block:
+    - name: get desired number of ingress pods
+      shell: "kubectl get ds ingress --namespace=kube-system -o=jsonpath='{.status.desiredNumberScheduled}'"
+      register: desiredPods
 
-  - name: wait until all ingress controllers pods are ready
-    command: "kubectl get ds ingress --namespace=kube-system -o=jsonpath='{.status.numberReady}'"
-    register: readyPods
-    until: desiredPods.stdout|int == readyPods.stdout|int
-    retries: 15
-    delay: 10
-    failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-  - name: fail if any ingress pods are not ready
-    fail:
-      msg: "Timed out waiting for all ingress controllers pods to be in the ready state."
-    when: desiredPods.stdout|int != readyPods.stdout|int
+    - name: wait until all ingress controllers pods are ready
+      command: "kubectl get ds ingress --namespace=kube-system -o=jsonpath='{.status.numberReady}'"
+      register: readyPods
+      until: desiredPods.stdout|int == readyPods.stdout|int
+      retries: 15
+      delay: 10
+      failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+    - name: fail if any ingress pods are not ready
+      fail:
+        msg: "Timed out waiting for all ingress controllers pods to be in the ready state."
+      when: desiredPods.stdout|int != readyPods.stdout|int
+    when: run_validation|bool == true 

--- a/ansible/roles/kube-ingress/tasks/main.yaml
+++ b/ansible/roles/kube-ingress/tasks/main.yaml
@@ -38,4 +38,4 @@
       fail:
         msg: "Timed out waiting for all ingress controllers pods to be in the ready state."
       when: desiredPods.stdout|int != readyPods.stdout|int
-    when: run_validation|bool == true 
+    when: run_pod_validation|bool == true 

--- a/ansible/roles/kubelet/templates/kubelet.service
+++ b/ansible/roles/kubelet/templates/kubelet.service
@@ -5,34 +5,28 @@ Wants=docker.service
 After=docker.service
 
 [Service]
-Environment=INTERNAL_IP={{ internal_ipv4 }}
-Environment=CLUSTER_DNS={{ kubernetes_dns_service_ip }}
-Environment=HOSTNAME={{ inventory_hostname }}
-Environment=INFRA_IMG={{ pause_img }}
-Environment=REGISTER_SCHEDULABLE={{ kubernetes_schedulable }}
-Environment=NETWORK_PLUGIN_DIR={{ network_plugin_dir }}
-Environment=POD_MANIFEST_PATH={{ kubelet_pod_manifests_dir }}
 ExecStart=/usr/bin/kubelet \
   --allow-privileged=true \
   --cloud-provider= \
-  --cluster-dns=${CLUSTER_DNS} \
+  --cluster-dns={{ kubernetes_dns_service_ip }} \
   --cluster-domain=cluster.local \
   --container-runtime=docker \
+{%   if cni.enabled|bool == true %}
   --cni-bin-dir=/opt/cni/bin \
   --cni-conf-dir={{ network_plugin_dir }} \
+  --network-plugin=cni \
+{%   endif %}
   --docker=unix:///var/run/docker.sock \
-  --hostname-override=${HOSTNAME} \
+  --hostname-override={{ inventory_hostname }} \
   --require-kubeconfig=true \
   --kubeconfig={{ kubernetes_kubeconfig.kubelet }} \
-  --node-ip=${INTERNAL_IP} \
-  --pod-infra-container-image=${INFRA_IMG} \
-  --pod-manifest-path=${POD_MANIFEST_PATH} \
-  --register-schedulable=${REGISTER_SCHEDULABLE} \
+  --node-ip={{ internal_ipv4 }} \
+  --pod-infra-container-image={{ pause_img }} \
+  --pod-manifest-path={{ kubelet_pod_manifests_dir }} \
+  --register-schedulable={{ kubernetes_schedulable }} \
   --serialize-image-pulls=false \
   --tls-cert-file={{ kubernetes_certificates.kubelet}} \
   --tls-private-key-file={{ kubernetes_certificates.kubelet_key }} \
-  --network-plugin=cni \
-  --network-plugin-dir=${NETWORK_PLUGIN_DIR} \
   --v=2
 Restart=on-failure
 RestartSec=3

--- a/ansible/upgrade-cluster-services.yaml
+++ b/ansible/upgrade-cluster-services.yaml
@@ -1,5 +1,6 @@
 ---
   - include: _calico-network-policy.yaml play_name="Upgrade Network Policy Controller" upgrading=true
+    when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _kube-dns.yaml play_name="Upgrade Kubernetes DNS" upgrading=true
     when: dns.enabled|bool == true
   - include: _kube-ingress.yaml play_name="Upgrade Kubernetes Ingress" upgrading=true

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -21,7 +21,8 @@
   #etcd
   - include: _etcd-k8s.yaml play_name="Upgrade Kubernetes Etcd Cluster" serial_count="1" upgrading=true
   - include: _etcd-networking.yaml play_name="Upgrade Network Etcd Cluster" serial_count="1" upgrading=true
-
+    when: cni.enabled|bool == true and cni.provider == "calico"
+  
   # kubernetes
   - include: _kube-apiserver-stop.yaml 
   - include: _kubeconfig.yaml upgrading=true
@@ -32,7 +33,9 @@
   - include: _validate-control-plane-node.yaml serial_count="1" upgrading=true
   - include: _kube-proxy.yaml play_name="Upgrade Kubernetes Proxy" upgrading=true
   - include: _calico.yaml play_name="Upgrade Cluster Network" upgrading=true
+    when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _calico-validate-node.yaml play_name="Validate Cluster Network" upgrading=true
+    when: cni.enabled|bool == true and cni.provider == "calico"
 
   - include: _kube-uncordon-node.yaml
 

--- a/integration/install.go
+++ b/integration/install.go
@@ -42,6 +42,7 @@ type installOptions struct {
 	noProxy                     string
 	useDirectLVM                bool
 	serviceCIDR                 string
+	disableCNI                  bool
 	heapsterReplicas            int
 	heapsterInfluxdbPVC         string
 }
@@ -98,6 +99,7 @@ func buildPlan(nodes provisionedNodes, installOpts installOptions, sshKey string
 		NoProxy:                      installOpts.noProxy,
 		UseDirectLVM:                 installOpts.useDirectLVM,
 		ServiceCIDR:                  installOpts.serviceCIDR,
+		DisableCNI:                   installOpts.disableCNI,
 		DisableHelm:                  disableHelm,
 		HeapsterReplicas:             installOpts.heapsterReplicas,
 		HeapsterInfluxdbPVC:          installOpts.heapsterInfluxdbPVC,

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -90,6 +90,18 @@ var _ = Describe("kismatic", func() {
 			})
 		})
 
+		Context("when deploying a cluster with all node roles and disabled CNI", func() {
+			installOpts := installOptions{
+				disableCNI: true,
+			}
+			ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
+				WithInfrastructure(NodeCount{1, 1, 1, 1, 1}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
+					err := installKismatic(nodes, installOpts, sshKey)
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+		})
+
 		Context("when targetting CentOS", func() {
 			ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
 				WithMiniInfrastructure(CentOS7, aws, func(node NodeDeets, sshKey string) {

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -29,6 +29,7 @@ type PlanAWS struct {
 	NoProxy                      string
 	UseDirectLVM                 bool
 	ServiceCIDR                  string
+	DisableCNI                   bool
 	DisableHelm                  bool
 	HeapsterReplicas             int
 	HeapsterInfluxdbPVC          string
@@ -70,7 +71,7 @@ docker_registry:
   CA: {{.DockerRegistryCAPath}}
 add_ons:
   cni:
-    disable: false
+    disable: {{.DisableCNI}}
     provider: calico
     options:
       calico:

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -42,7 +42,6 @@ const planAWSOverlay = `cluster:
   disconnected_installation: {{.DisconnectedInstallation}}
   disable_registry_seeding: {{.DisableRegistrySeeding}}
   networking:
-    type: overlay
     pod_cidr_block: 172.16.0.0/16
     service_cidr_block: {{if .ServiceCIDR}}{{.ServiceCIDR}}{{else}}172.20.0.0/16{{end}}
     update_hosts_files: {{.ModifyHostsFiles}}
@@ -70,6 +69,12 @@ docker_registry:
   port: {{.DockerRegistryPort}}
   CA: {{.DockerRegistryCAPath}}
 add_ons:
+  cni:
+    disable: false
+    provider: calico
+    options:
+      calico:
+        mode: overlay
   heapster:
     disable: false
     options:

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -78,7 +78,7 @@ type ClusterCatalog struct {
 		Enabled bool
 	}
 
-	RunValidation bool `yaml:"run_validation"`
+	RunPodValidation bool `yaml:"run_pod_validation"`
 
 	CNI struct {
 		Enabled  bool

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -10,7 +10,6 @@ type ClusterCatalog struct {
 	ClusterName               string `yaml:"kubernetes_cluster_name"`
 	AdminPassword             string `yaml:"kubernetes_admin_password"`
 	TLSDirectory              string `yaml:"tls_directory"`
-	CalicoNetworkType         string `yaml:"calico_network_type"`
 	ServicesCIDR              string `yaml:"kubernetes_services_cidr"`
 	PodCIDR                   string `yaml:"kubernetes_pods_cidr"`
 	DNSServiceIP              string `yaml:"kubernetes_dns_service_ip"`
@@ -77,6 +76,18 @@ type ClusterCatalog struct {
 
 	DNS struct {
 		Enabled bool
+	}
+
+	RunValidation bool `yaml:"run_validation"`
+
+	CNI struct {
+		Enabled  bool
+		Provider string
+		Options  struct {
+			Calico struct {
+				Mode string
+			}
+		}
 	}
 
 	Heapster struct {

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -113,7 +113,7 @@ func (c *applyCmd) run() error {
 
 	// Run smoketest
 	// Don't run
-	if plan.CanValidatePods() {
+	if plan.NetworkConfigured() {
 		if err := c.executor.RunSmokeTest(plan); err != nil {
 			return fmt.Errorf("error running smoke test: %v", err)
 		}

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -103,9 +103,8 @@ func (c *applyCmd) run() error {
 	err = install.GenerateKubeconfig(plan, c.generatedAssetsDir)
 	if err != nil {
 		return fmt.Errorf("error generating kubeconfig file: %v", err)
-	} else {
-		util.PrettyPrintOk(c.out, "Generated kubeconfig file in the %q directory", c.generatedAssetsDir)
 	}
+	util.PrettyPrintOk(c.out, "Generated kubeconfig file in the %q directory", c.generatedAssetsDir)
 
 	// Perform the installation
 	if err := c.executor.Install(plan); err != nil {
@@ -113,8 +112,11 @@ func (c *applyCmd) run() error {
 	}
 
 	// Run smoketest
-	if err := c.executor.RunSmokeTest(plan); err != nil {
-		return fmt.Errorf("error running smoke test: %v", err)
+	// Don't run
+	if plan.CanValidatePods() {
+		if err := c.executor.RunSmokeTest(plan); err != nil {
+			return fmt.Errorf("error running smoke test: %v", err)
+		}
 	}
 
 	util.PrintColor(c.out, util.Green, "\nThe cluster was installed successfully!\n")

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -236,8 +236,10 @@ without the "--partial-ok" flag to perform a full upgrade.
 		return fmt.Errorf("Failed to upgrade cluster services: %v", err)
 	}
 
-	if err := executor.RunSmokeTest(plan); err != nil {
-		return fmt.Errorf("Smoke test failed: %v", err)
+	if plan.CanValidatePods() {
+		if err := executor.RunSmokeTest(plan); err != nil {
+			return fmt.Errorf("Smoke test failed: %v", err)
+		}
 	}
 
 	if !opts.dryRun {

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -236,7 +236,7 @@ without the "--partial-ok" flag to perform a full upgrade.
 		return fmt.Errorf("Failed to upgrade cluster services: %v", err)
 	}
 
-	if plan.CanValidatePods() {
+	if plan.NetworkConfigured() {
 		if err := executor.RunSmokeTest(plan); err != nil {
 			return fmt.Errorf("Smoke test failed: %v", err)
 		}

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -763,7 +763,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	cc.EnableGluster = p.Storage.Nodes != nil && len(p.Storage.Nodes) > 0
 
 	// add_ons
-	cc.RunValidation = p.CanValidatePods()
+	cc.RunPodValidation = p.NetworkConfigured()
 	// CNI
 	if p.AddOns.CNI != nil && !p.AddOns.CNI.Disable {
 		cc.CNI.Enabled = true

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -695,7 +695,6 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		ClusterName:               p.Cluster.Name,
 		AdminPassword:             p.Cluster.AdminPassword,
 		TLSDirectory:              tlsDir,
-		CalicoNetworkType:         p.Cluster.Networking.Type,
 		ServicesCIDR:              p.Cluster.Networking.ServiceCIDRBlock,
 		PodCIDR:                   p.Cluster.Networking.PodCIDRBlock,
 		DNSServiceIP:              dnsIP,
@@ -764,6 +763,13 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	cc.EnableGluster = p.Storage.Nodes != nil && len(p.Storage.Nodes) > 0
 
 	// add_ons
+	cc.RunValidation = p.CanValidatePods()
+	// CNI
+	if p.AddOns.CNI != nil && !p.AddOns.CNI.Disable {
+		cc.CNI.Enabled = true
+		cc.CNI.Provider = p.AddOns.CNI.Provider
+		cc.CNI.Options.Calico.Mode = p.AddOns.CNI.Options.Calico.Mode
+	}
 	// DNS
 	cc.DNS.Enabled = !p.AddOns.DNS.Disable
 	// heapster

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -35,6 +35,13 @@ func TestReadWithNil(t *testing.T) {
 	p := &Plan{}
 	setDefaults(p)
 
+	if p.AddOns.CNI.Provider != "calico" {
+		t.Errorf("Expected add_ons.cni.provider to equal 'calico', instead got %s", p.AddOns.CNI.Provider)
+	}
+	if p.AddOns.CNI.Options.Calico.Mode != "overlay" {
+		t.Errorf("Expected add_ons.cni.options.calico.mode to equal 'overlay', instead got %s", p.AddOns.CNI.Options.Calico.Mode)
+	}
+
 	if p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas != 2 {
 		t.Errorf("Expected add_ons.heapster.options.heapster_replicas to equal 2, instead got %d", p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas)
 	}

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -390,7 +390,7 @@ func (p Plan) DockerRegistryPort() string {
 	return strconv.Itoa(port)
 }
 
-// CanValidatePods returns true if pod validation/smoketest should run
-func (p Plan) CanValidatePods() bool {
+// NetworkConfigured returns true if pod validation/smoketest should run
+func (p Plan) NetworkConfigured() bool {
 	return p.AddOns.CNI == nil || !p.AddOns.CNI.Disable
 }

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -14,9 +14,17 @@ func PackageManagerProviders() []string {
 	return []string{"helm", ""}
 }
 
+func CNIProviders() []string {
+	return []string{"calico"} //, "weave", "contiv", "custom"}
+}
+
+func CalicoMode() []string {
+	return []string{"overlay", "routed"}
+}
+
 // NetworkConfig describes the cluster's networking configuration
 type NetworkConfig struct {
-	Type             string
+	Type             string `yaml:"type,omitempty"`
 	PodCIDRBlock     string `yaml:"pod_cidr_block"`
 	ServiceCIDRBlock string `yaml:"service_cidr_block"`
 	UpdateHostsFiles bool   `yaml:"update_hosts_files"`
@@ -160,6 +168,7 @@ type SSHConnection struct {
 }
 
 type AddOns struct {
+	CNI                *CNI                `yaml:"cni"`
 	DNS                DNS                 `yaml:"dns"`
 	HeapsterMonitoring *HeapsterMonitoring `yaml:"heapster"`
 	Dashboard          Dashboard           `yaml:"dashbard"`
@@ -170,6 +179,20 @@ type AddOns struct {
 // When writing out a new plan file, this will be nil and will not appear
 type Features struct {
 	PackageManager *DeprecatedPackageManager `yaml:"package_manager,omitempty"`
+}
+
+type CNI struct {
+	Disable  bool
+	Provider string
+	Options  CNIOptions `yaml:"options"`
+}
+
+type CNIOptions struct {
+	Calico CalicoOptions
+}
+
+type CalicoOptions struct {
+	Mode string
 }
 
 type DNS struct {
@@ -365,4 +388,9 @@ func (p Plan) DockerRegistryPort() string {
 		port = p.DockerRegistry.Port
 	}
 	return strconv.Itoa(port)
+}
+
+// CanValidatePods returns true if pod validation/smoketest should run
+func (p Plan) CanValidatePods() bool {
+	return p.AddOns.CNI == nil || !p.AddOns.CNI.Disable
 }

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -228,13 +228,12 @@ func (n *CNI) validate() (bool, []error) {
 	v := newValidator()
 	if n != nil && !n.Disable {
 		if !util.Contains(n.Provider, CNIProviders()) {
-			v.addError(fmt.Errorf("CNI %q is not a valid option %v", n.Provider, CNIProviders()))
+			v.addError(fmt.Errorf("%q is not a valid CNI provider. Optins are %v", n.Provider, CNIProviders()))
 		}
-		if n.Options.Calico.Mode == "" {
-			v.addError(errors.New("Calico mode cannot be empty"))
-		}
-		if !util.Contains(n.Options.Calico.Mode, CalicoMode()) {
-			v.addError(fmt.Errorf("Calico mode %q is not a valid option %v", n.Options.Calico.Mode, CalicoMode()))
+		if n.Provider == "calico" {
+			if !util.Contains(n.Options.Calico.Mode, CalicoMode()) {
+				v.addError(fmt.Errorf("%q is not a valid Calico mode. Options are %v", n.Options.Calico.Mode, CalicoMode()))
+			}
 		}
 	}
 	return v.valid()


### PR DESCRIPTION
Fixes #593 

Make Calico as a CNI add-on
```
add_ons:
  cni:
    disable: false
    provider: calico
    options:
      calico:
        mode: overlay
```
When `disable` is `true` the installer will skip all pod validations and the smoketest.

To retain backwards compatibility if  `add_ons.cni` is *nil* KET will default to Calico and the `cluster.networking.type` option will be used.

