### PR TITLE
Deploy docker certificates in the docker play

### DIFF
--- a/ansible/_certs.yaml
+++ b/ansible/_certs.yaml
@@ -10,5 +10,3 @@
       - kubenode-cert
       - role: docker-registry-container-cert
         when: deploy_internal_docker_registry is defined and deploy_internal_docker_registry|bool == true
-      - role: docker-registry-cert
-        when: configure_docker_with_private_registry is defined and configure_docker_with_private_registry|bool == true

--- a/ansible/_docker.yaml
+++ b/ansible/_docker.yaml
@@ -11,6 +11,8 @@
       - role: packages-docker
         when: allow_package_installation|bool == true
       - role: docker-storage
+      - role: docker-registry-cert
+        when: configure_docker_with_private_registry is defined and configure_docker_with_private_registry|bool == true
       - role: docker-proxy
         when: >
           (https_proxy is defined and https_proxy != "") or


### PR DESCRIPTION
The docker certificates are only consumed by docker. For this reason, it seems to me that the best place for deploying them is when installing docker.