### PR TITLE
Stop defaulting "no ket version file" to 1.0.0

### DIFF
--- a/ansible/roles/update_version/tasks/main.yaml
+++ b/ansible/roles/update_version/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
-  # write version file
   - name: write version file
     template:
       src: kismatic-version.j2
       dest: "/etc/kismatic-version"
+      mode: 0644


### PR DESCRIPTION
Fixes #716, #563 

```
In the initial implementation of KET upgrades, a missing KET version
file would result in KET assuming the node was version 1.0.0. Given that KET no
longer supports upgrades from versions that don't have this file, we can
remove this special case.

Also set permissions on the KET version file marker.
```