### PR TITLE
Allow package installation in upgrade integ test

### DIFF
--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -383,14 +383,13 @@ var _ = Describe("Upgrade", func() {
 							err = os.Remove("kismatic-testing.yaml")
 							FailIfError(err)
 							opts = installOptions{
-								disablePackageInstallation: true,
-								disconnectedInstallation:   true,
-								modifyHostsFiles:           true,
-								dockerRegistryCAPath:       caFile,
-								dockerRegistryIP:           repoNode.PrivateIP,
-								dockerRegistryPort:         dockerRegistryPort,
-								dockerRegistryUsername:     "kismaticuser",
-								dockerRegistryPassword:     "kismaticpassword",
+								disconnectedInstallation: true,
+								modifyHostsFiles:         true,
+								dockerRegistryCAPath:     caFile,
+								dockerRegistryIP:         repoNode.PrivateIP,
+								dockerRegistryPort:       dockerRegistryPort,
+								dockerRegistryUsername:   "kismaticuser",
+								dockerRegistryPassword:   "kismaticpassword",
 							}
 							writePlanFile(buildPlan(nodes, opts, sshKey))
 
@@ -452,14 +451,13 @@ var _ = Describe("Upgrade", func() {
 							err = os.Remove("kismatic-testing.yaml")
 							FailIfError(err)
 							opts = installOptions{
-								disablePackageInstallation: true,
-								disconnectedInstallation:   true,
-								modifyHostsFiles:           true,
-								dockerRegistryCAPath:       caFile,
-								dockerRegistryIP:           repoNode.PrivateIP,
-								dockerRegistryPort:         dockerRegistryPort,
-								dockerRegistryUsername:     "kismaticuser",
-								dockerRegistryPassword:     "kismaticpassword",
+								disconnectedInstallation: true,
+								modifyHostsFiles:         true,
+								dockerRegistryCAPath:     caFile,
+								dockerRegistryIP:         repoNode.PrivateIP,
+								dockerRegistryPort:       dockerRegistryPort,
+								dockerRegistryUsername:   "kismaticuser",
+								dockerRegistryPassword:   "kismaticpassword",
 							}
 							writePlanFile(buildPlan(nodes, opts, sshKey))
 


### PR DESCRIPTION
```
The test is setup in a way that KET is responsible for installing the
packages. However, the plan file was not updated from the previous
implementation of the test that was performing the installation of
packages out of band from KET upgrade.
```

Fixes #829 