### PR TITLE
Proxy envs: Set uppercase env vars as well

### DIFF
--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -21,20 +21,12 @@
       - name: "run helm init"
         local_action: command ../../helm init --service-account=tiller -i="{{ images.helm }}" --upgrade {% if disconnected_installation|bool == true %}--skip-refresh{% endif %}
         become: no
-        environment:
-          KUBECONFIG: "{{ local_kubeconfig_directory }}"
-          https_proxy: "{{ https_proxy }}"
-          http_proxy: "{{ http_proxy }}"
-          no_proxy: "{{ no_proxy }}"
+        environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
           
       - name: "add kismatic helm repo"
         local_action: command ../../helm repo add kismatic https://apprenda.github.io/kismatic-charts/
         become: no
-        environment:
-          KUBECONFIG: "{{ local_kubeconfig_directory }}"
-          https_proxy: "{{ https_proxy }}"
-          http_proxy: "{{ http_proxy }}"
-          no_proxy: "{{ no_proxy }}"
+        environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
         when: disconnected_installation|bool != true
 
       - block:

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -272,6 +272,9 @@ volume_replica_count: 2
 volume_distribution_count: 1
 
 proxy_env:
+  HTTPS_PROXY: "{{ https_proxy }}"
   https_proxy: "{{ https_proxy }}"
+  HTTP_PROXY: "{{ http_proxy }}"
   http_proxy: "{{ http_proxy }}"
+  NO_PROXY: "{{ no_proxy }}"
   no_proxy: "{{ no_proxy }}"


### PR DESCRIPTION
```
The CI machines on Circle have a predefined NO_PROXY environment
variable. This made `helm init` fail during the installation because the
existing NO_PROXY environment variable was taking precedence over the
no_proxy env var we were setting. Given that respecting these
environment variables is application specific, we now set them in both
upper and lowercase form.
```

Fixes #820 