### PR TITLE
Install nfs-common or nfs-utils package along with the kubelet

### DIFF
--- a/ansible/roles/packages-kubernetes/tasks/main.yaml
+++ b/ansible/roles/packages-kubernetes/tasks/main.yaml
@@ -1,5 +1,16 @@
 ---
   # YUM
+  - name: install nfs-utils yum package
+    yum:
+      name: nfs-utils
+      state: present
+    register: nfs_utils_installation_rpm
+    until: nfs_utils_installation_rpm|success
+    retries: 3
+    delay: 3
+    when: ansible_os_family == 'RedHat'
+    environment: "{{proxy_env}}"
+
   - name: install kubelet yum package
     yum:
       name: kubelet-{{ kubernetes_yum_version }}
@@ -24,6 +35,17 @@
     environment: "{{proxy_env}}"
 
   # DEB
+  - name: install nfs-common deb package
+    apt:
+      name: nfs-common
+      state: present
+    register: nfs_common_installation_deb
+    until: nfs_common_installation_deb|success
+    retries: 3
+    delay: 3
+    when: ansible_os_family == 'Debian'
+    environment: "{{proxy_env}}"
+
   - name: install kubelet deb package
     apt:
       name: kubelet={{ kubernetes_deb_version }}

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -39,7 +39,7 @@ EOF'
 | Component | Install Command |
 | ---- | ---- |
 | Etcd Node | `sudo yum -y install docker-engine-1.12.6-1.el7.centos` |
-| Kubernetes Node | `sudo yum -y install docker-engine-1.12.6-1.el7.centos kubelet-1.7.4-0 kubectl-1.7.4-0` |
+| Kubernetes Node | `sudo yum -y install docker-engine-1.12.6-1.el7.centos nfs-utils kubelet-1.7.4-0 kubectl-1.7.4-0` |
 
 ## Installing via DEB (Ubuntu Xenial)
 
@@ -90,7 +90,7 @@ sudo apt-get update
 | Component | Install Command |
 | ---- | ---- |
 | Etcd Node | `sudo apt-get install -y docker-engine=1.12.6-0~ubuntu-xenial` |
-| Kubernetes Node | `sudo apt-get install -y docker-engine=1.12.6-0~ubuntu-xenial kubelet=1.7.4-00 kubectl=1.7.4-00` |
+| Kubernetes Node | `sudo apt-get install -y docker-engine=1.12.6-0~ubuntu-xenial nfs-common kubelet=1.7.4-00 kubectl=1.7.4-00` |
 
 #### Stop the kubelet
 When the Ubuntu kubelet package is installed the service will be started and will bind to ports. This will cause some preflight port checks to fail.

--- a/integration/prepare.go
+++ b/integration/prepare.go
@@ -53,6 +53,7 @@ EOF`
 
 	installDockerYum          = `sudo yum -y install docker-engine-1.12.6-1.el7.centos`
 	installKubeletYum         = `sudo yum -y install kubelet-1.7.4-0`
+	installNFSUtilsYum        = `sudo yum -y install nfs-utils` // required for the kubelet
 	installKubectlYum         = `sudo yum -y install kubectl-1.7.4-0`
 	installGlusterfsServerYum = `sudo yum -y install --nogpgcheck glusterfs-server-3.8.15-2.el7`
 
@@ -65,6 +66,7 @@ EOF`
 	addKubernetesRepoApt    = `sudo add-apt-repository "deb https://packages.cloud.google.com/apt/ kubernetes-xenial main"`
 	installKubeletApt       = `sudo apt-get -y install kubelet=1.7.4-00`
 	stopKubeletService      = `sudo systemctl stop kubelet`
+	installNFSCommonApt     = `sudo apt-get -y install nfs-common`
 	installKubectlApt       = `sudo apt-get -y install kubectl=1.7.4-00`
 
 	addGlusterRepoApt         = `sudo add-apt-repository -y ppa:gluster/glusterfs-3.8`
@@ -84,7 +86,7 @@ var ubuntu1604Prep = nodePrep{
 	CommandsToPrepDockerRepo:     []string{addDockerRepoKeyApt, addDockerRepoApt, updateAptGet},
 	CommandsToInstallDocker:      []string{installDockerApt},
 	CommandsToPrepKubernetesRepo: []string{addKubernetesRepoKeyApt, addKubernetesRepoApt, updateAptGet},
-	CommandsToInstallKubelet:     []string{installKubeletApt, stopKubeletService},
+	CommandsToInstallKubelet:     []string{installKubeletApt, installNFSCommonApt, stopKubeletService},
 	CommandsToInstallKubectl:     []string{installKubectlApt},
 	CommandsToInstallGlusterfs:   []string{addGlusterRepoApt, updateAptGet, installGlusterfsServerApt},
 }
