### PR TITLE
Fix docker-registry validation

### DIFF
--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -481,8 +481,11 @@ func (n *Node) validate() (bool, []error) {
 
 func (dr *DockerRegistry) validate() (bool, []error) {
 	v := newValidator()
-	if dr.Address == "" && (dr.CAPath != "") {
-		v.addError(fmt.Errorf("Docker Registry address cannot be empty when CA is provided"))
+	if (dr.Server == "" && dr.Address == "") && (dr.CAPath != "") {
+		v.addError(fmt.Errorf("Docker Registry server cannot be empty when CA is provided"))
+	}
+	if (dr.Server == "" && dr.Address == "") && (dr.Username != "") {
+		v.addError(fmt.Errorf("Docker Registry server cannot be empty when a username is provided"))
 	}
 	if _, err := os.Stat(dr.CAPath); dr.CAPath != "" && os.IsNotExist(err) {
 		v.addError(fmt.Errorf("Docker Registry CA file was not found at %q", dr.CAPath))

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -856,6 +856,72 @@ func TestValidatePlanDisconnectedInstallationSucceeds(t *testing.T) {
 	}
 }
 
+func TestDockerRegistry(t *testing.T) {
+	tests := []struct {
+		d     DockerRegistry
+		valid bool
+	}{
+		{
+			d:     DockerRegistry{},
+			valid: true,
+		},
+		{
+			d: DockerRegistry{
+				Server: "172.0.0.1",
+				CAPath: "/bin/sh",
+			},
+			valid: true,
+		},
+		{
+			d: DockerRegistry{
+				Server:   "172.0.0.1",
+				Username: "user",
+				Password: "password",
+			},
+			valid: true,
+		},
+		{
+			d: DockerRegistry{
+				Address: "172.0.0.1",
+				CAPath:  "/bin/sh",
+			},
+			valid: true,
+		},
+		{
+			d: DockerRegistry{
+				Address:  "172.0.0.1",
+				Username: "user",
+				Password: "password",
+			},
+			valid: true,
+		},
+		{
+			d: DockerRegistry{
+				CAPath: "user",
+			},
+			valid: false,
+		},
+		{
+			d: DockerRegistry{
+				Username: "user",
+			},
+			valid: false,
+		},
+		{
+			d: DockerRegistry{
+				Password: "password",
+			},
+			valid: false,
+		},
+	}
+	for i, test := range tests {
+		ok, _ := test.d.validate()
+		if ok != test.valid {
+			t.Errorf("test %d: expect %t, but got %t", i, test.valid, ok)
+		}
+	}
+}
+
 func TestValidateDockerStorageDirectLVM(t *testing.T) {
 	tests := []struct {
 		config DockerStorageDirectLVM


### PR DESCRIPTION
A an issue with the docker-registry validation was introduced in https://github.com/apprenda/kismatic/pull/869.

Fixed the validations and added some tests. For the deprecated field to still work must validate `.server` or `.address`.