### PR TITLE
Ansible become

### DIFF
--- a/ansible/_addon-logging.yaml
+++ b/ansible/_addon-logging.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Add-On Logging"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     roles:

--- a/ansible/_addon-logging.yaml
+++ b/ansible/_addon-logging.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "Add-On Logging"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_calico-network-policy.yaml
+++ b/ansible/_calico-network-policy.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "{{ play_name | default('Configure Calico Network Policy') }}"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_calico-network-policy.yaml
+++ b/ansible/_calico-network-policy.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Configure Calico Network Policy') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     pre_tasks:

--- a/ansible/_calico-validate-node.yaml
+++ b/ansible/_calico-validate-node.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Validate Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_calico-validate-node.yaml
+++ b/ansible/_calico-validate-node.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Validate Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_calico-validate.yaml
+++ b/ansible/_calico-validate.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Validate Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_calico-validate.yaml
+++ b/ansible/_calico-validate.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Validate Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_calico.yaml
+++ b/ansible/_calico.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_calico.yaml
+++ b/ansible/_calico.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Network Components') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_certs-etcd.yaml
+++ b/ansible/_certs-etcd.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Deploy Etcd Certificates"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_certs-etcd.yaml
+++ b/ansible/_certs-etcd.yaml
@@ -2,7 +2,6 @@
   - hosts: etcd
     any_errors_fatal: true
     name: "Deploy Etcd Certificates"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_certs.yaml
+++ b/ansible/_certs.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Deploy Cluster Certificates"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_certs.yaml
+++ b/ansible/_certs.yaml
@@ -2,7 +2,6 @@
   - hosts: master:worker:ingress:storage
     any_errors_fatal: true
     name: "Deploy Cluster Certificates"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_docker-registry.yaml
+++ b/ansible/_docker-registry.yaml
@@ -2,7 +2,7 @@
   - hosts: master[0]
     name: "{{ play_name | default('Configure Internal Docker Registry') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     environment:

--- a/ansible/_docker-registry.yaml
+++ b/ansible/_docker-registry.yaml
@@ -1,7 +1,6 @@
 ---
   - hosts: master[0]
     name: "{{ play_name | default('Configure Internal Docker Registry') }}"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_docker.yaml
+++ b/ansible/_docker.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Install Docker') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_docker.yaml
+++ b/ansible/_docker.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Install Docker') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_etcd-k8s-migrate.yaml
+++ b/ansible/_etcd-k8s-migrate.yaml
@@ -3,7 +3,7 @@
     name: "{{ play_name | default('Migrate Kubernetes Etcd Cluster to v3') }}"
     serial: 1 # need to always do this serially
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
       - group_vars/etcd-k8s.yaml

--- a/ansible/_etcd-k8s-migrate.yaml
+++ b/ansible/_etcd-k8s-migrate.yaml
@@ -2,7 +2,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Migrate Kubernetes Etcd Cluster to v3') }}"
     serial: 1 # need to always do this serially
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_etcd-k8s.yaml
+++ b/ansible/_etcd-k8s.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Etcd Cluster') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_etcd-k8s.yaml
+++ b/ansible/_etcd-k8s.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Kubernetes Etcd Cluster') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
       - group_vars/etcd-k8s.yaml

--- a/ansible/_etcd-networking.yaml
+++ b/ansible/_etcd-networking.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Network Etcd Cluster') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
       - group_vars/etcd-networking.yaml

--- a/ansible/_etcd-networking.yaml
+++ b/ansible/_etcd-networking.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Network Etcd Cluster') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_etcd-transition.yaml
+++ b/ansible/_etcd-transition.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "Temporarily Install Transition Etcd 3.x version"
     serial: 1 # need to always do this serially
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_etcd-transition.yaml
+++ b/ansible/_etcd-transition.yaml
@@ -4,7 +4,7 @@
     name: "Temporarily Install Transition Etcd 3.x version"
     serial: 1 # need to always do this serially
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
       - group_vars/etcd-networking.yaml

--- a/ansible/_heapster.yaml
+++ b/ansible/_heapster.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Configure Heapster Cluster Monitoring"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_heapster.yaml
+++ b/ansible/_heapster.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "Configure Heapster Cluster Monitoring"
-    remote_user: root
     become: yes
     run_once: true
     vars_files:

--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "{{ play_name | default('Initialize Helm and Start Tiller') }}"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Initialize Helm and Start Tiller') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     environment:

