### PR TITLE
Add serviceType and sink options to heapster

### DIFF
--- a/ansible/roles/heapster/tasks/main.yaml
+++ b/ansible/roles/heapster/tasks/main.yaml
@@ -27,5 +27,5 @@
   - block:
     - name: validate heapster pods  # don't verify if user is going to create their own PVC/PV
       include: validate.yaml
-      when: heapster.options.influxdb_pvc_name is not defined or heapster.options.influxdb_pvc_name == ''
+      when: heapster.options.influxdb.pvc_name is not defined or heapster.options.influxdb.pvc_name == ''
     when: run_pod_validation|bool == true 

--- a/ansible/roles/heapster/tasks/validate.yaml
+++ b/ansible/roles/heapster/tasks/validate.yaml
@@ -14,7 +14,7 @@
   - name: wait until the heapster pods are ready
     command: kubectl get deployment heapster -n kube-system -o jsonpath='{.status.availableReplicas}'
     register: readyReplicas
-    until: readyReplicas.stdout|int == {{ heapster.options.heapster_replicas }}
+    until: readyReplicas.stdout|int == {{ heapster.options.heapster.replicas }}
     retries: 24
     delay: 10
     failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
@@ -22,4 +22,4 @@
   - name: fail if the heapster pod is not ready
     fail:
       msg: "Timed out waiting for the heapster pods to be in the ready state."
-    when: readyReplicas.stdout|int != {{ heapster.options.heapster_replicas }}
+    when: readyReplicas.stdout|int != {{ heapster.options.heapster.replicas }}

--- a/ansible/roles/heapster/templates/heapster.yaml
+++ b/ansible/roles/heapster/templates/heapster.yaml
@@ -18,6 +18,7 @@ spec:
     targetPort: 8082
   selector:
     k8s-app: heapster
+  type: {{ heapster.options.heapster.service_type }}
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -27,7 +28,7 @@ metadata:
   annotations:
     kismatic/version: "{{ kismatic_short_version }}"
 spec:
-  replicas: {{ heapster.options.heapster_replicas }}
+  replicas: {{ heapster.options.heapster.replicas }}
   template:
     metadata:
       labels:
@@ -42,4 +43,4 @@ spec:
         command:
         - /heapster
         - --source=kubernetes:https://kubernetes.default
-        - --sink=influxdb:http://heapster-influxdb.kube-system.svc:8086
+        - --sink={{ heapster.options.heapster.sink }}

--- a/ansible/roles/heapster/templates/influxdb.yaml
+++ b/ansible/roles/heapster/templates/influxdb.yaml
@@ -36,9 +36,9 @@ spec:
           name: influxdb-storage
       volumes:
       - name: influxdb-storage
-{% if heapster.options.influxdb_pvc_name is defined and heapster.options.influxdb_pvc_name != "" %}
+{% if heapster.options.influxdb.pvc_name is defined and heapster.options.influxdb.pvc_name != "" %}
         persistentVolumeClaim:
-          claimName: "{{ heapster.options.influxdb_pvc_name }}"
+          claimName: "{{ heapster.options.influxdb.pvc_name }}"
 {% else %}
         emptyDir: {}
 {% endif %}

--- a/docs/ADD_ONS.md
+++ b/docs/ADD_ONS.md
@@ -15,15 +15,15 @@ Heapster is a monitoring solution that enables container monitoring throughout
 the cluster. When heapster is running on the cluster, `kubectl` and the Kubernetes 
 dashboard surface resource utilization metrics for all pods.
 
-**Important:** If you wish to persist the gathered metrics, you must set the `add_ons.heapster.options.influxdb_pvc_name` option.
+**Important:** If you wish to persist the gathered metrics, you must set the `add_ons.heapster.options.influxdb.pvc_name` option.
 
 Plan file options:
 
 | Plan file key | Description |
 |---------------|-------------|
 | add_ons.heapster.disable | Set to true if heapster should not be deployed during installation |
-| add_ons.heapster.options.heapster_replicas  | Number of replicas for the heapster deployment |
-| add_ons.heapster.options.influxdb_pvc_name | Name of a persistent volume claim that will be used by the influxdb databse for persistence. This PVC must be manually created after installation. |
+| add_ons.heapster.options.heapster.replicas  | Number of replicas for the heapster deployment |
+| add_ons.heapster.options.influxdb.pvc_name | Name of a persistent volume claim that will be used by the influxdb databse for persistence. This PVC must be manually created after installation. |
 
 ### Package Manager
 Helm is the official package manager for Kubernetes. KET includes the `helm` client-side binary in the distribution package. KET also installs the server-side agent, Tiller, on the cluster during installation. 

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -79,8 +79,12 @@ add_ons:
   heapster:
     disable: false
     options:
