### PR TITLE
Clean yum cache after setting up repos

### DIFF
--- a/ansible/roles/packages-repo/tasks/main.yaml
+++ b/ansible/roles/packages-repo/tasks/main.yaml
@@ -30,6 +30,11 @@
     environment: "{{proxy_env}}"
 
   - name: clean yum cache
+    command: 'yum --disablerepo="*" --enablerepo="docker,kubernetes,gluster" clean all'
+    when: ansible_os_family == 'RedHat'
+    environment: "{{proxy_env}}"
+
+  - name: yum makecache
     command: 'yum --disablerepo="*" --enablerepo="docker,kubernetes,gluster" makecache'
     when: ansible_os_family == 'RedHat'
     environment: "{{proxy_env}}"

--- a/docs/disconnected_install.md
+++ b/docs/disconnected_install.md
@@ -101,6 +101,9 @@ gpgcheck=1
 repo_gpgcheck=0
 gpgkey=https://download.gluster.org/pub/gluster/glusterfs/3.8/3.8.7/rsa.pub
 EOF'
+
+# Clean yum cache
+yum clean all
 ```
 
 ### Download the RPMs using reposync

--- a/integration/test-resources/disconnected-installation/configure-rpm-mirrors.sh
+++ b/integration/test-resources/disconnected-installation/configure-rpm-mirrors.sh
@@ -174,3 +174,6 @@ enabled=1
 gpgcheck=1
 gpgkey=file:///tmp/gluster.gpg
 EOF
+
+# Need to clean cache to download metadata again
+yum clean all


### PR DESCRIPTION
During the disconnected upgrade integration test packages could not be found.

This is due to the fact that the kubernetes package repo does not follow the standard repo structure and the packages are not where it was expected to be.

```
- Running task: install kubelet yum package
 ip-10-0-3-211.ec2.internal Retrying: install kubelet yum package (1/3 attempts)
 ip-10-0-3-211.ec2.internal Retrying: install kubelet yum package (2/3 attempts)
 ip-10-0-3-211.ec2.internal Retrying: install kubelet yum package (3/3 attempts)
  ip-10-0-3-211.ec2.internal http://10.0.3.137/kubernetes/../../pool/a35571037b554243d386436ff729c90a3cb270f5797b7cd254ef0afbd4e706bf-kubelet-1.8.1-0.x86_64.rpm: [Errno 14] HTTP Error 400 - Bad Request
Trying other mirror.
http://10.0.3.137/kubernetes/../../pool/79f9ba89dbe7000e7dfeda9b119f711bb626fe2c2d56abeb35141142cda00342-kubernetes-cni-0.5.1-1.x86_64.rpm: [Errno 14] HTTP Error 400 - Bad Request
Trying other mirror.


Error downloading packages:
  kubelet-1.8.1-0.x86_64: [Errno 256] No more mirrors to try.
  kubernetes-cni-0.5.1-1.x86_64: [Errno 256] No more mirrors to try.
```