### PR TITLE
Add certificates generate command

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: f1e1c7515c49bc69417f943bf7c8dc863edf1b0936bd768db5284244e97ca0d5
-updated: 2017-02-28T16:08:49.881263189-05:00
+updated: 2017-07-25T11:20:54.761474195-04:00
 imports:
 - name: github.com/aws/aws-sdk-go
-  version: 106ddd8e308f1f57a8907b191a4ea94db104b3da
+  version: 40f45e34986ba617a372d1590de273a0ca84a53d
   subpackages:
   - aws
   - aws/awserr
@@ -11,19 +11,19 @@ imports:
   - service/ec2
   - service/efs
   - service/route53
-  - aws/awsutil
   - service/s3
-  - aws/endpoints
+  - internal/shareddefaults
   - aws/client
   - aws/corehandlers
   - aws/credentials/stscreds
   - aws/defaults
+  - aws/endpoints
   - aws/request
+  - aws/awsutil
   - aws/client/metadata
   - aws/signer/v4
   - private/protocol
   - private/protocol/ec2query
-  - private/waiter
   - private/protocol/restjson
   - private/protocol/restxml
   - service/sts
@@ -68,7 +68,7 @@ imports:
 - name: github.com/fatih/color
   version: 87d4004f2ab62d0d255e0a38f1680aa534549fe3
 - name: github.com/go-ini/ini
-  version: c437d20015c2ab6454b7a66a13109ff0fb99e17a
+  version: 3d73f4b845efdf9989fffd4b4e562727744a34ba
 - name: github.com/google/certificate-transparency
   version: 6e5648d13b43cdde25cc8274b87675230ffefbd6
   repo: https://github.com/google/certificate-transparency
@@ -79,15 +79,15 @@ imports:
   - go/asn1
   - go/x509/pkix
 - name: github.com/gosuri/uilive
-  version: d0940d76630b415cbb002ef3e753ca4fddd3c99f
+  version: ac356e6e42cd31fcef8e6aec13ae9ed6fe87713e
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
 - name: github.com/mattn/go-colorable
-  version: 5411d3eea5978e6cdc258b30de592b60df6aba96
+  version: 3fa8c76f9daed4067e4a806fb7e4dc86455c6d6a
 - name: github.com/mattn/go-isatty
-  version: 3a115632dcd687f9c8cd01679c83a06a0e21c1f3
+  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/michaelbironneau/garbler
   version: eaea49f3709333a999768eddd70d24eba599e78d
   subpackages:
@@ -98,7 +98,7 @@ imports:
   version: 63fe23f7434723dc904c901043af07931f293c47
   repo: https://github.com/mreiferson/go-httpclient
 - name: github.com/onsi/ginkgo
-  version: bb93381d543b0e5725244abe752214a110791d01
+  version: 8382b23d18dbaaff8e5f7e83784c53ebb8ec2f47
   subpackages:
   - config
   - internal/codelocation
@@ -110,6 +110,7 @@ imports:
   - reporters
   - reporters/stenographer
   - types
+  - internal/spec_iterator
   - internal/containernode
   - internal/leafnodes
   - internal/spec
@@ -117,7 +118,7 @@ imports:
   - reporters/stenographer/support/go-colorable
   - reporters/stenographer/support/go-isatty
 - name: github.com/onsi/gomega
-  version: c463cd2a8578290d4be7a25cba69de81cf35785e
+  version: c893efa28eb45626cdaa76c9f653b62488858837
   subpackages:
   - internal/assertion
   - internal/asyncassertion
@@ -131,20 +132,18 @@ imports:
   - matchers/support/goraph/node
   - matchers/support/goraph/util
 - name: github.com/packethost/packngo
-  version: 91a3a4f65e3cd6ee66d919b4e7103ae038ce66ff
+  version: 8ff1de745a8a4fdc5323ffd9ac2bc55195ff671e
 - name: github.com/pkg/browser
-  version: 8189194c9f158043d6d45a0b939a47a924ea4b13
+  version: c90ca0c84f15f81c982e32665bffd8d7aac8f097
 - name: github.com/russross/blackfriday
-  version: 5f33e7b7878355cd2b7e6b8eefc48a5472c69f70
-- name: github.com/shurcooL/sanitized_anchor_name
-  version: 1dba4b3954bc059efc3991ec364f9f9a35f597d2
+  version: 067529f716f4c3f5e37c8c95ddd59df1007290ae
 - name: github.com/spf13/cobra
-  version: 92ea23a837e66f46ac9e7d04fa826602b7b0a42d
+  version: 34594c771f2c18301dc152640ad40ece28795373
   subpackages:
   - cobra
   - doc
 - name: github.com/spf13/pflag
-  version: 9ff6c6923cfffbcd502984b8e0c80539a94968b7
+  version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
 - name: golang.org/x/crypto
   version: 1f22c0103821b9390939b6776727195525381532
   subpackages:
@@ -152,10 +151,34 @@ imports:
   - pkcs12
   - curve25519
   - pkcs12/internal/rc2
