### PR TITLE
Use port 10256 as the kube-proxy health port

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -18,7 +18,7 @@ etcd_k8s_client_port: 2379
 etcd_networking_client_port: 6666
 kubernetes_master_secure_port: 6443
 kubernetes_master_insecure_port: 8080
-kubernetes_proxy_insecure_port: 10249
+kubernetes_proxy_insecure_port: 10256
 kubernetes_scheduler_insecure_port: 10251
 kubernetes_controller_mgr_insecure_port: 10252
 #===============================================================================

--- a/ansible/roles/kube-proxy/templates/kube-proxy.yaml
+++ b/ansible/roles/kube-proxy/templates/kube-proxy.yaml
@@ -39,7 +39,7 @@ spec:
       httpGet:
         host: 127.0.0.1
         path: /healthz
-        port: 10249
+        port: 10256
       initialDelaySeconds: 15
       timeoutSeconds: 15
       failureThreshold: 8

--- a/integration/disconnected_install_test.go
+++ b/integration/disconnected_install_test.go
@@ -189,8 +189,8 @@ var _ = Describe("disconnected installation", func() {
 
 func disableInternetAccess(nodes []NodeDeets, sshKey string) error {
 	By("Blocking all outbound connections")
-	allowSourcePorts := "8888,2379,6666,2380,6660,6443,8443,80,443,4194,10249,10250,10251,10252,10254" // ports needed/checked by inspector
-	allowDestPorts := "8888,2379,6666,2380,6660,6443,8443,80,443,4194,10249,10250,10251,10252,10254"
+	allowSourcePorts := "8888,2379,6666,2380,6660,6443,8443,80,443,4194,10256,10250,10251,10252,10254" // ports needed/checked by inspector
+	allowDestPorts := "8888,2379,6666,2380,6660,6443,8443,80,443,4194,10256,10250,10251,10252,10254"
 	allowedStorgePorts := "8081,111,2049,38465,38466,38467"
 	cmd := []string{
 		"sudo iptables -A OUTPUT -o lo -j ACCEPT",                                                                 // allow loopback

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -105,10 +105,14 @@ const defaultRuleSet = `---
 - kind: TCPPortAvailable
   when: ["master","worker","ingress","storage"]
   port: 10248
-# kube-proxy
+# kube-proxy metrics
 - kind: TCPPortAvailable
   when: ["master","worker","ingress","storage"]
   port: 10249
+# kube-proxy health
+- kind: TCPPortAvailable
+  when: ["master","worker","ingress","storage"]
+  port: 10256
 # kubelet
 - kind: TCPPortAvailable
   when: ["master","worker","ingress","storage"]
@@ -127,7 +131,7 @@ const defaultRuleSet = `---
 # kube-proxy
 - kind: TCPPortAccessible
   when: ["master","worker","ingress","storage"]
-  port: 10249
+  port: 10256
   timeout: 5s
 # kubelet
 - kind: TCPPortAccessible


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/809

Port `10249` is used for metrics and by default only binds to `127.0.0.1` no need for it to be *accessible* only *available*. 