-      heapster_replicas: {{if eq .HeapsterReplicas 0}}2{{else}}{{.HeapsterReplicas}}{{end}}
-      influxdb_pvc_name: {{.HeapsterInfluxdbPVC}}
+      heapster:
+        replicas: {{if eq .HeapsterReplicas 0}}2{{else}}{{.HeapsterReplicas}}{{end}}
+        service_type: ClusterIP
+        sink: influxdb:http://heapster-influxdb.kube-system.svc:8086
+      influxdb:
+        pvc_name: {{.HeapsterInfluxdbPVC}}
   package_manager:
     disable: {{.DisableHelm}}
     provider: helm

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -93,8 +93,14 @@ type ClusterCatalog struct {
 	Heapster struct {
 		Enabled bool
 		Options struct {
-			HeapsterReplicas int    `yaml:"heapster_replicas"`
-			InfluxDBPVCName  string `yaml:"influxdb_pvc_name"`
+			Heapster struct {
+				Replicas    int    `yaml:"replicas"`
+				Sink        string `yaml:"sink"`
+				ServiceType string `yaml:"service_type"`
+			}
+			InfluxDB struct {
+				PVCName string `yaml:"pvc_name"`
+			}
 		}
 	}
 

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -775,8 +775,10 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	// heapster
 	if p.AddOns.HeapsterMonitoring != nil && !p.AddOns.HeapsterMonitoring.Disable {
 		cc.Heapster.Enabled = true
-		cc.Heapster.Options.HeapsterReplicas = p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas
-		cc.Heapster.Options.InfluxDBPVCName = p.AddOns.HeapsterMonitoring.Options.InfluxDBPVCName
+		cc.Heapster.Options.Heapster.Replicas = p.AddOns.HeapsterMonitoring.Options.Heapster.Replicas
+		cc.Heapster.Options.Heapster.ServiceType = p.AddOns.HeapsterMonitoring.Options.Heapster.ServiceType
+		cc.Heapster.Options.Heapster.Sink = p.AddOns.HeapsterMonitoring.Options.Heapster.Sink
+		cc.Heapster.Options.InfluxDB.PVCName = p.AddOns.HeapsterMonitoring.Options.InfluxDB.PVCName
 	}
 	// dashboard
 	cc.Dashboard.Enabled = !p.AddOns.Dashboard.Disable

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -42,8 +42,16 @@ func TestReadWithNil(t *testing.T) {
 		t.Errorf("Expected add_ons.cni.options.calico.mode to equal 'overlay', instead got %s", p.AddOns.CNI.Options.Calico.Mode)
 	}
 
-	if p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas != 2 {
-		t.Errorf("Expected add_ons.heapster.options.heapster_replicas to equal 2, instead got %d", p.AddOns.HeapsterMonitoring.Options.HeapsterReplicas)
+	if p.AddOns.HeapsterMonitoring.Options.Heapster.Replicas != 2 {
+		t.Errorf("Expected add_ons.heapster.options.heapster.replicas to equal 2, instead got %d", p.AddOns.HeapsterMonitoring.Options.Heapster.Replicas)
+	}
+
+	if p.AddOns.HeapsterMonitoring.Options.Heapster.ServiceType != "ClusterIP" {
+		t.Errorf("Expected add_ons.heapster.options.heapster.service_type to equal ClusterIP, instead got %s", p.AddOns.HeapsterMonitoring.Options.Heapster.ServiceType)
+	}
+
+	if p.AddOns.HeapsterMonitoring.Options.Heapster.Sink != "influxdb:http://heapster-influxdb.kube-system.svc:8086" {
+		t.Errorf("Expected add_ons.heapster.options.heapster.service_type to equal 'influxdb:http://heapster-influxdb.kube-system.svc:8086', instead got %s", p.AddOns.HeapsterMonitoring.Options.Heapster.Sink)
 	}
 
 	if p.Cluster.Certificates.CAExpiry != defaultCAExpiry {

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -22,6 +22,10 @@ func CalicoMode() []string {
 	return []string{"overlay", "routed"}
 }
 
+func ServiceTypes() []string {
+	return []string{"ClusterIP", "NodePort", "LoadBalancer", "ExternalName"}
+}
+
 // NetworkConfig describes the cluster's networking configuration
 type NetworkConfig struct {
 	Type             string `yaml:"type,omitempty"`
@@ -209,8 +213,19 @@ type Dashboard struct {
 }
 
 type HeapsterOptions struct {
-	HeapsterReplicas int    `yaml:"heapster_replicas"`
-	InfluxDBPVCName  string `yaml:"influxdb_pvc_name"`
+	Heapster         Heapster `yaml:"heapster"`
+	InfluxDB         InfluxDB `yaml:"influxdb"`
+	HeapsterReplicas int      `yaml:"heapster_replicas,omitempty"`
+	InfluxDBPVCName  string   `yaml:"influxdb_pvc_name,omitempty"`
+}
+
+type Heapster struct {
+	Replicas    int    `yaml:"replicas"`
+	ServiceType string `yaml:"service_type"`
+	Sink        string `yaml:"sink"`
+}
+type InfluxDB struct {
+	PVCName string `yaml:"pvc_name"`
 }
 
 type PackageManager struct {

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -242,8 +242,11 @@ func (n *CNI) validate() (bool, []error) {
 func (h *HeapsterMonitoring) validate() (bool, []error) {
 	v := newValidator()
 	if h != nil && !h.Disable {
-		if h.Options.HeapsterReplicas <= 0 {
+		if h.Options.Heapster.Replicas <= 0 {
 			v.addError(fmt.Errorf("Heapster replicas %d is not valid, must be greater than 0", h.Options.HeapsterReplicas))
+		}
+		if !util.Contains(h.Options.Heapster.ServiceType, ServiceTypes()) {
+			v.addError(fmt.Errorf("Heapster Service Type %q is not a valid option %v", h.Options.Heapster.ServiceType, ServiceTypes()))
 		}
 	}
 	return v.valid()

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -34,7 +34,10 @@ var validPlan = Plan{
 		},
 		HeapsterMonitoring: &HeapsterMonitoring{
 			Options: HeapsterOptions{
-				HeapsterReplicas: 2,
+				Heapster: Heapster{
+					Replicas:    2,
+					ServiceType: "ClusterIP",
+				},
 			},
 		},
 	},
@@ -1091,7 +1094,10 @@ func TestHeapsterAddOn(t *testing.T) {
 		{
 			h: HeapsterMonitoring{
 				Options: HeapsterOptions{
-					HeapsterReplicas: 0,
+					Heapster: Heapster{
+						Replicas:    0,
+						ServiceType: "ClusterIP",
+					},
 				},
 			},
 			valid: false,
@@ -1099,7 +1105,10 @@ func TestHeapsterAddOn(t *testing.T) {
 		{
 			h: HeapsterMonitoring{
 				Options: HeapsterOptions{
-					HeapsterReplicas: -1,
+					Heapster: Heapster{
+						Replicas:    1,
+						ServiceType: "Foo",
+					},
 				},
 			},
 			valid: false,
@@ -1107,7 +1116,21 @@ func TestHeapsterAddOn(t *testing.T) {
 		{
 			h: HeapsterMonitoring{
 				Options: HeapsterOptions{
-					HeapsterReplicas: 1,
+					Heapster: Heapster{
+						Replicas:    -1,
+						ServiceType: "ClusterIP",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			h: HeapsterMonitoring{
+				Options: HeapsterOptions{
+					Heapster: Heapster{
+						Replicas:    1,
+						ServiceType: "ClusterIP",
+					},
 				},
 			},
 			valid: true,


### PR DESCRIPTION
Fixes #648, #649, #650.

Add additional options in heapster add-on
```
add_ons:
  dns:
    disable: false
  heapster:
    disable: false
    options:
      heapster_replicas: 2
      heapster_service_type: ClusterIP   # Specify kubernetes ServiceType; default 'ClusterIP'
      heapster_sink: influxdb:http://heapster-influxdb.kube-system.svc:8086 # Specify the sink to store heapster data; default to a pod running on cluster.
      influxdb_pvc_name: ""              # Provide the name of the persistent volume claim that you will create after installation. If not specified, the data will be stored in ephemeral storage.
```

Added `heapster_service_type` and `heapster_sink`. Both of these are optional and will have defaults if empty.

Another thing to consider is should the options have structs, ie.
```
add_ons:
  dns:
    disable: false
  heapster:
    disable: false
    options:
      heapster:
        replicas: 2
        service_type: ClusterIP
        sink: influxdb:http://heapster-influxdb.kube-system.svc:8086
      influxdb:
        pvc_name:
```

TODO:
- [ ]  Modify provisioner to include these options