### PR TITLE
Deploy pod resheduler by default

### DIFF
--- a/ansible/_rescheduler.yaml
+++ b/ansible/_rescheduler.yaml
@@ -1,0 +1,11 @@
+---
+  - hosts: master[0]
+    any_errors_fatal: true
+    name: "{{ play_name | default('Start Kubernetes Pod Rescheduler') }}"
+    become: yes
+    vars_files:
+      - group_vars/all.yaml
+      - group_vars/container_images.yaml
+
+    roles:
+      - rescheduler

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -265,6 +265,7 @@ official_versioned_images:
   helm: "{{official_images.helm.name}}:{{official_images.helm.version}}"
   heapster: "{{official_images.heapster.name}}:{{official_images.heapster.version}}"
   influxdb: "{{official_images.influxdb.name}}:{{official_images.influxdb.version}}"
+  rescheduler: "{{official_images.rescheduler.name}}:{{official_images.rescheduler.version}}"
 
 images:
   etcd: "{{ official_versioned_images.etcd | final_image(docker_registry_full_url, load_private_images) }}"
@@ -294,6 +295,7 @@ images:
   helm: "{{ official_versioned_images.helm | final_image(docker_registry_full_url, load_private_images) }}"
   heapster: "{{ official_versioned_images.heapster | final_image(docker_registry_full_url, load_private_images) }}"
   influxdb: "{{ official_versioned_images.influxdb | final_image(docker_registry_full_url, load_private_images) }}"
+  rescheduler: "{{ official_versioned_images.rescheduler | final_image(docker_registry_full_url, load_private_images) }}"
 
 #===============================================================================
 # docker packages

--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -80,3 +80,6 @@ official_images:
   influxdb: 
     name: gcr.io/google_containers/heapster-influxdb-amd64
     version: v1.1.1  
+  rescheduler: 
+    name: gcr.io/google-containers/rescheduler
+    version: v0.3.1

--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -37,6 +37,8 @@
     when: cni.enabled|bool == true and cni.provider == "weave"
   - include: _contiv.yaml
     when: cni.enabled|bool == true and cni.provider == "contiv"
+  - include: _rescheduler.yaml
+    when: rescheduler.enabled|bool == true
   - include: _kube-dns.yaml
     when: dns.enabled|bool == true
   - include: _heapster.yaml

--- a/ansible/roles/calico-network-policy/templates/policy-controller.yaml
+++ b/ansible/roles/calico-network-policy/templates/policy-controller.yaml
@@ -13,9 +13,6 @@ metadata:
     kismatic/version: "{{ kismatic_short_version }}"
   annotations:
     scheduler.alpha.kubernetes.io/critical-pod: ''
-    scheduler.alpha.kubernetes.io/tolerations: |
-      [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-      {"key":"CriticalAddonsOnly", "operator":"Exists"}]
 spec:
   # The controllers can only have a single active instance.
   replicas: 1
@@ -33,6 +30,9 @@ spec:
       # it isn't governed by policy that would prevent it from working.
       hostNetwork: true
       serviceAccountName: calico-kube-controllers
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: "ca"
           hostPath:

--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -74,12 +74,12 @@ spec:
         k8s-app: calico-node
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        scheduler.alpha.kubernetes.io/tolerations: |
-          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
     spec:
       hostNetwork: true
       serviceAccountName: calico-node
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       containers:
         # Runs calico/node container on each Kubernetes node.  This
         # container programs network policy and routes on each