--- a/ansible/_hosts.yaml
+++ b/ansible/_hosts.yaml
@@ -3,7 +3,6 @@
   - hosts: all
     any_errors_fatal: true
     name: "Update Hosts File"
-    remote_user: root
     become: yes
 
     roles:

--- a/ansible/_hosts.yaml
+++ b/ansible/_hosts.yaml
@@ -4,7 +4,7 @@
     any_errors_fatal: true
     name: "Update Hosts File"
     remote_user: root
-    become_method: sudo
+    become: yes
 
     roles:
       - role: hosts

--- a/ansible/_kube-apiserver-stop.yaml
+++ b/ansible/_kube-apiserver-stop.yaml
@@ -2,7 +2,6 @@
   - hosts: master
     any_errors_fatal: true
     name: "{{ play_name | default('Stop Kubernetes API Server') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_kube-apiserver-stop.yaml
+++ b/ansible/_kube-apiserver-stop.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Stop Kubernetes API Server') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_kube-apiserver.yaml
+++ b/ansible/_kube-apiserver.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Kubernetes API Server') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_kube-apiserver.yaml
+++ b/ansible/_kube-apiserver.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes API Server') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_kube-controller-manager.yaml
+++ b/ansible/_kube-controller-manager.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Controller Manager') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_kube-controller-manager.yaml
+++ b/ansible/_kube-controller-manager.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Kubernetes Controller Manager') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_kube-dashboard.yaml
+++ b/ansible/_kube-dashboard.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Dashboard') }}"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_kube-dashboard.yaml
+++ b/ansible/_kube-dashboard.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Dashboard') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     roles:

--- a/ansible/_kube-dns.yaml
+++ b/ansible/_kube-dns.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes DNS') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     roles:

--- a/ansible/_kube-dns.yaml
+++ b/ansible/_kube-dns.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes DNS') }}"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_kube-ingress.yaml
+++ b/ansible/_kube-ingress.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Ingress') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     roles:

--- a/ansible/_kube-ingress.yaml
+++ b/ansible/_kube-ingress.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Ingress') }}"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_kube-proxy.yaml
+++ b/ansible/_kube-proxy.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Kubernetes Proxy') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_kube-proxy.yaml
+++ b/ansible/_kube-proxy.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Proxy') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_kube-scheduler.yaml
+++ b/ansible/_kube-scheduler.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Kubernetes Scheduler') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_kube-scheduler.yaml
+++ b/ansible/_kube-scheduler.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Scheduler') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_kubeconfig.yaml
+++ b/ansible/_kubeconfig.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: Generate Kubectl Config File
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_kubeconfig.yaml
+++ b/ansible/_kubeconfig.yaml
@@ -4,7 +4,7 @@
     name: Generate Kubectl Config File
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_kubelet.yaml
+++ b/ansible/_kubelet.yaml
@@ -4,7 +4,7 @@
     name: "{{ play_name | default('Start Kubernetes Kubelet') }}"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_kubelet.yaml
+++ b/ansible/_kubelet.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "{{ play_name | default('Start Kubernetes Kubelet') }}"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_nfs-volumes.yaml
+++ b/ansible/_nfs-volumes.yaml
@@ -2,7 +2,6 @@
   - hosts: master[0]
     any_errors_fatal: true
     name: "Configure PersistentVolumes for NFS"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_nfs-volumes.yaml
+++ b/ansible/_nfs-volumes.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Configure PersistentVolumes for NFS"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     roles:

--- a/ansible/_packages-cleanup.yaml
+++ b/ansible/_packages-cleanup.yaml
@@ -2,7 +2,6 @@
   - hosts: all
     any_errors_fatal: true
     name: Remove Old Kismatic Packages
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_packages-cleanup.yaml
+++ b/ansible/_packages-cleanup.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: Remove Old Kismatic Packages
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
 

--- a/ansible/_packages-repo.yaml
+++ b/ansible/_packages-repo.yaml
@@ -3,7 +3,6 @@
   - hosts: all
     any_errors_fatal: true
     name: "Configure Kismatic Package Repos"
-    remote_user: root
     become: yes
 
     environment:

--- a/ansible/_packages-repo.yaml
+++ b/ansible/_packages-repo.yaml
@@ -4,7 +4,7 @@
     any_errors_fatal: true
     name: "Configure Kismatic Package Repos"
     remote_user: root
-    become_method: sudo
+    become: yes
 
     environment:
       https_proxy: "{{ https_proxy }}"

