### PR TITLE
Disable preflight check for rpcbind.socket port 111

### DIFF
--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -380,13 +380,14 @@ const defaultRuleSet = `---
   timeout: 5s
 
 # Ports required for NFS
-- kind: TCPPortAvailable
-  when: ["storage"]
-  port: 111
-- kind: TCPPortAccessible
-  when: ["storage"]
-  port: 111
-  timeout: 5s
+# Removed due to https://github.com/apprenda/kismatic/issues/784
+#- kind: TCPPortAvailable
+#  when: ["storage"]
+#  port: 111
+#- kind: TCPPortAccessible
+#  when: ["storage"]
+#  port: 111
+#  timeout: 5s
 - kind: TCPPortAvailable
   when: ["storage"]
   port: 2049


### PR DESCRIPTION
Fixes #784 

Disable the checks for port 111 in the preflight, until we have a better method of checking if ports are used by the expected service.