--- a/ansible/roles/rescheduler/tasks/main.yaml
+++ b/ansible/roles/rescheduler/tasks/main.yaml
@@ -1,0 +1,36 @@
+  - name: copy rescheduler.yaml manifest
+    template:
+      src: rescheduler.yaml
+      dest: "{{ kubelet_pod_manifests_dir }}/rescheduler.yaml"
+      owner: "{{ kubernetes_owner }}"
+      group: "{{ kubernetes_group }}"
+      mode: "{{ kubernetes_service_mode }}"
+
+  - name: wait up to 5 min until pod 'rescheduler' is running
+    command: kubectl get pods --selector  k8s-app=rescheduler --namespace kube-system --kubeconfig {{ kubernetes_kubeconfig_path }}
+    register: phase
+    until: phase|success and "Running" in phase.stdout
+    retries: 60
+    delay: 5
+    failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+
+  - name: get docker container ID for pod 'rescheduler'
+    command: docker ps -a -f name=rescheduler --format {%raw%}"{{.ID}}"{%endraw%} -l
+    register: containerID
+    when: phase|failure or "Running" not in phase.stdout
+
+  - name: get docker logs for pod 'rescheduler'
+    command: docker logs {{ containerID.stdout }} --tail 15
+    register: docker_logs
+    when: containerID is defined and containerID|success and containerID.stdout is defined and containerID.stdout != ""
+
+  - name: fail if pod 'rescheduler' is not running
+    fail:
+      msg: |
+        Waited for pod 'rescheduler' to be running, but it did not start up in time.
+
+        The pod's latest logs may indicate why it failed to start up:
+
+        {{ docker_logs.stderr }}
+
+    when: phase|failure or "Running" not in phase.stdout