--- a/ansible/_preflight.yaml
+++ b/ansible/_preflight.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: Run Cluster Pre-Flight Checks
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
     roles:

--- a/ansible/_preflight.yaml
+++ b/ansible/_preflight.yaml
@@ -2,7 +2,6 @@
   - hosts: all
     any_errors_fatal: true
     name: Run Cluster Pre-Flight Checks
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_smoketest.yaml
+++ b/ansible/_smoketest.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: Smoke Test Master Node
     remote_user: root
-    become_method: sudo
+    become: yes
     serial: 1
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_smoketest.yaml
+++ b/ansible/_smoketest.yaml
@@ -2,7 +2,6 @@
   - hosts: master
     any_errors_fatal: true
     name: Smoke Test Master Node
-    remote_user: root
     become: yes
     serial: 1
     vars_files:

--- a/ansible/_storage.yaml
+++ b/ansible/_storage.yaml
@@ -2,7 +2,6 @@
   - hosts: storage
     any_errors_fatal: true
     name: "Bootstrap Persistent Storage Cluster"
-    remote_user: root
     become: yes
 
     environment:
@@ -19,7 +18,6 @@
     any_errors_fatal: true
     name: "Create NFS service on the cluster"
     run_once: true
-    remote_user: root
     become: yes
     roles:
       - glusterfs-k8s

--- a/ansible/_storage.yaml
+++ b/ansible/_storage.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Bootstrap Persistent Storage Cluster"
     remote_user: root
-    become_method: sudo
+    become: yes
 
     environment:
       https_proxy: "{{ https_proxy }}"
@@ -20,6 +20,6 @@
     name: "Create NFS service on the cluster"
     run_once: true
     remote_user: root
-    become_method: sudo
+    become: yes
     roles:
       - glusterfs-k8s

--- a/ansible/_update-version.yaml
+++ b/ansible/_update-version.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Update Kismatic Version File"
     remote_user: root
-    become_method: sudo
+    become: yes
 
     roles:
       - role: update_version

--- a/ansible/_update-version.yaml
+++ b/ansible/_update-version.yaml
@@ -2,7 +2,6 @@
   - hosts: all
     any_errors_fatal: true
     name: "Update Kismatic Version File"
-    remote_user: root
     become: yes
 
     roles:

--- a/ansible/_upgrade-preflight.yaml
+++ b/ansible/_upgrade-preflight.yaml
@@ -2,7 +2,6 @@
   - hosts: all
     any_errors_fatal: true
     name: Run Upgrade Pre-Flight Checks
-    remote_user: root
     become: yes
     vars_files:
       - group_vars/all.yaml

--- a/ansible/_upgrade-preflight.yaml
+++ b/ansible/_upgrade-preflight.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: Run Upgrade Pre-Flight Checks
     remote_user: root
-    become_method: sudo
+    become: yes
     vars_files:
       - group_vars/all.yaml
     roles:

--- a/ansible/_validate-control-plane-node.yaml
+++ b/ansible/_validate-control-plane-node.yaml
@@ -3,7 +3,6 @@
     any_errors_fatal: true
     name: "Validate Kubernetes Control Plane is Running"
     serial: "{{ serial_count | default('100%') }}"
-    remote_user: root
     become: yes
     
     roles:

--- a/ansible/_validate-control-plane-node.yaml
+++ b/ansible/_validate-control-plane-node.yaml
@@ -4,7 +4,7 @@
     name: "Validate Kubernetes Control Plane is Running"
     serial: "{{ serial_count | default('100%') }}"
     remote_user: root
-    become_method: sudo
+    become: yes
     
     roles:
       - validate-control-plane-node

--- a/ansible/_worker-smoke-test.yaml
+++ b/ansible/_worker-smoke-test.yaml
@@ -2,7 +2,6 @@
   - hosts: worker
     any_errors_fatal: true
     name: "Smoke Test New Worker"
-    remote_user: root
     become: yes
     run_once: true
 

--- a/ansible/_worker-smoke-test.yaml
+++ b/ansible/_worker-smoke-test.yaml
@@ -3,7 +3,7 @@
     any_errors_fatal: true
     name: "Smoke Test New Worker"
     remote_user: root
-    become_method: sudo
+    become: yes
     run_once: true
 
     roles:


### PR DESCRIPTION
Fixes #661 

* `remote_user` is default to `root` removing that flag allows the user to overwrite a global option ins `ansible.cfg`
* use `become` instead of `become_method` to allow the user to overwrite a global option ins `ansible.cfg`