### PR TITLE
Increase pod validation timeout, and improve failure message

### DIFF
--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -12,15 +12,36 @@
     register: out
   
   - block:
-    - name: wait until DNS pods are ready
+    - name: wait up to 5 minutes until DNS pods are ready
       command: kubectl get deployment kube-dns -n kube-system -o jsonpath='{.status.availableReplicas}'
       register: readyReplicas
       until: readyReplicas.stdout|int == kube_dns_replicas|int
-      retries: 24
+      retries: 30
       delay: 10
       failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-    - name: fail if any DNS pods are not ready
+    
+    - name: find the DNS pods that failed to start
+      # Get the name and status/phase for all kubedns pods, and then filter out the ones that are not running.
+      # Once we have those, grab the first one, and cut the status/phase out of the output.
+      raw: >
+        kubectl get pods -n kube-system -l k8s-app=kube-dns 
+        --no-headers -o custom-columns=name:{.metadata.name},status:{.status.phase} | grep -v "Running" | head -n 1 | cut -d " " -f 1
+      register: failedDNSPodNames
+      when: readyReplicas.stdout|int != kube_dns_replicas|int
+
+    - name: get the logs of the first DNS pod that did not start up in time
+      command: kubectl logs -c kubedns -n kube-system {{ failedDNSPodNames.stdout_lines[0] }} --tail 15
+      register: failedDNSPodLogs
+      when: "'stdout_lines' in failedDNSPodNames and failedDNSPodNames.stdout_lines|length > 0"
+      
+    - name: fail if DNS pods are not ready
       fail:
-        msg: "Timed out waiting for DNS pods to be in the ready state."
+        msg: | 
+          Waited for all DNS pods to be ready, but they took longer than 5 minutes to be in the ready state.
+          
+          The pod's latest logs may indicate why it failed to start up:
+
+          {{ failedDNSPodLogs.stdout }}
+
       when: readyReplicas.stdout|int != kube_dns_replicas|int
     when: run_pod_validation|bool == true 

--- a/ansible/roles/kube-ingress/tasks/main.yaml
+++ b/ansible/roles/kube-ingress/tasks/main.yaml
@@ -27,15 +27,15 @@
       shell: "kubectl get ds ingress --namespace=kube-system -o=jsonpath='{.status.desiredNumberScheduled}'"
       register: desiredPods
 
-    - name: wait until all ingress controllers pods are ready
+    - name: wait up to 5 minutes until all ingress controllers pods are ready
       command: "kubectl get ds ingress --namespace=kube-system -o=jsonpath='{.status.numberReady}'"
       register: readyPods
       until: desiredPods.stdout|int == readyPods.stdout|int
-      retries: 15
+      retries: 30
       delay: 10
       failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
     - name: fail if any ingress pods are not ready
       fail:
-        msg: "Timed out waiting for all ingress controllers pods to be in the ready state."
+        msg: "Waited for all ingress controller pods to be ready, but they took longer than 5 minutes to be in the ready state."
       when: desiredPods.stdout|int != readyPods.stdout|int
-    when: run_pod_validation|bool == true 
+    when: run_pod_validation|bool == true

--- a/ansible/roles/validate-pod/tasks/validate-pod.yaml
+++ b/ansible/roles/validate-pod/tasks/validate-pod.yaml
@@ -1,18 +1,32 @@
 ---
-    # kubeconfig is required becuase this task can be triggered from any k8s node
-  - name: wait until {{ item }} pod has the desired version
+    # kubeconfig is required because this task can be triggered from any k8s node
+  - name: wait up to 5 min until pod '{{ item }}' has the desired version
     command: kubectl get pods {{ item }} --namespace kube-system -o jsonpath='{.metadata.annotations.kismatic/version}' --kubeconfig {{ kubernetes_kubeconfig_path }}
     register: podVersion
     until: podVersion.stdout == kismatic_short_version
-    retries: 20
-    delay: 6
+    retries: 60
+    delay: 5
+    failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
 
