### PR TITLE
Upgrade weave to 2.0.4, mount xtables.lock in the container

### DIFF
--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -37,10 +37,10 @@ official_images:
     version: 1.1.1
   weave:
     name: weaveworks/weave-kube
-    version: 2.0.1
+    version: 2.0.4
   weave_npc:
     name: weaveworks/weave-npc
-    version: 2.0.1
+    version: 2.0.4
   defaultbackend:
     name: gcr.io/google_containers/defaultbackend
     version: 1.0

--- a/ansible/roles/weave/templates/weave.yaml
+++ b/ansible/roles/weave/templates/weave.yaml
@@ -109,6 +109,9 @@ items:
                   mountPath: /host/var/lib/dbus
                 - name: lib-modules
                   mountPath: /lib/modules
+                - name: xtables-lock			
+                  mountPath: /run/xtables.lock			
+                  readOnly: false
             - name: weave-npc
               env:
                 - name: HOSTNAME
@@ -123,6 +126,10 @@ items:
                   cpu: 10m
               securityContext:
                 privileged: true
+              volumeMounts:	
+                - name: xtables-lock			
+                  mountPath: /run/xtables.lock			
+                  readOnly: false
           hostNetwork: true
           hostPID: true
           restartPolicy: Always
@@ -151,3 +158,6 @@ items:
             - name: lib-modules
               hostPath:
                 path: /lib/modules
+            - name: xtables-lock		 
+              hostPath:			
+                path: /run/xtables.lock

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -38,7 +38,7 @@
     when: cni.enabled|bool == true and cni.provider == "calico"
   - include: _calico-validate.yaml upgrading=true
     when: cni.enabled|bool == true and cni.provider == "calico"
-  - include: _weave.yaml play_name="Upgrade Wave Cluster Network" upgrading=true
+  - include: _weave.yaml play_name="Upgrade Weave Cluster Network" upgrading=true
     when: cni.enabled|bool == true and cni.provider == "weave"
   - include: _weave-validate.yaml upgrading=true
     when: cni.enabled|bool == true and cni.provider == "weave"


### PR DESCRIPTION
Intermittent issues were discovered during integration tests. 
Use fix from https://github.com/weaveworks/weave/pull/3134 