### PR TITLE
Deprecate 'dashbard' field in the plan file

### DIFF
--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -786,8 +786,13 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		cc.Heapster.Options.Heapster.Sink = p.AddOns.HeapsterMonitoring.Options.Heapster.Sink
 		cc.Heapster.Options.InfluxDB.PVCName = p.AddOns.HeapsterMonitoring.Options.InfluxDB.PVCName
 	}
+
 	// dashboard
-	cc.Dashboard.Enabled = !p.AddOns.Dashboard.Disable
+	cc.Dashboard.Enabled = true
+	if p.AddOns.Dashboard != nil && p.AddOns.Dashboard.Disable {
+		cc.Dashboard.Enabled = false
+	}
+
 	// package_manager
 	if !p.AddOns.PackageManager.Disable {
 		// Currently only helm is supported

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -103,6 +103,13 @@ func readDeprecatedFields(p *Plan) {
 	if p.Cluster.AllowPackageInstallation != nil {
 		p.Cluster.DisablePackageInstallation = !*p.Cluster.AllowPackageInstallation
 	}
+
+	// Only read the deprecated dashboard field if the new one is not set
+	if p.AddOns.DashboardDeprecated != nil && p.AddOns.Dashboard == nil {
+		p.AddOns.Dashboard = &Dashboard{
+			Disable: p.AddOns.DashboardDeprecated.Disable,
+		}
+	}
 }
 
 func setDefaults(p *Plan) {
@@ -137,6 +144,10 @@ func setDefaults(p *Plan) {
 
 	if p.Cluster.Certificates.CAExpiry == "" {
 		p.Cluster.Certificates.CAExpiry = defaultCAExpiry
+	}
+
+	if p.AddOns.Dashboard == nil {
+		p.AddOns.Dashboard = &Dashboard{}
 	}
 }
 

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -177,11 +177,12 @@ type SSHConnection struct {
 }
 
 type AddOns struct {
-	CNI                *CNI                `yaml:"cni"`
-	DNS                DNS                 `yaml:"dns"`
-	HeapsterMonitoring *HeapsterMonitoring `yaml:"heapster"`
-	Dashboard          Dashboard           `yaml:"dashbard"`
-	PackageManager     PackageManager      `yaml:"package_manager"`
+	CNI                 *CNI                `yaml:"cni"`
+	DNS                 DNS                 `yaml:"dns"`
+	HeapsterMonitoring  *HeapsterMonitoring `yaml:"heapster"`
+	Dashboard           *Dashboard          `yaml:"dashboard"`
+	DashboardDeprecated *Dashboard          `yaml:"dashbard"`
+	PackageManager      PackageManager      `yaml:"package_manager"`
 }
 
 // Features is deprecated, required to support KET v1.3.3


### PR DESCRIPTION
Fixes #707 

Punting on the refactoring of the reading of deprecated / nil fields.