-  - name: wait until {{ item }} pod is running
+  - name: fail if pod '{{ item }}' does not have the desired version
+    fail:
+      msg: |
+        An error occurred getting the pod's version using kubectl.
+        
+        {{ podVersion.stderr }}
+    when: podVersion.stderr != ""
+
+  - name: fail if pod '{{ item }}' does not have the desired version
+    fail:
+      msg: "The pod '{{ item }}' is expected to have version '{{ kismatic_short_version }}', but it has version '{{ podVersion.stdout }}'."
+    when: podVersion.stdout != kismatic_short_version
+
+  - name: wait up to 5 min until pod '{{ item }}' is running
     command: kubectl get pods {{ item }} --namespace kube-system --kubeconfig {{ kubernetes_kubeconfig_path }}
     register: phase
     until: phase|success and "Running" in phase.stdout
-    retries: 20
-    delay: 6
+    retries: 60
+    delay: 5
     failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
 
   - name: get docker container ID for {{ item }}
@@ -20,14 +34,18 @@
     register: containerID
     when: phase|failure or "Running" not in phase.stdout
 
-    #failed_when: true to always print stderr and stdout
   - name: get docker logs for {{ item }}
-    command: docker logs {{ containerID.stdout }}
+    command: docker logs {{ containerID.stdout }} --tail 15
     register: docker_logs
-    failed_when: true
     when: containerID is defined and containerID|success and containerID.stdout is defined and containerID.stdout != ""
 
   - name: fail if {{ item }} pod is not running
     fail:
-      msg: "Timed out waiting for {{ item }} pod to be running."
+      msg: |
+        Waited for pod '{{ item }}' to be running, but it did not start up in time.
+
+        The pod's latest logs may indicate why it failed to start up:
+
+        {{ docker_logs.stderr }}
+
     when: phase|failure or "Running" not in phase.stdout


### PR DESCRIPTION
Fixes #694 

We have seen various instances of pod validation failing because the API server pod takes longer than the original timeout. We have also seen this with the DNS pod.

Also improved the UX when one of these failures happen. This not only improves error messages, but also diagnosability during integration tests:

* When the pod doesn't have the expected version:
```
Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [OK]
Validating SSH connectivity to nodes                                            [OK]

Running Task========================================================================
Validate Kubernetes Control Plane is Running                                    [ERROR]
- Task: fail if pod 'kube-apiserver-ip-10-0-3-130' does not have the desired version
  ip-10-0-3-130: The pod 'kube-apiserver-ip-10-0-3-130' is expected to have version '1.5.0', but it has version '1.5.0-dirty'.[ERROR]
```

