### PR TITLE
Upgrade Calico to v2.6.1

### DIFF
--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -16,7 +16,7 @@ official_images:
     version: v1.8.0
   calico_node:
     name: calico/node
-    version: v2.6.0
+    version: v2.6.1
   calico_ctl:
     name: calico/ctl
     version: v1.6.1

--- a/integration/test-resources/network-policy/default-deny.yaml
+++ b/integration/test-resources/network-policy/default-deny.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: policy-tester
 spec:
   podSelector:
+    matchLabels: {}


### PR DESCRIPTION
Related to https://github.com/projectcalico/calico/issues/1135

Looks like `v2.6.0` had a bad version of Felix. https://docs.projectcalico.org/v2.6/releases/