### PR TITLE
Add DNS and Dashboard as add-ons

### DIFF
--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -29,11 +29,13 @@
   - include: _calico-validate.yaml
   - include: _calico-network-policy.yaml
   - include: _kube-dns.yaml
+    when: dns.enabled|bool == true
   - include: _heapster.yaml
-    when: heapster is defined and heapster.enabled is defined and heapster.enabled|bool == true
+    when: heapster.enabled|bool == true
   - include: _kube-dashboard.yaml
+    when: dashboard.enabled|bool == true
   - include: _helm.yaml
-    when: helm is defined and helm.enabled is defined and helm.enabled|bool == true
+    when: helm.enabled|bool == true
   - include: _kube-ingress.yaml
     when: configure_ingress|bool == true
   - include: _storage.yaml

--- a/ansible/roles/smoketest/tasks/main.yaml
+++ b/ansible/roles/smoketest/tasks/main.yaml
@@ -5,4 +5,4 @@
       dest: "{{ bin_dir }}/kuberang"
       mode: 0744
   - name: run smoke test checks using Kuberang
-    command: "{{ bin_dir }}/kuberang --registry-url={% if load_private_images|bool == true %}{{ docker_registry_full_url }}{% else %}{% endif %}"
+    command: "{{ bin_dir }}/kuberang --registry-url={% if load_private_images|bool == true %}{{ docker_registry_full_url }}{% else %}{% endif %} {% if dns.enabled|bool == false%}--skip-dns-tests{% endif %}"

--- a/ansible/upgrade-cluster-services.yaml
+++ b/ansible/upgrade-cluster-services.yaml
@@ -1,10 +1,12 @@
 ---
   - include: _calico-network-policy.yaml play_name="Upgrade Network Policy Controller" upgrading=true
   - include: _kube-dns.yaml play_name="Upgrade Kubernetes DNS" upgrading=true
+    when: dns.enabled|bool == true
   - include: _kube-ingress.yaml play_name="Upgrade Kubernetes Ingress" upgrading=true
     when: configure_ingress|bool == true
   - include: _heapster.yaml play_name="Upgrade Heapster Cluster Monitoring" upgrading=true
-    when: heapster is defined and heapster.enabled is defined and heapster.enabled|bool == true
+    when: heapster.enabled|bool == true
   - include: _kube-dashboard.yaml play_name="Upgrade Kubernetes Dashboard" upgrading=true
+    when: dashboard.enabled|bool == true
   - include: _helm.yaml play_name="Upgrade Helm and Tiller" upgrading=true
-    when: helm is defined and helm.enabled is defined and helm.enabled|bool == true
+    when: helm.enabled|bool == true

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -75,7 +75,7 @@ type ClusterCatalog struct {
 
 	LocalKubeconfigDirectory string `yaml:"local_kubeconfig_directory"`
 
-	Helm struct {
+	DNS struct {
 		Enabled bool
 	}
 
@@ -85,6 +85,14 @@ type ClusterCatalog struct {
 			HeapsterReplicas int    `yaml:"heapster_replicas"`
 			InfluxDBPVCName  string `yaml:"influxdb_pvc_name"`
 		}
+	}
+
+	Dashboard struct {
+		Enabled bool
+	}
+
+	Helm struct {
+		Enabled bool
 	}
 
 	HTTPProxy  string `yaml:"http_proxy"`

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -764,12 +764,16 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	cc.EnableGluster = p.Storage.Nodes != nil && len(p.Storage.Nodes) > 0
 
 	// add_ons
+	// DNS
+	cc.DNS.Enabled = !p.AddOns.DNS.Disable
 	// heapster
 	if p.AddOns.HeapsterMonitoring != nil && !p.AddOns.HeapsterMonitoring.Disable {
 		cc.Heapster.Enabled = true
 		cc.Heapster.Options.HeapsterReplicas = p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas
 		cc.Heapster.Options.InfluxDBPVCName = p.AddOns.HeapsterMonitoring.Options.InfluxDBPVCName
 	}
+	// dashboard
+	cc.Dashboard.Enabled = !p.AddOns.Dashboard.Disable
 	// package_manager
 	if !p.AddOns.PackageManager.Disable {
 		// Currently only helm is supported

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -160,7 +160,9 @@ type SSHConnection struct {
 }
 
 type AddOns struct {
+	DNS                DNS                 `yaml:"dns"`
 	HeapsterMonitoring *HeapsterMonitoring `yaml:"heapster"`
+	Dashboard          Dashboard           `yaml:"dashbard"`
 	PackageManager     PackageManager      `yaml:"package_manager"`
 }
 
@@ -170,9 +172,17 @@ type Features struct {
 	PackageManager *DeprecatedPackageManager `yaml:"package_manager,omitempty"`
 }
 
+type DNS struct {
+	Disable bool
+}
+
 type HeapsterMonitoring struct {
 	Disable bool
 	Options HeapsterOptions `yaml:"options"`
+}
+
+type Dashboard struct {
+	Disable bool
 }
 
 type HeapsterOptions struct {


### PR DESCRIPTION
Fixes #662, Fixes #663

Because DNS is now optional need to add an option in `kuberang` to skip DNS related tests: 
`--skip-dns-tests` 