* When a pod takes longer than expected to enter the ready state:
```

Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [OK]
Validating SSH connectivity to nodes                                            [OK]

Running Task========================================================================
Validate Kubernetes Control Plane is Running                                    [ERROR]
- Task: fail if kube-apiserver-ip-10-0-3-130 pod is not running
  ip-10-0-3-130: Waited for pod 'kube-apiserver-ip-10-0-3-130' to be running, but it did not start up in time.

The pod's latest logs may indicate why it failed to start up:

I0801 22:59:05.333632       1 wrap.go:42] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.720274ms) 200 [[kube-controller-manager/v1.7.2 (linux/amd64) kubernetes/922a86c/leader-election] 54.211.237.33:33332]
I0801 22:59:05.340609       1 wrap.go:42] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (2.712948ms) 200 [[kube-controller-manager/v1.7.2 (linux/amd64) kubernetes/922a86c/leader-election] 54.211.237.33:33332]
I0801 22:59:05.874497       1 wrap.go:42] GET /api/v1/watch/services?resourceVersion=4267&timeoutSeconds=568: (9m28.003605551s) 200 [[nginx-ingress-controller/v0.0.0 (linux/amd64) kubernetes/$Format] 10.0.3.41:34094]
I0801 22:59:05.878363       1 rbac.go:114] RBAC DENY: user "system:serviceaccount:kube-system:default" groups ["system:serviceaccounts" "system:serviceaccounts:kube-system" "system:authenticated"] cannot "watch" resource "services" cluster-wide
I0801 22:59:05.878610       1 rest.go:349] Starting watch for /api/v1/watch/services, rv=4267 labels= fields= timeout=6m12s
I0801 22:59:06.695118       1 wrap.go:42] GET /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (1.807858ms) 200 [[kube-scheduler/v1.7.2 (linux/amd64) kubernetes/922a86c/leader-election] 54.211.237.33:33318]
I0801 22:59:06.698910       1 wrap.go:42] PUT /api/v1/namespaces/kube-system/endpoints/kube-scheduler: (2.351219ms) 200 [[kube-scheduler/v1.7.2 (linux/amd64) kubernetes/922a86c/leader-election] 54.211.237.33:33318]
I0801 22:59:06.936095       1 wrap.go:42] GET /api/v1/watch/pods?resourceVersion=4565: (10.010573652s) 200 [[python-requests/2.13.0] 54.159.140.140:55516]
I0801 22:59:06.949559       1 rbac.go:114] RBAC DENY: user "system:serviceaccount:kube-system:default" groups ["system:serviceaccounts" "system:serviceaccounts:kube-system" "system:authenticated"] cannot "watch" resource "pods" cluster-wide
I0801 22:59:06.949865       1 rest.go:349] Starting watch for /api/v1/watch/pods, rv=4565 labels= fields= timeout=54m5.954863982s
I0801 22:59:07.344904       1 wrap.go:42] GET /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (1.840436ms) 200 [[kube-controller-manager/v1.7.2 (linux/amd64) kubernetes/922a86c/leader-election] 54.211.237.33:33332]
I0801 22:59:07.348377       1 wrap.go:42] PUT /api/v1/namespaces/kube-system/endpoints/kube-controller-manager: (2.221147ms) 200 [[kube-controller-manager/v1.7.2 (linux/amd64) kubernetes/922a86c/leader-election] 54.211.237.33:33332]
I0801 22:59:07.432024       1 wrap.go:42] GET /api/v1/nodes: (4.497246ms) 200 [[kube-controller-manager/v1.7.2 (linux/amd64) kubernetes/922a86c/system:serviceaccount:kube-system:pod-garbage-collector] 54.211.237.33:33350]
I0801 22:59:07.541130       1 wrap.go:42] GET /apis/extensions/v1beta1/ingresses?resourceVersion=4267&timeoutSeconds=569&watch=true: (9m29.000603971s) 200 [[kube-controller-manager/v1.7.2 (linux/amd64) kubernetes/922a86c/shared-informers] 54.211.237.33:33332]
I0801 22:59:07.542505       1 rest.go:349] Starting watch for /apis/extensions/v1beta1/ingresses, rv=4267 labels= fields= timeout=5m47s
                                                                                [ERROR]
error running playbook: error running ansible: exit status 2
```

* When DNS fails to start up
```
Validating==========================================================================
Reading installation plan file "kismatic-cluster.yaml"                          [OK]
Validating installation plan file                                               [OK]
Validating SSH connectivity to nodes                                            [OK]

Running Task========================================================================
Start Kubernetes DNS                                                            [ERROR]
- Task: fail if DNS pods are not ready
  ip-10-0-3-130: Waited for all DNS pods to be ready, but they took longer than 5 minutes to be in the ready state.

The pod's latest logs may indicate why it failed to start up:

I0801 21:38:55.241950       1 server.go:113] FLAG: --nameservers=""
I0801 21:38:55.241953       1 server.go:113] FLAG: --stderrthreshold="2"
I0801 21:38:55.241955       1 server.go:113] FLAG: --v="2"
I0801 21:38:55.241959       1 server.go:113] FLAG: --version="false"
I0801 21:38:55.241973       1 server.go:113] FLAG: --vmodule=""
I0801 21:38:55.242043       1 server.go:176] Starting SkyDNS server (0.0.0.0:10053)
I0801 21:38:55.242215       1 server.go:200] Skydns metrics not enabled
I0801 21:38:55.242223       1 dns.go:147] Starting endpointsController
I0801 21:38:55.242226       1 dns.go:150] Starting serviceController
I0801 21:38:55.243359       1 logs.go:41] skydns: ready for queries on cluster.local. for tcp://0.0.0.0:10053 [rcache 0]
I0801 21:38:55.243389       1 logs.go:41] skydns: ready for queries on cluster.local. for udp://0.0.0.0:10053 [rcache 0]
I0801 21:38:55.742424       1 dns.go:171] Initialized services and endpoints from apiserver
I0801 21:38:55.742439       1 server.go:129] Setting up Healthz Handler (/readiness)
I0801 21:38:55.742444       1 server.go:134] Setting up cache handler (/cache)
I0801 21:38:55.742448       1 server.go:120] Status HTTP port 8081
                                                                                [ERROR]
error running playbook: error running ansible: exit status 2
```