+- name: golang.org/x/net
+  version: ab5485076ff3407ad2d02db054635913f017b0ed
+  subpackages:
+  - html/charset
+  - html
+  - html/atom
 - name: golang.org/x/sys
-  version: e24f485414aeafb646f6fca458b0bf869c0880a1
+  version: 85d149506305e7abe0aca5ad5ac4b1fce82ccd11
   subpackages:
   - unix
+- name: golang.org/x/text
+  version: 836efe42bb4aa16aaa17b9c155d8813d336ed720
+  subpackages:
+  - encoding
+  - encoding/charmap
+  - encoding/htmlindex
+  - transform
+  - encoding/internal/identifier
+  - encoding/internal
+  - encoding/japanese
+  - encoding/korean
+  - encoding/simplifiedchinese
+  - encoding/traditionalchinese
+  - encoding/unicode
+  - language
+  - internal/utf8internal
+  - runes
+  - internal/tag
 - name: gopkg.in/yaml.v2
-  version: a3f3340b5840cee44f372bddb5880fcbc419b46a
+  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
 testImports: []

--- a/pkg/cli/certificates.go
+++ b/pkg/cli/certificates.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+)
+
+// NewCmdCertificates creates a new certificates command
+func NewCmdCertificates(out io.Writer) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "certificates",
+		Short: "Manage cluster certificates",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(NewCmdGenerate(out))
+
+	return cmd
+}

--- a/pkg/cli/certificates_generate.go
+++ b/pkg/cli/certificates_generate.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/apprenda/kismatic/pkg/install"
+	"github.com/apprenda/kismatic/pkg/util"
+	"github.com/spf13/cobra"
+)
+
+type certificatesGenerateOpts struct {
+	commonName         string
+	validityPeriod     int
+	subjAltNames       []string
+	organizations      []string
+	overwrite          bool
+	generatedAssetsDir string
+}
+
+// NewCmdGenerate creates a new certificates generate command
+func NewCmdGenerate(out io.Writer) *cobra.Command {
+	opts := &certificatesGenerateOpts{}
+
+	cmd := &cobra.Command{
+		Use:   "generate <name> [options]",
+		Short: "Generate a cluster certificate, expects 'ca.pem' and 'ca-key.pem' to be in the --generated-assets-dir",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || args[0] == "" {
+				cmd.Help()
+				return fmt.Errorf("no valid <name> argument provided")
+			}
+			if len(args) != 1 {
+				cmd.Help()
+				return fmt.Errorf("invalid arguments provided: %v", args)
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if opts.validityPeriod <= 0 {
+				cmd.Help()
+				return fmt.Errorf("--validity-period must be greater than 0")
+			}
+			return doCertificatesGenerate(args[0], opts, out)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.commonName, "common-name", "", "override the common name. If left blank, will use <name>")
+	cmd.Flags().IntVar(&opts.validityPeriod, "validity-period", 365, "specify the number of days this certificate should be valid for. Expiration date will be calculated relative to the machine's clock.")
+	cmd.Flags().StringSliceVar(&opts.subjAltNames, "subj-alt-names", []string{}, "comma-separated list of names that should be included in the certificate's subject alternative names field.")
+	cmd.Flags().StringSliceVar(&opts.organizations, "organizations", []string{}, "comma-separated list of names that should be included in the certificate's organization field.")
+	cmd.Flags().BoolVar(&opts.overwrite, "overwrite", false, "overwrite existing certificate if it already exists in the target directory.")
+	cmd.Flags().StringVar(&opts.generatedAssetsDir, "generated-assets-dir", "generated", "path to the directory where assets generated during the installation process will be stored")
+
+	return cmd
+}
+
+func doCertificatesGenerate(name string, opts *certificatesGenerateOpts, out io.Writer) error {
+	ansibleDir := "ansible"
+	certsDir := filepath.Join(opts.generatedAssetsDir, "keys")
+	pki := &install.LocalPKI{
+		CACsr: filepath.Join(ansibleDir, "playbooks", "tls", "ca-csr.json"),
+		GeneratedCertsDirectory: certsDir,
+		Log: out,
+	}
+	ca, err := pki.GetClusterCA()
+	if err != nil {
+		return err
+	}
+	commonName := opts.commonName
+	if commonName == "" {
+		commonName = name
+	}
+	validityPeriod := fmt.Sprintf("%dh", opts.validityPeriod*24)
+	exists, err := pki.GenerateCertificate(name, validityPeriod, commonName, opts.subjAltNames, opts.organizations, ca, opts.overwrite)
+	if err != nil {
+		return err
+	}
+	if exists && !opts.overwrite {
+		util.PrettyPrintWarn(out, "Certficate '%s.pem' already exists in '%s' directory, use --overwrite option", name, opts.generatedAssetsDir)
+	} else {
+		util.PrettyPrintOk(out, "Certficate '%s.pem' created succesfully in '%s' directory", name, opts.generatedAssetsDir)
+	}
+
+	return nil
+}

--- a/pkg/cli/fakes_test.go
+++ b/pkg/cli/fakes_test.go
@@ -112,3 +112,8 @@ func (fp *fakePKI) GenerateClusterCerts(p *install.Plan, ca *tls.CA, users []str
 	fp.called = true
 	return fp.err
 }
+
+func (fp *fakePKI) GenerateCertificate(name string, validityPeriod string, commonName string, subjectAlternateNames []string, organizations []string, ca *tls.CA, overwrite bool) (bool, error) {
+	fp.called = true
+	return false, fp.err
+}

--- a/pkg/cli/kismatic.go
+++ b/pkg/cli/kismatic.go
@@ -29,6 +29,7 @@ more documentation is availble at https://github.com/apprenda/kismatic`,
 	cmd.AddCommand(NewCmdInfo(out))
 	cmd.AddCommand(NewCmdUpgrade(in, out))
 	cmd.AddCommand(NewCmdDiagnostic(out))
+	cmd.AddCommand(NewCmdCertificates(out))
 
 	return cmd, nil
 }

