### PR TITLE
Add node labels option in the plan file to label nodes

### DIFF
--- a/ansible/_label-nodes.yaml
+++ b/ansible/_label-nodes.yaml
@@ -1,0 +1,13 @@
+---
+  - hosts: master:worker:ingress:storage
+    any_errors_fatal: true
+    name: Label Kubernetes Nodes 
+    serial: "{{ serial_count | default('100%') }}"
+    become: yes
+    vars_files:
+      - group_vars/all.yaml
+      
+    tasks:
+      - name: label nodes
+        command: kubectl label --overwrite nodes --selector kismatic/host={{ inventory_hostname }} --kubeconfig {{ kubernetes_kubeconfig_path }} {{ node_labels[inventory_hostname] | join(" ") }}
+        when: node_labels[inventory_hostname] is defined and node_labels[inventory_hostname]|length > 0

--- a/ansible/kubernetes-worker.yaml
+++ b/ansible/kubernetes-worker.yaml
@@ -9,6 +9,7 @@
   - include: _docker.yaml
   - include: _kubelet.yaml
   - include: _kube-proxy.yaml
+  - include: _label-nodes.yaml
   - include: _cni.yaml
     when: cni.enabled|bool == true
   - include: _calico.yaml

--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -24,6 +24,7 @@
   # kubelet does not have an API yet to retrieve the status of a DS pod
   # after installing kube-proxy, there is a dependecy on the API server to validate the static pod
   - include: _kube-proxy.yaml
+  - include: _label-nodes.yaml
   - include: _cni.yaml
     when: cni.enabled|bool == true
   - include: _calico.yaml

--- a/ansible/roles/kubelet/templates/kubelet.service
+++ b/ansible/roles/kubelet/templates/kubelet.service
@@ -21,7 +21,7 @@ ExecStart=/usr/bin/kubelet \
   --hostname-override={{ inventory_hostname }} \
   --require-kubeconfig=true \
   --kubeconfig={{ kubernetes_kubeconfig.kubelet }} \
-  --node-labels=kismatic/host={{ inventory_hostname }},kismatic/cni-provider={{ cni.provider|default("")}}{% if 'ingress' in group_names%},kismatic/ingress=true{% endif %}{% if 'storage' in group_names%},kismatic/storage=true{% endif %}{% if inventory_hostname in groups['master'] %},node-role.kubernetes.io/master={% endif %} \
+  --node-labels=kismatic/host={{ inventory_hostname }},kismatic/cni-provider={{ cni.provider|default("")}}{% if 'ingress' in group_names%},kismatic/ingress=true{% endif %}{% if 'storage' in group_names%},kismatic/storage=true{% endif %}{% if 'master' in group_names %},node-role.kubernetes.io/master={% endif %} \
   --node-ip={{ internal_ipv4 }} \
   --pod-infra-container-image={{ pause_img }} \
   --pod-manifest-path={{ kubelet_pod_manifests_dir }} \

--- a/ansible/roles/validate-pod/tasks/validate-pod.yaml
+++ b/ansible/roles/validate-pod/tasks/validate-pod.yaml
@@ -39,7 +39,7 @@
     register: docker_logs
     when: containerID is defined and containerID|success and containerID.stdout is defined and containerID.stdout != ""
 
-  - name: fail if pod '{{ name }}'
+  - name: fail if pod '{{ name }}' is not running
     fail:
       msg: |
         Waited for pod '{{ name }}' to be running, but it did not start up in time.

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -33,6 +33,7 @@
   - include: _validate-control-plane-node.yaml serial_count="1" upgrading=true
   - include: _kube-proxy-stop.yaml play_name="Upgrade Kubernetes Proxy" upgrading=true
   - include: _kube-proxy.yaml play_name="Upgrade Kubernetes Proxy" upgrading=true
+  - include: _label-nodes.yaml
   - include: _cni.yaml play_name="Upgrade Kubernetes CNI" upgrading=true
     when: cni.enabled|bool == true
   - include: _calico.yaml play_name="Upgrade Calico Cluster Network" upgrading=true

