### PR TITLE
Lower case CN for the kubelets to work with NodeRestriction policy

### DIFF
--- a/pkg/install/pki.go
+++ b/pkg/install/pki.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/apprenda/kismatic/pkg/tls"
@@ -169,7 +170,7 @@ func certManifestForNode(plan Plan, node Node) ([]certificateSpec, error) {
 		m = append(m, certificateSpec{
 			description:   fmt.Sprintf("%s kubelet", node.Host),
 			filename:      fmt.Sprintf("%s-kubelet", node.Host),
-			commonName:    fmt.Sprintf("%s:%s", kubeletUserPrefix, node.Host),
+			commonName:    fmt.Sprintf("%s:%s", kubeletUserPrefix, strings.ToLower(node.Host)),
 			organizations: []string{kubeletGroup},
 		})
 


### PR DESCRIPTION
A regression as a side effect of https://github.com/apprenda/kismatic/issues/602 was introduced. The CN name must match exactly the nodeName, and the nodeName is always lowercased.

If users did have an uppercase in their certs during an upgrade the validation will catch and fail, the user can then delete (or regenerate) the certificates with the lowercase CN.