### PR TITLE
Preflight throw up "device" attribute not found

### DIFF
--- a/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
+++ b/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
@@ -14,5 +14,5 @@
   - name: fail if the block device is already mounted
     fail:
       msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
-    with_items: "(( ansible_mounts }}"
+    with_items: "{{ ansible_mounts }}"
     when: item.device == "{{ docker_direct_lvm_block_device_path }}"

--- a/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
+++ b/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
@@ -14,5 +14,5 @@
   - name: fail if the block device is already mounted
     fail:
       msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
-    with_items: ansible_mounts
+    with_items: "(( ansible_mounts }}"
     when: item.device == "{{ docker_direct_lvm_block_device_path }}"


### PR DESCRIPTION
I was facing the following error:
```
Run Cluster Pre-Flight Checks                                                   [ERROR]
- Task: fail if the block device is already mounted
  kubemedium02: The conditional check 'item.device == "{{ docker_direct_lvm_block_device_path }}"' failed. The error was: error while evaluating conditional (item.device == "{{ docker_direct_lvm_block_device_path }}"): 'ansible.vars.unsafe_proxy.AnsibleUnsafeText object' has no attribute 'device'

The error appears to have been in '/home/prateek.agarwal/kismatic-v1.4.1/ansible/playbooks/roles/preflight/tasks/direct_lvm_preflight.yaml': line 19, column 5, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

    with_items: ansible_mounts
  - name: fail if the block device is already mounted
    ^ here
                                                                                [ERROR]
```

Issue was `ansible_mounts` was taken as a literal list and was not expanded.

This patch fixes it.

kismatic version: v1.4.1