### PR TITLE
Remove deprecated fields from plan file.

### DIFF
--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -4,12 +4,10 @@
   * [name](#clustername)
   * [admin_password](#clusteradmin_password)
   * [disable_package_installation](#clusterdisable_package_installation)
-  * [allow_package_installation _(deprecated)_](#clusterallow_package_installation-deprecated)
   * [package_repository_urls](#clusterpackage_repository_urls)
   * [disconnected_installation](#clusterdisconnected_installation)
   * [disable_registry_seeding](#clusterdisable_registry_seeding)
   * [networking](#clusternetworking)
-    * [type _(deprecated)_](#clusternetworkingtype-deprecated)
     * [pod_cidr_block](#clusternetworkingpod_cidr_block)
     * [service_cidr_block](#clusternetworkingservice_cidr_block)
     * [update_hosts_files](#clusternetworkingupdate_hosts_files)
@@ -53,18 +51,11 @@
         * [sink](#add_onsheapsteroptionsheapstersink)
       * [influxdb](#add_onsheapsteroptionsinfluxdb)
         * [pvc_name](#add_onsheapsteroptionsinfluxdbpvc_name)
-      * [heapster_replicas _(deprecated)_](#add_onsheapsteroptionsheapster_replicas-deprecated)
-      * [influxdb_pvc_name _(deprecated)_](#add_onsheapsteroptionsinfluxdb_pvc_name-deprecated)
   * [dashboard](#add_onsdashboard)
     * [disable](#add_onsdashboarddisable)
-  * [dashbard _(deprecated)_](#add_onsdashbard-deprecated)
-    * [disable](#add_onsdashbarddisable)
   * [package_manager](#add_onspackage_manager)
     * [disable](#add_onspackage_managerdisable)
     * [provider](#add_onspackage_managerprovider)
-* [features _(deprecated)_](#features-deprecated)
-  * [package_manager _(deprecated)_](#featurespackage_manager-deprecated)
-    * [enabled _(deprecated)_](#featurespackage_managerenabled-deprecated)
 * [etcd](#etcd)
   * [expected_count](#etcdexpected_count)
   * [nodes](#etcdnodes)
@@ -135,16 +126,6 @@
 | **Required** |  No |
 | **Default** | `false` | 
 
-###  cluster.allow_package_installation _(deprecated)_
-
- Whether KET should install the packages on the cluster nodes. Use DisablePackageInstallation instead. 
-
-| | |
-|----------|-----------------|
-| **Kind** |  bool |
-| **Required** |  No |
-| **Default** | `false` | 
-
 ###  cluster.package_repository_urls
 
  Comma-separated list of URLs of repositories that will be used for fetching the required packages. This is mainly used during a disconnected installation. In this scenario, internal package repositories that contain the KET packages and all their transitive dependencies should be listed here. Example: `http://rpm.apprenda.local:8080` 
@@ -178,17 +159,6 @@
 ###  cluster.networking
 
  The Networking configuration for the cluster. 
-
-###  cluster.networking.type _(deprecated)_
-
- The datapath technique that should be configured in Calico. 
-
-| | |
-|----------|-----------------|
-| **Kind** |  string |
-| **Required** |  No |
-| **Default** | `overlay` | 
-| **Options** |  `overlay`, `routed`
 
 ###  cluster.networking.pod_cidr_block
 
@@ -527,45 +497,11 @@
 | **Required** |  No |
 | **Default** | ` ` | 
 
-###  add_ons.heapster.options.heapster_replicas _(deprecated)_
-
- Number of Heapster replicas that should be scheduled on the cluster. 
-
-| | |
-|----------|-----------------|
-| **Kind** |  int |
-| **Required** |  No |
-| **Default** | ` ` | 
-
-###  add_ons.heapster.options.influxdb_pvc_name _(deprecated)_
-
- Name of the Persistent Volume Claim that will be used by InfluxDB. When set, this PVC must be created after the installation. If not set, InfluxDB will be configured with ephemeral storage. 
-
-| | |
-|----------|-----------------|
-| **Kind** |  string |
-| **Required** |  No |
-| **Default** | ` ` | 
-
 ###  add_ons.dashboard
 
  The Dashboard add-on configuration. 
 
 ###  add_ons.dashboard.disable
-
- Whether the dashboard add-on should be disabled. When set to true, the Kubernetes Dashboard will not be installed on the cluster. 
-
-| | |
-|----------|-----------------|
-| **Kind** |  bool |
-| **Required** |  No |
-| **Default** | `false` | 
-
-###  add_ons.dashbard _(deprecated)_
-
- The Dashboard add-on configuration. 
-
-###  add_ons.dashbard.disable
 
  Whether the dashboard add-on should be disabled. When set to true, the Kubernetes Dashboard will not be installed on the cluster. 
 
@@ -599,24 +535,6 @@
 | **Required** |  Yes |
 | **Default** | ` ` | 
 | **Options** |  `helm`
-
-##  features _(deprecated)_
-
- Feature configuration 
-
-###  features.package_manager _(deprecated)_
-
- The PackageManager feature configuration. 
-
-###  features.package_manager.enabled _(deprecated)_
-
- Whether the package manager add-on should be enabled. 
-
-| | |
-|----------|-----------------|
-| **Kind** |  bool |
-| **Required** |  No |
-| **Default** | `false` | 
 
 ##  etcd
 

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -42,9 +42,6 @@ type Plan struct {
 	DockerRegistry DockerRegistry `yaml:"docker_registry"`
 	// Add on configuration
 	AddOns AddOns `yaml:"add_ons"`
-	// Feature configuration
-	// +deprecated
-	Features *Features `yaml:"features,omitempty"`
 	// Etcd nodes of the cluster
 	// +required
 	Etcd NodeGroup
@@ -75,10 +72,6 @@ type Cluster struct {
 	// When true, KET will not install the required packages.
 	// Instead, it will verify that the packages have been installed by the operator.
 	DisablePackageInstallation bool `yaml:"disable_package_installation"`
-	// Whether KET should install the packages on the cluster nodes.
-	// Use DisablePackageInstallation instead.
-	// +deprecated
-	AllowPackageInstallation *bool `yaml:"allow_package_installation,omitempty"`
 	// Comma-separated list of URLs of repositories that will
 	// be used for fetching the required packages. This is mainly used during a
 	// disconnected installation. In this scenario, internal package repositories
@@ -109,11 +102,6 @@ type Cluster struct {
 
 // NetworkConfig describes the cluster's networking configuration
 type NetworkConfig struct {
-	// The datapath technique that should be configured in Calico.
-	// +default=overlay
-	// +options=overlay,routed
-	// +deprecated
-	Type string `yaml:"type,omitempty"`
 	// The pod network's CIDR block. For example: `172.16.0.0/16`
 	// +required
 	PodCIDRBlock string `yaml:"pod_cidr_block"`
@@ -217,19 +205,8 @@ type AddOns struct {
 	HeapsterMonitoring *HeapsterMonitoring `yaml:"heapster"`
 	// The Dashboard add-on configuration.
 	Dashboard *Dashboard `yaml:"dashboard"`
-	// The Dashboard add-on configuration.
-	// +deprecated
-	DashboardDeprecated *Dashboard `yaml:"dashbard,omitempty"`
 	// The PackageManager add-on configuration.
 	PackageManager PackageManager `yaml:"package_manager"`
-}
-
-// Features configuration
-// +deprecated
-type Features struct {
-	// The PackageManager feature configuration.
-	// +deprecated
-	PackageManager *DeprecatedPackageManager `yaml:"package_manager,omitempty"`
 }
 
 // CNI add-on configuration
@@ -284,14 +261,6 @@ type HeapsterOptions struct {
 	Heapster Heapster `yaml:"heapster"`
 	// The InfluxDB configuration options.
 	InfluxDB InfluxDB `yaml:"influxdb"`
-	// Number of Heapster replicas that should be scheduled on the cluster.
-	// +deprecated
-	HeapsterReplicas int `yaml:"heapster_replicas,omitempty"`
-	// Name of the Persistent Volume Claim that will be used by InfluxDB.
-	// When set, this PVC must be created after the installation.
-	// If not set, InfluxDB will be configured with ephemeral storage.
-	// +deprecated
-	InfluxDBPVCName string `yaml:"influxdb_pvc_name,omitempty"`
 }
 
 // Heapster configuration options for the Heapster add-on
@@ -334,12 +303,6 @@ type PackageManager struct {
 	// +required
 	// +options=helm
 	Provider string
-}
-
-type DeprecatedPackageManager struct {
-	// Whether the package manager add-on should be enabled.
-	// +deprecated
-	Enabled bool
 }
 
 // MasterNodeGroup is the collection of master nodes

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -243,7 +243,7 @@ func (h *HeapsterMonitoring) validate() (bool, []error) {
 	v := newValidator()
 	if h != nil && !h.Disable {
 		if h.Options.Heapster.Replicas <= 0 {
-			v.addError(fmt.Errorf("Heapster replicas %d is not valid, must be greater than 0", h.Options.HeapsterReplicas))
+			v.addError(fmt.Errorf("Heapster replicas %d is not valid, must be greater than 0", h.Options.Heapster.Replicas))
 		}
 		if !util.Contains(h.Options.Heapster.ServiceType, serviceTypes()) {
 			v.addError(fmt.Errorf("Heapster Service Type %q is not a valid option %v", h.Options.Heapster.ServiceType, serviceTypes()))

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -10,7 +10,6 @@ var validPlan = Plan{
 		Name:          "test",
 		AdminPassword: "password",
 		Networking: NetworkConfig{
-			Type:             "overlay",
 			PodCIDRBlock:     "172.16.0.0/16",
 			ServiceCIDRBlock: "172.20.0.0/16",
 		},


### PR DESCRIPTION
```
Remove deprecated fields, and code for handling/testing deprecated
fields.

Also made the plan file unmarshalling fail if any unknown field is
provided in the YAML file. This will prevent mis-configuration and also
let the user know when their plan file is outdated.
```