### PR TITLE
Components on master node should talk to local API

### DIFF
--- a/ansible/roles/kube-controller-manager/templates/kubeconfig.j2
+++ b/ansible/roles/kube-controller-manager/templates/kubeconfig.j2
@@ -4,7 +4,7 @@ clusters:
 - name: {{ kubernetes_cluster_name }}
   cluster:
     certificate-authority: {{ kubernetes_certificates.ca }}
-    server: "{{ kubernetes_master_ip }}" 
+    server: "{% if 'master' in group_names %}{{ local_kubernetes_master_ip }}{% else %}{{ kubernetes_master_ip }}{% endif %}"
 users:
 - name: controller-manager
   user:

--- a/ansible/roles/kube-proxy/templates/kubeconfig.j2
+++ b/ansible/roles/kube-proxy/templates/kubeconfig.j2
@@ -3,7 +3,7 @@ clusters:
 - name: {{ kubernetes_cluster_name }}
   cluster:
     certificate-authority: {{ kubernetes_certificates.ca }}
-    server: "{{ kubernetes_master_ip }}" 
+    server: "{% if 'master' in group_names %}{{ local_kubernetes_master_ip }}{% else %}{{ kubernetes_master_ip }}{% endif %}"
 users:
 - name: kube-proxy
   user:

--- a/ansible/roles/kube-scheduler/templates/kubeconfig.j2
+++ b/ansible/roles/kube-scheduler/templates/kubeconfig.j2
@@ -4,7 +4,7 @@ clusters:
 - name: {{ kubernetes_cluster_name }}
   cluster:
     certificate-authority: {{ kubernetes_certificates.ca }}
-    server: "{{ kubernetes_master_ip }}" 
+    server: "{% if 'master' in group_names %}{{ local_kubernetes_master_ip }}{% else %}{{ kubernetes_master_ip }}{% endif %}"
 users:
 - name: scheduler
   user:

--- a/ansible/roles/kubelet/templates/kubeconfig.j2
+++ b/ansible/roles/kubelet/templates/kubeconfig.j2
@@ -4,7 +4,7 @@ clusters:
 - name: {{ kubernetes_cluster_name }}
   cluster:
     certificate-authority: {{ kubernetes_certificates.ca }}
-    server: "{{ kubernetes_master_ip }}" 
+    server: "{% if 'master' in group_names %}{{ local_kubernetes_master_ip }}{% else %}{{ kubernetes_master_ip }}{% endif %}"
 users:
 - name: kubelet
   user:


### PR DESCRIPTION
Components running on master nodes that require access to the Kubernetes
API server should use the local API server, instead of going out to the
load balanced endpoint.

Fix #703 