@@ -93,7 +95,7 @@ var rhel7FamilyPrep = nodePrep{
 	CommandsToPrepDockerRepo:     []string{createDockerRepoFileYum, moveDockerRepoFileYum},
 	CommandsToInstallDocker:      []string{installDockerYum},
 	CommandsToPrepKubernetesRepo: []string{createKubernetesRepoFileYum, moveKubernetesRepoFileYum},
-	CommandsToInstallKubelet:     []string{installKubeletYum},
+	CommandsToInstallKubelet:     []string{installKubeletYum, installNFSUtilsYum},
 	CommandsToInstallKubectl:     []string{installKubectlYum},
 	CommandsToInstallGlusterfs:   []string{createGlusterRepoFileYum, moveGlusterRepoFileYum, installGlusterfsServerYum},
 }

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -179,6 +179,10 @@ const defaultRuleSet = `---
   packageVersion: 1.7.4-00
 - kind: PackageDependency
   when: ["master","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
+- kind: PackageDependency
+  when: ["master","ubuntu"]
   packageName: kubectl
   packageVersion: 1.7.4-00
 - kind: PackageDependency
@@ -202,13 +206,25 @@ const defaultRuleSet = `---
   packageName: kubelet
   packageVersion: 1.7.4-00
 - kind: PackageDependency
+  when: ["worker","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","ubuntu"]
   packageName: kubelet
   packageVersion: 1.7.4-00
 - kind: PackageDependency
+  when: ["ingress","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","ubuntu"]
   packageName: kubelet
   packageVersion: 1.7.4-00
+- kind: PackageDependency
+  when: ["storage","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","ubuntu"]
   packageName: kubectl
@@ -233,6 +249,10 @@ const defaultRuleSet = `---
   packageVersion: 1.7.4-0
 - kind: PackageDependency
   when: ["master","centos"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
+  when: ["master","centos"]
   packageName: kubectl
   packageVersion: 1.7.4-0
 - kind: PackageDependency
@@ -256,13 +276,25 @@ const defaultRuleSet = `---
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["worker","centos"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","centos"]
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["ingress","centos"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","centos"]
   packageName: kubelet
   packageVersion: 1.7.4-0
+- kind: PackageDependency
+  when: ["storage","centos"]
+  packageName: nfs-utils
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","centos"]
   packageName: kubectl
@@ -287,6 +319,10 @@ const defaultRuleSet = `---
   packageVersion: 1.7.4-0
 - kind: PackageDependency
   when: ["master","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
+  when: ["master","rhel"]
   packageName: kubectl
   packageVersion: 1.7.4-0
 - kind: PackageDependency
@@ -310,13 +346,25 @@ const defaultRuleSet = `---
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["worker","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","rhel"]
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["ingress","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","rhel"]
   packageName: kubelet
   packageVersion: 1.7.4-0
+- kind: PackageDependency
+  when: ["storage","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","rhel"]
   packageName: kubectl
@@ -408,6 +456,10 @@ const upgradeRuleSet = `---
   packageVersion: 1.7.4-00
 - kind: PackageDependency
   when: ["master","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
+- kind: PackageDependency
+  when: ["master","ubuntu"]
   packageName: kubectl
   packageVersion: 1.7.4-00
 - kind: PackageDependency
@@ -431,13 +483,25 @@ const upgradeRuleSet = `---
   packageName: kubelet
   packageVersion: 1.7.4-00
 - kind: PackageDependency
+  when: ["worker","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","ubuntu"]
   packageName: kubelet
   packageVersion: 1.7.4-00
 - kind: PackageDependency
+  when: ["ingress","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","ubuntu"]
   packageName: kubelet
   packageVersion: 1.7.4-00
+- kind: PackageDependency
+  when: ["storage","ubuntu"]
+  packageName: nfs-common
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","ubuntu"]
   packageName: kubectl
@@ -461,6 +525,10 @@ const upgradeRuleSet = `---
   packageVersion: 1.7.4-0
 - kind: PackageDependency
   when: ["master","centos"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
+  when: ["master","centos"]
   packageName: kubectl
   packageVersion: 1.7.4-0
 - kind: PackageDependency
@@ -484,13 +552,25 @@ const upgradeRuleSet = `---
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["worker","centos"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","centos"]
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["ingress","centos"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","centos"]
   packageName: kubelet
   packageVersion: 1.7.4-0
+- kind: PackageDependency
+  when: ["storage","centos"]
+  packageName: nfs-utils
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","centos"]
   packageName: kubectl
@@ -512,6 +592,10 @@ const upgradeRuleSet = `---
   when: ["master","rhel"]
   packageName: kubelet
   packageVersion: 1.7.4-0
+- kind: PackageDependency
+  when: ["master","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
 - kind: PackageDependency
   when: ["master","rhel"]
   packageName: kubectl
@@ -537,13 +621,25 @@ const upgradeRuleSet = `---
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["worker","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["ingress","rhel"]
   packageName: kubelet
   packageVersion: 1.7.4-0
 - kind: PackageDependency
+  when: ["ingress","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
+- kind: PackageDependency
   when: ["storage","rhel"]
   packageName: kubelet
   packageVersion: 1.7.4-0
+- kind: PackageDependency
+  when: ["storage","rhel"]
+  packageName: nfs-utils
+  anyVersion: true
 - kind: PackageDependency
   when: ["worker","rhel"]
   packageName: kubectl


### PR DESCRIPTION
Fixes #815, fixes #816, fixes #818 

The `kismatic` package had a dependency on `nfs-utils` or `nfs-common` packages, switching to the upstream kubernetes ones does not have this dependency and broke the NFS and Gluster tests.