--- a/cmd/gen-kismatic-ref-docs/main.go
+++ b/cmd/gen-kismatic-ref-docs/main.go
@@ -133,6 +133,13 @@ func docForType(typeName string, allTypes []*godoc.Type, parentFieldName string)
 						if isStruct(typeName) {
 							docs = append(docs, docForType(typeName, allTypes, fieldName)...)
 						}
+					case *ast.MapType:
+						typeName = fmt.Sprintf("map[%s]%s", x.Key.(*ast.Ident).Name, x.Value.(*ast.Ident).Name)
+						d, err := parseDoc(fieldName, typeName, f.Doc.Text())
+						if err != nil {
+							panic(err)
+						}
+						docs = append(docs, d)
 					default:
 						panic(fmt.Sprintf("unhandled typespec type: %q", reflect.TypeOf(x).Name()))
 					}
@@ -198,7 +205,8 @@ func isStruct(s string) bool {
 
 // not a comprehensive list, but works for now...
 var basicTypes = map[string]bool{
-	"bool":   true,
-	"int":    true,
-	"string": true,
+	"bool":              true,
+	"int":               true,
+	"string":            true,
+	"map[string]string": true,
 }

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -76,6 +76,7 @@
     * [host](#etcdnodeshost)
     * [ip](#etcdnodesip)
     * [internalip](#etcdnodesinternalip)
+    * [labels](#etcdnodeslabels)
 * [master](#master)
   * [expected_count](#masterexpected_count)
   * [load_balanced_fqdn](#masterload_balanced_fqdn)
@@ -84,24 +85,28 @@
     * [host](#masternodeshost)
     * [ip](#masternodesip)
     * [internalip](#masternodesinternalip)
+    * [labels](#masternodeslabels)
 * [worker](#worker)
   * [expected_count](#workerexpected_count)
   * [nodes](#workernodes)
     * [host](#workernodeshost)
     * [ip](#workernodesip)
     * [internalip](#workernodesinternalip)
+    * [labels](#workernodeslabels)
 * [ingress](#ingress)
   * [expected_count](#ingressexpected_count)
   * [nodes](#ingressnodes)
     * [host](#ingressnodeshost)
     * [ip](#ingressnodesip)
     * [internalip](#ingressnodesinternalip)
+    * [labels](#ingressnodeslabels)
 * [storage](#storage)
   * [expected_count](#storageexpected_count)
   * [nodes](#storagenodes)
     * [host](#storagenodeshost)
     * [ip](#storagenodesip)
     * [internalip](#storagenodesinternalip)
+    * [labels](#storagenodeslabels)
 * [nfs](#nfs)
   * [nfs_volume](#nfsnfs_volume)
     * [nfs_host](#nfsnfs_volumenfs_host)
@@ -717,6 +722,16 @@
 | **Required** |  No |
 | **Default** | ` ` | 
 
+###  etcd.nodes.labels
+
+ Labels to add when installing the node in the cluster. If a node is defined under multiple roles, the labels for that node will be merged. If a label is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. It is recommended to use reverse-DNS notation to avoid collision with other labels. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  map[string]string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
 ##  master
 
  Master nodes of the cluster 
@@ -785,6 +800,16 @@
 | **Required** |  No |
 | **Default** | ` ` | 
 
+###  master.nodes.labels
+
+ Labels to add when installing the node in the cluster. If a node is defined under multiple roles, the labels for that node will be merged. If a label is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. It is recommended to use reverse-DNS notation to avoid collision with other labels. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  map[string]string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
 ##  worker
 
  Worker nodes of the cluster 
@@ -830,6 +855,16 @@
 | | |
 |----------|-----------------|
 | **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  worker.nodes.labels
+
+ Labels to add when installing the node in the cluster. If a node is defined under multiple roles, the labels for that node will be merged. If a label is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. It is recommended to use reverse-DNS notation to avoid collision with other labels. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  map[string]string |
 | **Required** |  No |
 | **Default** | ` ` | 
 
@@ -881,6 +916,16 @@
 | **Required** |  No |
 | **Default** | ` ` | 
 
+###  ingress.nodes.labels
+
+ Labels to add when installing the node in the cluster. If a node is defined under multiple roles, the labels for that node will be merged. If a label is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. It is recommended to use reverse-DNS notation to avoid collision with other labels. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  map[string]string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
 ##  storage
 
  Storage nodes of the cluster. 
@@ -926,6 +971,16 @@
 | | |
 |----------|-----------------|
 | **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  storage.nodes.labels
+
+ Labels to add when installing the node in the cluster. If a node is defined under multiple roles, the labels for that node will be merged. If a label is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. It is recommended to use reverse-DNS notation to avoid collision with other labels. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  map[string]string |
 | **Required** |  No |
 | **Default** | ` ` | 
 

--- a/integration/add_worker.go
+++ b/integration/add_worker.go
@@ -9,9 +9,12 @@ import (
 	. "github.com/onsi/ginkgo"
 )
 
-func addWorkerToCluster(newWorker NodeDeets, sshKey string) error {
+func addWorkerToCluster(newWorker NodeDeets, sshKey string, labels []string) error {
 	By("Adding new worker")
 	cmd := exec.Command("./kismatic", "install", "add-worker", "-f", "kismatic-testing.yaml", newWorker.Hostname, newWorker.PublicIP, newWorker.PrivateIP)
+	if len(labels) > 0 {
+		cmd.Args = append(cmd.Args, "--labels", strings.Join(labels, ","))
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {

--- a/integration/hosts_file_test.go
+++ b/integration/hosts_file_test.go
@@ -51,7 +51,7 @@ var _ = Describe("hosts file modification feature", func() {
 				FailIfError(err)
 
 				By("Adding a worker with a bogus hostname that is added to hosts files")
-				err = addWorkerToCluster(nodes.worker[3], sshKey)
+				err = addWorkerToCluster(nodes.worker[3], sshKey, []string{})
 				FailIfError(err)
 			})
 		})

--- a/integration/install_test.go
+++ b/integration/install_test.go
@@ -234,7 +234,7 @@ var _ = Describe("kismatic", func() {
 
 						sub.It("should allow adding a worker node", func() error {
 							newWorker := allWorkers[len(allWorkers)-1]
-							return addWorkerToCluster(newWorker, sshKey)
+							return addWorkerToCluster(newWorker, sshKey, []string{"com.integrationtest/worker=true"})
 						})
 
 						sub.It("should be able to deploy a workload with ingress", func() error {
@@ -256,6 +256,10 @@ var _ = Describe("kismatic", func() {
 
 						sub.It("should have tiller running", func() error {
 							return verifyTiller(nodes.master[0], sshKey)
+						})
+
+						sub.It("nodes should contain expected labels", func() error {
+							return containsLabels(nodes, sshKey)
 						})
 					})
 				})
@@ -284,7 +288,7 @@ var _ = Describe("kismatic", func() {
 
 						sub.It("should allow adding a worker node", func() error {
 							newWorker := allWorkers[len(allWorkers)-1]
-							return addWorkerToCluster(newWorker, sshKey)
+							return addWorkerToCluster(newWorker, sshKey, []string{"com.integrationtest/worker=true"})
 						})
 
 						sub.It("should be able to deploy a workload with ingress", func() error {
@@ -306,6 +310,10 @@ var _ = Describe("kismatic", func() {
 
 						sub.It("should have tiller running", func() error {
 							return verifyTiller(nodes.master[0], sshKey)
+						})
+
+						sub.It("nodes should contain expected labels", func() error {
+							return containsLabels(nodes, sshKey)
 						})
 					})
 				})
@@ -334,7 +342,7 @@ var _ = Describe("kismatic", func() {
 
 		// 				sub.It("should allow adding a worker node", func() error {
 		// 					newWorker := allWorkers[len(allWorkers)-1]
-		// 					return addWorkerToCluster(newWorker, sshKey)
+		// 					return addWorkerToCluster(newWorker, sshKey, []string{})
 		// 				})
 
 		// 				// This test is flaky with contiv

--- a/integration/labels.go
+++ b/integration/labels.go
@@ -1,0 +1,40 @@
+package integration
+
+import (
+	"fmt"
+	"time"
+)
+
+func containsLabels(nodes provisionedNodes, sshKey string) error {
+	// labels were hardcoded in th plan pattern
+	tests := []struct {
+		nodes []NodeDeets
+		label string
+	}{
+		{
+			nodes: nodes.master,
+			label: "com.integrationtest/master:true",
+		},
+		{
+			nodes: nodes.worker,
+			label: "com.integrationtest/worker:true",
+		},
+		{
+			nodes: nodes.ingress,
+			label: "com.integrationtest/ingress:true",
+		},
+		{
+			nodes: nodes.storage,
+			label: "com.integrationtest/storage:true",
+		},
+	}
+	for _, role := range tests {
+		for _, n := range role.nodes {
+			if err := runViaSSH([]string{fmt.Sprintf("sudo kubectl get nodes %s -o jsonpath='{.metadata.labels}' | grep %q", n.Hostname, role.label)}, []NodeDeets{nodes.master[0]}, sshKey, 1*time.Minute); err != nil {
+				return fmt.Errorf("error validating node %q label: %v", n.Hostname, err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -108,7 +108,9 @@ master:
   nodes:{{range .Master}}
   - host: {{.Hostname}}
     ip: {{.PublicIP}}
-    internalip: {{.PrivateIP}}{{end}}
+    internalip: {{.PrivateIP}}
+    labels:
+      com.integrationtest/master: true{{end}}
   load_balanced_fqdn: {{.MasterNodeFQDN}}
   load_balanced_short_name: {{.MasterNodeShortName}}
 worker:
@@ -116,19 +118,25 @@ worker:
   nodes:{{range .Worker}}
   - host: {{.Hostname}}
     ip: {{.PublicIP}}
-    internalip: {{.PrivateIP}}{{end}}
+    internalip: {{.PrivateIP}}
+    labels:
+      com.integrationtest/worker: true{{end}}
 ingress:
   expected_count: {{len .Ingress}}
   nodes:{{range .Ingress}}
   - host: {{.Hostname}}
     ip: {{.PublicIP}}
-    internalip: {{.PrivateIP}}{{end}}
+    internalip: {{.PrivateIP}}
+    labels:
+      com.integrationtest/ingress: true{{end}}
 storage:
   expected_count: {{len .Storage}}
   nodes:{{range .Storage}}
   - host: {{.Hostname}}
     ip: {{.PublicIP}}
-    internalip: {{.PrivateIP}}{{end}}
+    internalip: {{.PrivateIP}}
+    labels:
+      com.integrationtest/storage: true{{end}}
 nfs:
   nfs_volume:{{range .NFSVolume}}
   - nfs_host: {{.Host}}

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Upgrade", func() {
 
 						sub.It("should allow adding a worker node", func() error {
 							newWorker := allWorkers[len(allWorkers)-1]
-							return addWorkerToCluster(newWorker, sshKey)
+							return addWorkerToCluster(newWorker, sshKey, []string{})
 						})
 
 						sub.It("should be able to deploy a workload with ingress", func() error {
@@ -248,7 +248,7 @@ var _ = Describe("Upgrade", func() {
 
 						sub.It("should allow adding a worker node", func() error {
 							newWorker := allWorkers[len(allWorkers)-1]
-							return addWorkerToCluster(newWorker, sshKey)
+							return addWorkerToCluster(newWorker, sshKey, []string{})
 						})
 
 						sub.It("should be able to deploy a workload with ingress", func() error {

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -121,6 +121,8 @@ type ClusterCatalog struct {
 	HTTPProxy  string `yaml:"http_proxy"`
 	HTTPSProxy string `yaml:"https_proxy"`
 	NoProxy    string `yaml:"no_proxy"`
+
+	NodeLabels map[string][]string `yaml:"node_labels"`
 }
 
 type NFSVolume struct {

--- a/pkg/cli/info.go
+++ b/pkg/cli/info.go
@@ -46,6 +46,12 @@ func list(out io.Writer, opts *infoOpts) error {
 		return fmt.Errorf("error reading plan file: %v", err)
 	}
 
+	// Validate just the nodes
+	if ok, errs := install.ValidateNodes(plan.GetUniqueNodes()); !ok {
+		util.PrintValidationErrors(out, errs)
+		return fmt.Errorf("error validating nodes")
+	}
+
 	// Validate SSH connections
 	if ok, errs := install.ValidatePlanSSHConnections(plan); !ok {
 		util.PrintValidationErrors(out, errs)

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -349,13 +349,13 @@ func upgradeNodes(in io.Reader, out io.Writer, plan install.Plan, opts upgradeOp
 		// upgrade unsafe nodes when --ignoreSafetyChecks
 		if !opts.ignoreSafetyChecks {
 			for _, unsafe := range unsafeNodes {
-				if unsafe.Node == n.Node {
+				if unsafe.Node.Equal(n.Node) {
 					upgrade = false
 				}
 			}
 		}
 		for _, unready := range unreadyNodes {
-			if unready.Node == n.Node {
+			if unready.Node.Equal(n.Node) {
 				upgrade = false
 			}
 		}

--- a/pkg/install/add_worker_test.go
+++ b/pkg/install/add_worker_test.go
@@ -122,7 +122,7 @@ func TestAddWorkerPlanIsUpdated(t *testing.T) {
 	}
 	found := false
 	for _, w := range updatedPlan.Worker.Nodes {
-		if w.Host == newWorker.Host {
+		if w.Equal(newWorker) {
 			found = true
 		}
 	}

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -787,6 +787,18 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		}
 	}
 
+	// merge node labels
+	// cannot use inventory file because nodes share roles
+	// set it to a map[host][]key=value
+	cc.NodeLabels = make(map[string][]string)
+	for _, n := range p.getAllNodes() {
+		if val, ok := cc.NodeLabels[n.Host]; ok {
+			cc.NodeLabels[n.Host] = append(val, keyValueList(n.Labels)...)
+		} else {
+			cc.NodeLabels[n.Host] = keyValueList(n.Labels)
+		}
+	}
+
 	return &cc, nil
 }
 
@@ -932,4 +944,13 @@ func timestampWriter(out io.Writer) io.Writer {
 		}
 	}(pr)
 	return pw
+}
+
+// key=value slice
+func keyValueList(in map[string]string) []string {
+	pairs := make([]string, 0, len(in))
+	for k, v := range in {
+		pairs = append(pairs, fmt.Sprintf("%s=%s", k, v))
+	}
+	return pairs
 }

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -474,6 +474,7 @@ type SSHConnection struct {
 
 // GetUniqueNodes returns a list of the unique nodes that are listed in the plan file.
 // That is, if a node has multiple roles, it will only appear once in the list.
+// Nodes are considered unique if the combination of 'host', 'IP' or 'internalIP' is unique to all other nodes.
 func (p *Plan) GetUniqueNodes() []Node {
 	seenNodes := map[string]bool{}
 	nodes := []Node{}

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -412,6 +412,22 @@ type Node struct {
 	// The internal (or private) IP address of the node.
 	// If set, this IP will be used when configuring cluster components.
 	InternalIP string
+	// Labels to add when installing the node in the cluster.
+	// If a node is defined under multiple roles, the labels for that node will be merged.
+	// If a label is repeated for the same node,
+	// only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence.
+	// It is recommended to use reverse-DNS notation to avoid collision with other labels.
+	Labels map[string]string
+}
+
+// Equal returns true of 2 nodes have the same host, IP and InternalIP
+func (node Node) Equal(other Node) bool {
+	return node.Host == other.Host && node.IP == other.IP && node.InternalIP == other.InternalIP
+}
+
+// HashCode is crude implementation for the Node struct
+func (node Node) HashCode() string {
+	return fmt.Sprint(node.Host, node.IP, node.InternalIP)
 }
 
 type NFS struct {
@@ -459,14 +475,16 @@ type SSHConnection struct {
 // GetUniqueNodes returns a list of the unique nodes that are listed in the plan file.
 // That is, if a node has multiple roles, it will only appear once in the list.
 func (p *Plan) GetUniqueNodes() []Node {
-	seenNodes := map[Node]bool{}
+	seenNodes := map[string]bool{}
 	nodes := []Node{}
 	for _, node := range p.getAllNodes() {
-		if seenNodes[node] {
+		// Cannot use the Node struct directly as it contains a map
+		key := node.HashCode()
+		if seenNodes[key] {
 			continue
 		}
 		nodes = append(nodes, node)
-		seenNodes[node] = true
+		seenNodes[key] = true
 	}
 	return nodes
 }

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -168,12 +168,15 @@ etcd:
     # If the node has an IP for internal traffic, enter it here.
     # Otherwise leave blank.
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 
 # Here you will identify all of the nodes that should play the master role.
 master:
@@ -190,9 +193,11 @@ master:
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 
 # Here you will identify all of the nodes that will be workers.
 worker:
@@ -201,30 +206,37 @@ worker:
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 ingress:
   expected_count: 2
   nodes:
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 storage:
   expected_count: 2
   nodes:
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 
 # A set of NFS volumes for use by on-cluster persistent workloads
 nfs:

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -168,12 +168,15 @@ etcd:
     # If the node has an IP for internal traffic, enter it here.
     # Otherwise leave blank.
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 
 # Here you will identify all of the nodes that should play the master role.
 master:
@@ -190,9 +193,11 @@ master:
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 
 # Here you will identify all of the nodes that will be workers.
 worker:
@@ -201,21 +206,26 @@ worker:
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 ingress:
   expected_count: 2
   nodes:
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
   - host: ""
     ip: ""
     internalip: ""
+    labels: {}
 storage:
   expected_count: 0
   nodes: []

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -1265,3 +1265,112 @@ func TestCloudProvider(t *testing.T) {
 		}
 	}
 }
+
+func TestNodeLabels(t *testing.T) {
+	tests := []struct {
+		n     Node
+		valid bool
+	}{
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"com.foo/bar": ""},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"com.foo/bar": "foobar"},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"com.foo/bar": "foobar", "com.foo/xyz": "xyz"},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"kismatic/foo": "bar"},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"com.foo/kismatic-version": "v1.0.0"},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"": "com.foo/worker"},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"": ""},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"node-type:test": "test"},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"com.foo/invalid": ":test"},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Labels: map[string]string{"node-type:test": ":test"},
+			},
+			valid: false,
+		},
+	}
+	for i, test := range tests {
+		ok, _ := test.n.validate()
+		if ok != test.valid {
+			t.Errorf("test %d: expect %t, but got %t", i, test.valid, ok)
+		}
+	}
+}

--- a/pkg/validation/validation.go
+++ b/pkg/validation/validation.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const qnameCharFmt string = "[A-Za-z0-9]"
+const qnameExtCharFmt string = "[-A-Za-z0-9_.]"
+const qualifiedNameFmt string = "(" + qnameCharFmt + qnameExtCharFmt + "*)?" + qnameCharFmt
+const qualifiedNameErrMsg string = "must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+const qualifiedNameMaxLength int = 63
+
+var qualifiedNameRegexp = regexp.MustCompile("^" + qualifiedNameFmt + "$")
+
+// IsQualifiedName tests whether the value passed is what Kubernetes calls a
+// "qualified name".  This is a format used in various places throughout the
+// system.  If the value is not valid, a list of error strings is returned.
+// Otherwise an empty list (or nil) is returned.
+func IsQualifiedName(value string) []string {
+	var errs []string
+	parts := strings.Split(value, "/")
+	var name string
+	switch len(parts) {
+	case 1:
+		name = parts[0]
+	case 2:
+		var prefix string
+		prefix, name = parts[0], parts[1]
+		if len(prefix) == 0 {
+			errs = append(errs, "prefix part "+EmptyError())
+		} else if msgs := IsDNS1123Subdomain(prefix); len(msgs) != 0 {
+			errs = append(errs, prefixEach(msgs, "prefix part ")...)
+		}
+	default:
+		return append(errs, "a qualified name "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc")+
+			" with an optional DNS subdomain prefix and '/' (e.g. 'example.com/MyName')")
+	}
+
+	if len(name) == 0 {
+		errs = append(errs, "name part "+EmptyError())
+	} else if len(name) > qualifiedNameMaxLength {
+		errs = append(errs, "name part "+MaxLenError(qualifiedNameMaxLength))
+	}
+	if !qualifiedNameRegexp.MatchString(name) {
+		errs = append(errs, "name part "+RegexError(qualifiedNameErrMsg, qualifiedNameFmt, "MyName", "my.name", "123-abc"))
+	}
+	return errs
+}
+
+const labelValueFmt string = "(" + qualifiedNameFmt + ")?"
+const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+const LabelValueMaxLength int = 63
+
+var labelValueRegexp = regexp.MustCompile("^" + labelValueFmt + "$")
+
+// IsValidLabelValue tests whether the value passed is a valid label value.  If
+// the value is not valid, a list of error strings is returned.  Otherwise an
+// empty list (or nil) is returned.
+func IsValidLabelValue(value string) []string {
+	var errs []string
+	if len(value) > LabelValueMaxLength {
+		errs = append(errs, MaxLenError(LabelValueMaxLength))
+	}
+	if !labelValueRegexp.MatchString(value) {
+		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345"))
+	}
+	return errs
+}
+
+const dns1123LabelFmt string = "[a-z0-9]([-a-z0-9]*[a-z0-9])?"
+const dns1123LabelErrMsg string = "a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character"
+const DNS1123LabelMaxLength int = 63
+
+var dns1123LabelRegexp = regexp.MustCompile("^" + dns1123LabelFmt + "$")
+
+// IsDNS1123Label tests for a string that conforms to the definition of a label in
+// DNS (RFC 1123).
+func IsDNS1123Label(value string) []string {
+	var errs []string
+	if len(value) > DNS1123LabelMaxLength {
+		errs = append(errs, MaxLenError(DNS1123LabelMaxLength))
+	}
+	if !dns1123LabelRegexp.MatchString(value) {
+		errs = append(errs, RegexError(dns1123LabelErrMsg, dns1123LabelFmt, "my-name", "123-abc"))
+	}
+	return errs
+}
+
+const dns1123SubdomainFmt string = dns1123LabelFmt + "(\\." + dns1123LabelFmt + ")*"
+const dns1123SubdomainErrorMsg string = "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"
+const DNS1123SubdomainMaxLength int = 253
+
+var dns1123SubdomainRegexp = regexp.MustCompile("^" + dns1123SubdomainFmt + "$")
+
+// IsDNS1123Subdomain tests for a string that conforms to the definition of a
+// subdomain in DNS (RFC 1123).
+func IsDNS1123Subdomain(value string) []string {
+	var errs []string
+	if len(value) > DNS1123SubdomainMaxLength {
+		errs = append(errs, MaxLenError(DNS1123SubdomainMaxLength))
+	}
+	if !dns1123SubdomainRegexp.MatchString(value) {
+		errs = append(errs, RegexError(dns1123SubdomainErrorMsg, dns1123SubdomainFmt, "example.com"))
+	}
+	return errs
+}
+
+// MaxLenError returns a string explanation of a "string too long" validation
+// failure.
+func MaxLenError(length int) string {
+	return fmt.Sprintf("must be no more than %d characters", length)
+}
+
+// RegexError returns a string explanation of a regex validation failure.
+func RegexError(msg string, fmt string, examples ...string) string {
+	if len(examples) == 0 {
+		return msg + " (regex used for validation is '" + fmt + "')"
+	}
+	msg += " (e.g. "
+	for i := range examples {
+		if i > 0 {
+			msg += " or "
+		}
+		msg += "'" + examples[i] + "', "
+	}
+	msg += "regex used for validation is '" + fmt + "')"
+	return msg
+}
+
+// EmptyError returns a string explanation of a "must not be empty" validation
+// failure.
+func EmptyError() string {
+	return "must be non-empty"
+}
+
+func prefixEach(msgs []string, prefix string) []string {
+	for i := range msgs {
+		msgs[i] = prefix + msgs[i]
+	}
+	return msgs
+}


### PR DESCRIPTION
Fixes #133 

Example, either format will work as the are both `map[string]string`
```
worker:
  expected_count: 1
  nodes:
  - host: worker001
    ip: 192.168.42.4
    labels: {"com.koshkin/worker" : "", "com.koshkin/foo": "bar"}
  - host: worker002
    ip: 192.168.42.5
    labels:
      com.koshkin/foo: bar
      com.koshkin/ssd: true 
```