--- a/ansible/roles/rescheduler/templates/rescheduler.yaml
+++ b/ansible/roles/rescheduler/templates/rescheduler.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rescheduler
+  namespace: kube-system
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ''
+  labels:
+    k8s-app: rescheduler
+    version: {{ official_images.rescheduler.version }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "Rescheduler"
+spec:
+  hostNetwork: true
+  containers:
+  - image: {{ images.rescheduler }}
+    name: rescheduler
+    volumeMounts:
+    # TODO: Make resource requirements depend on the size of the cluster
+    resources:
+      requests:
+        cpu: 10m
+        memory: 100Mi
+    command:
+    - /rescheduler 
+    - --running-in-cluster=false

--- a/ansible/roles/validate-pod/tasks/validate-pod.yaml
+++ b/ansible/roles/validate-pod/tasks/validate-pod.yaml
@@ -30,7 +30,7 @@
     failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
 
   - name: get docker container ID for pod '{{ name }}'
-    command: docker ps -a -f name={{ item }} --format {%raw%}"{{.ID}}"{%endraw%} -l
+    command: docker ps -a -f name={{ name }} --format {%raw%}"{{.ID}}"{%endraw%} -l
     register: containerID
     when: phase|failure or "Running" not in phase.stdout
 

--- a/ansible/roles/weave/templates/weave.yaml
+++ b/ansible/roles/weave/templates/weave.yaml
@@ -67,9 +67,6 @@ items:
             k8s-app: weave-net
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
-            scheduler.alpha.kubernetes.io/tolerations: |
-              [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
-              {"key":"CriticalAddonsOnly", "operator":"Exists"}]
         spec:
           containers:
             - name: weave

--- a/ansible/upgrade-nodes.yaml
+++ b/ansible/upgrade-nodes.yaml
@@ -42,6 +42,8 @@
     when: cni.enabled|bool == true and cni.provider == "weave"
   - include: _weave-validate.yaml upgrading=true
     when: cni.enabled|bool == true and cni.provider == "weave"
+  - include: _rescheduler.yaml play_name="Upgrade Kubernetes Pod Rescheduler" upgrading=true
+    when: rescheduler.enabled|bool == true
     
   - include: _kube-uncordon-node.yaml
 

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -74,6 +74,8 @@
   * [package_manager](#add_onspackage_manager)
     * [disable](#add_onspackage_managerdisable)
     * [provider](#add_onspackage_managerprovider)
+  * [rescheduler](#add_onsrescheduler)
+    * [disable](#add_onsreschedulerdisable)
 * [features _(deprecated)_](#features-deprecated)
   * [package_manager _(deprecated)_](#featurespackage_manager-deprecated)
     * [enabled _(deprecated)_](#featurespackage_managerenabled-deprecated)
@@ -718,6 +720,20 @@
 | **Required** |  Yes |
 | **Default** | ` ` | 
 | **Options** |  `helm`
+
+###  add_ons.rescheduler
+
+ The Rescheduler add-on configuration. Because the Rescheduler does not have leader election and therefore can only run as a single instance in a cluster, it will be deployed as a static pod on the first master. More information about the Rescheduler can be found here: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/ 
+
+###  add_ons.rescheduler.disable
+
+ Whether the pod rescheduler add-on should be disabled. When set to true, the rescheduler will not be installed on the cluster. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  bool |
+| **Required** |  No |
+| **Default** | `false` | 
 
 ##  features _(deprecated)_
 

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -108,6 +108,8 @@ add_ons:
   package_manager:
     disable: {{.DisableHelm}}
     provider: helm
+  rescheduler:
+    disable: false
 etcd:
   expected_count: {{len .Etcd}}
   nodes:{{range .Etcd}}

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -118,6 +118,10 @@ type ClusterCatalog struct {
 		Enabled bool
 	}
 
+	Rescheduler struct {
+		Enabled bool
+	}
+
 	InsecureNetworkingEtcd bool `yaml:"insecure_networking_etcd"`
 
 	HTTPProxy  string `yaml:"http_proxy"`

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -763,6 +763,8 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		}
 	}
 
+	cc.Rescheduler.Enabled = !p.AddOns.Rescheduler.Disable
+
 	// merge node labels
 	// cannot use inventory file because nodes share roles
 	// set it to a map[host][]key=value

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -440,6 +440,7 @@ var commentMap = map[string][]string{
 	"add_ons.heapster.options.heapster.service_type":     []string{"Specify kubernetes ServiceType. Defaults to 'ClusterIP'.", "Options: 'ClusterIP','NodePort','LoadBalancer','ExternalName'."},
 	"add_ons.heapster.options.heapster.sink":             []string{"Specify the sink to store heapster data. Defaults to an influxdb pod", "running on the cluster."},
 	"add_ons.package_manager.provider":                   []string{"Options: 'helm'"},
+	"add_ons.rescheduler":                                []string{"The rescheduler ensures that critical add-ons remain running on the cluster."},
 }
 
 type stack struct {

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -273,6 +273,10 @@ type AddOns struct {
 	DashboardDeprecated *Dashboard `yaml:"dashbard,omitempty"`
 	// The PackageManager add-on configuration.
 	PackageManager PackageManager `yaml:"package_manager"`
+	// The Rescheduler add-on configuration.
+	// Because the Rescheduler does not have leader election and therefore can only run as a single instance in a cluster, it will be deployed as a static pod on the first master.
+	// More information about the Rescheduler can be found here: https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+	Rescheduler Rescheduler `yaml:"rescheduler"`
 }
 
 // Features configuration
@@ -389,6 +393,14 @@ type PackageManager struct {
 	// +required
 	// +options=helm
 	Provider string
+}
+
+// Rescheduler add-on configuration
+type Rescheduler struct {
+	// Whether the pod rescheduler add-on should be disabled.
+	// When set to true, the rescheduler will not be installed on the cluster.
+	// +default=false
+	Disable bool
 }
 
 type DeprecatedPackageManager struct {

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -170,6 +170,10 @@ add_ons:
     # Options: 'helm'
     provider: helm
 
+  # The rescheduler ensures that critical add-ons remain running on the cluster.
+  rescheduler:
+    disable: false
+
 # Etcd nodes are the ones that run the etcd distributed key-value database.
 etcd:
   expected_count: 3

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -170,6 +170,10 @@ add_ons:
     # Options: 'helm'
     provider: helm
 
+  # The rescheduler ensures that critical add-ons remain running on the cluster.
+  rescheduler:
+    disable: false
+
 # Etcd nodes are the ones that run the etcd distributed key-value database.
 etcd:
   expected_count: 3


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/611, fixes https://github.com/apprenda/kismatic/issues/804

Deploy the static pod as described [here](https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/)