### PR TITLE
Better error messages during online upgrades

### DIFF
--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -265,7 +265,11 @@ func upgradeNodes(in io.Reader, out io.Writer, plan install.Plan, opts upgradeOp
 			util.PrettyPrint(out, "%s %v", node.Node.Host, node.Roles)
 			errs := install.DetectNodeUpgradeSafety(plan, node.Node, kubeClient)
 			if len(errs) != 0 {
-				util.PrintError(out)
+				if opts.ignoreSafetyChecks {
+					util.PrintWarn(out)
+				} else {
+					util.PrintError(out)
+				}
 				fmt.Fprintln(out)
 				for _, err := range errs {
 					fmt.Println("-", err.Error())

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -24,40 +24,40 @@ type etcdNodeCountErr struct{}
 
 func (e etcdNodeCountErr) Error() string {
 	return "This node is part of an etcd cluster that has less than 3 members. " +
-		"Upgrading it will make the cluster unavailable."
+		"Upgrading it may make the cluster unavailable."
 }
 
 type masterNodeCountErr struct{}
 
 func (e masterNodeCountErr) Error() string {
 	return "This is the only master node in the cluster. " +
-		"Upgrading it will make the cluster unavailable."
+		"Upgrading it may make the cluster unavailable."
 }
 
 type masterNodeLoadBalancingErr struct{}
 
 func (e masterNodeLoadBalancingErr) Error() string {
 	return "This node is acting as the load balanced endpoint for the master nodes. " +
-		"Upgrading it will make the cluster unavailable"
+		"Upgrading it may make the cluster unavailable"
 }
 
 type ingressNotSupportedErr struct{}
 
 func (e ingressNotSupportedErr) Error() string {
-	return "Performing an online upgrade of ingress nodes is not supported."
+	return "Upgrading this node may result in storage volumes becoming temporarily unavailable."
 }
 
 type storageNotSupportedErr struct{}
 
 func (e storageNotSupportedErr) Error() string {
-	return "Performing an online upgrade of storage nodes is not supported."
+	return "Upgrading this node may result in service unavailability if clients are accessing services directly through this ingress point."
 }
 
 type workerNodeCountErr struct{}
 
 func (e workerNodeCountErr) Error() string {
 	return "This is the only worker node in the cluster. " +
-		"Upgrading it will make cluster features unavailable."
+		"Upgrading it may make cluster features unavailable."
 }
 
 type podUnsafeVolumeErr struct {
@@ -90,7 +90,7 @@ type podUnsafeDaemonErr struct {
 
 func (e podUnsafeDaemonErr) Error() string {
 	return fmt.Sprintf(`Pod managed by DaemonSet "%s/%s" is running on this node, and no other nodes `+
-		"are capable of hosting this daemon. Upgrading it will make the daemon unavailable.", e.dsNamespace, e.dsName)
+		"are capable of hosting this daemon. Upgrading it may make the daemon unavailable.", e.dsNamespace, e.dsName)
 }
 
 type unmanagedPodErr struct {


### PR DESCRIPTION
Fixes #670 

```
Validate Online Upgrade=============================================================
etcd001 [etcd]                                                                  [WARNING]
- This node is part of an etcd cluster that has less than 3 members. Upgrading it may make the cluster unavailable.
master001 [master]                                                              [WARNING]
- This is the only master node in the cluster. Upgrading it may make the cluster unavailable.
- This node is acting as the load balanced endpoint for the master nodes. Upgrading it may make the cluster unavailable
worker001 [worker ingress storage]                                              [WARNING]
- This is the only worker node in the cluster. Upgrading it may make cluster features unavailable.
- Pod "kube-system/calico-node-nfm61" is using HostPath volume "lib-modules", which is unsafe for upgrades.
- Pod "kube-system/calico-node-nfm61" is using HostPath volume "var-run-calico", which is unsafe for upgrades.
- Pod "kube-system/calico-node-nfm61" is using HostPath volume "cni-bin-dir", which is unsafe for upgrades.
- Pod "kube-system/calico-node-nfm61" is using HostPath volume "cni-net-dir", which is unsafe for upgrades.
- Pod "kube-system/calico-node-nfm61" is using HostPath volume "etcd-certs", which is unsafe for upgrades.
- Pod "kube-system/calico-policy-controller-4277936060-hm2z9" is using HostPath volume "ca", which is unsafe for upgrades.
- Pod "kube-system/calico-policy-controller-4277936060-hm2z9" is using HostPath volume "cert", which is unsafe for upgrades.
- Pod "kube-system/calico-policy-controller-4277936060-hm2z9" is using HostPath volume "key", which is unsafe for upgrades.
- Pod "kube-system/kube-proxy-worker001" is using HostPath volume "ssl-certs", which is unsafe for upgrades.
- Pod "kube-system/kube-proxy-worker001" is using HostPath volume "kubeconfig", which is unsafe for upgrades.
- Pod "kube-system/kube-proxy-worker001" is using HostPath volume "etc-kube-ssl", which is unsafe for upgrades.
- Pod managed by ReplicaSet "kube-system/calico-policy-controller-4277936060" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/calico-policy-controller-4277936060" are running on this node.
- Pod managed by DaemonSet "kube-system/default-http-backend" is running on this node, and no other nodes are capable of hosting this daemon. Upgrading it may make the daemon unavailable.
- Pod managed by DaemonSet "kube-system/gluster-healthz" is running on this node, and no other nodes are capable of hosting this daemon. Upgrading it may make the daemon unavailable.
- Pod managed by ReplicaSet "kube-system/heapster-622576002" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/heapster-622576002" are running on this node.
- Pod managed by ReplicaSet "kube-system/heapster-influxdb-1807514822" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/heapster-influxdb-1807514822" are running on this node.
- Pod managed by DaemonSet "kube-system/ingress" is running on this node, and no other nodes are capable of hosting this daemon. Upgrading it may make the daemon unavailable.
- Pod managed by ReplicaSet "kube-system/kube-dns-3793137827" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/kube-dns-3793137827" are running on this node.
- The pod "kube-system/kube-proxy-worker001" is not being managed by a controller. Upgrading this node might result in data or availability loss.
- Pod managed by ReplicaSet "kube-system/kubernetes-dashboard-4218587249" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/kubernetes-dashboard-4218587249" are running on this node.
- Pod managed by ReplicaSet "kube-system/tiller-deploy-4160234829" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/tiller-deploy-4160234829" are running on this node.
- Performing an upgrade of ingress nodes may cause it to be temporary offline.
- Performing an upgrade of storage nodes may cause it to be temporary offline.

Ignoring safety checks and continuing with the upgrade                          [WARNING]
```