### PR TITLE
Fix docker registry docker login test

### DIFF
--- a/integration/docker_registry_test.go
+++ b/integration/docker_registry_test.go
@@ -15,18 +15,19 @@ var _ = Describe("kismatic docker registry feature", func() {
 
 	Describe("using an existing private docker registry", func() {
 		ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
-			WithInfrastructure(NodeCount{1, 1, 1, 0, 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
+			WithInfrastructure(NodeCount{2, 1, 1, 0, 0}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
 				By("Installing an external Docker registry on one of the nodes")
 				dockerRegistryPort := 8443
-				caFile, err := deployDockerRegistry(nodes.etcd[0], dockerRegistryPort, sshKey)
+				caFile, err := deployDockerRegistry(nodes.etcd[1], dockerRegistryPort, sshKey)
 				Expect(err).ToNot(HaveOccurred())
 				opts := installOptions{
 					dockerRegistryCAPath:   caFile,
-					dockerRegistryIP:       nodes.etcd[0].PrivateIP,
+					dockerRegistryIP:       nodes.etcd[1].PrivateIP,
 					dockerRegistryPort:     dockerRegistryPort,
 					dockerRegistryUsername: "kismaticuser",
 					dockerRegistryPassword: "kismaticpassword",
 				}
+				nodes.etcd = []NodeDeets{nodes.etcd[0]}
 				err = installKismatic(nodes, opts, sshKey)
 				Expect(err).ToNot(HaveOccurred())
 			})


### PR DESCRIPTION
Fixes #819 

This work was completed before etcd was moved to run as a docker container, because an etcd node was used to install the registry on after installing docker on that node and restarting it, the registry is no longer running.