--- a/pkg/install/add_worker_test.go
+++ b/pkg/install/add_worker_test.go
@@ -302,6 +302,9 @@ func (f *fakePKI) GenerateClusterCA(p *Plan) (*tls.CA, error) {
 	return nil, f.err
 }
 func (f *fakePKI) GenerateClusterCertificates(p *Plan, ca *tls.CA) error { return f.err }
+func (f *fakePKI) GenerateCertificate(name string, validityPeriod string, commonName string, subjectAlternateNames []string, organizations []string, ca *tls.CA, overwrite bool) (bool, error) {
+	return false, f.err
+}
 
 type fakeRunner struct {
 	eventChan         chan ansible.Event


### PR DESCRIPTION
Fixes #603

Updated glide dependency versions to pick up cobra changes.

```
➜  out git:(certs-generate) ./kismatic certificates generate --help
Generate a cluster certificate, expects 'ca.pem' and 'ca-key.pem' to be in the --generated-assets-dir

Usage:
  kismatic certificates generate <name> [options] [flags]

Flags:
      --common-name string            override the common name. If left blank, will use <name>
      --generated-assets-dir string   path to the directory where assets generated during the installation process will be stored (default "generated")
  -h, --help                          help for generate
      --organizations stringSlice     comma-separated list of names that should be included in the certificate's organization field.
      --overwrite                     overwrite existing certificate if it already exists in the target directory.
      --subj-alt-names stringSlice    comma-separated list of names that should be included in the certificate's subject alternative names field.
      --validity-period int           specify the number of days this certificate should be valid for. Expiration date will be calculated relative to the machine's clock. (default 365)

===================================================================================================================================================================================================
➜  out git:(master) ✗ ./kismatic certificates generate foo
Certficate "foo".pem created succesfully in "generated"                         [OK]

➜  out git:(master) ✗ ./kismatic certificates generate foo
Certficate "foo".pem already exists in "generated", use --overwrite option      [WARNING]

➜  out git:(master) ✗ ./kismatic certificates generate foo --common-name=foo-cn --organizations=admin,super-admin --subj-alt-names=foo-alt,foo-bar-alt --validity-period=10 --overwrite=true
Certficate "foo".pem created succesfully in "generated"                         [OK]
```
```
➜  keys git:(master) ✗ openssl x509 -in foo.pem -text -noout
Certificate:
    Data:
        Version: 3 (0x2)
        Serial Number:
            55:c1:c1:8f:a4:a0:85:a0:c1:ae:7a:26:fd:9d:e9:d8:f2:d8:93:9b
        Signature Algorithm: sha256WithRSAEncryption
        Issuer: C=US, ST=New York, L=Troy, O=Kubernetes, OU=CA, CN=kubernetes
        Validity
            Not Before: Jul 25 18:13:00 2017 GMT
            Not After : Aug  4 18:13:00 2017 GMT
        Subject: O=admin, O=super-admin, CN=foo-cn
        Subject Public Key Info:
            Public Key Algorithm: rsaEncryption
            RSA Public Key: (2048 bit)
                Modulus (2048 bit):
                Exponent: 65537 (0x10001)
        X509v3 extensions:
            X509v3 Key Usage: critical
                Digital Signature, Key Encipherment
            X509v3 Extended Key Usage:
                TLS Web Server Authentication, TLS Web Client Authentication
            X509v3 Basic Constraints: critical
                CA:FALSE
            X509v3 Subject Key Identifier:
                30:0D:AA:89:99:CC:AC:36:91:FA:9C:04:D9:99:FE:35:82:C3:93:13
            X509v3 Authority Key Identifier:
                keyid:98:CD:B3:30:1D:F7:CE:3F:6F:61:07:22:BC:F3:A8:01:6C:41:E4:B3

            X509v3 Subject Alternative Name:
                DNS:foo-alt, DNS:foo-bar-alt
```