### PR TITLE
Validate docker package

### DIFF
--- a/pkg/inspector/check/package.go
+++ b/pkg/inspector/check/package.go
@@ -18,7 +18,6 @@ func (p PackageQuery) String() string {
 // package is installed.
 type PackageCheck struct {
 	PackageQuery         PackageQuery
-	ShouldNotBeInstalled bool
 	PackageManager       PackageManager
 	InstallationDisabled bool
 }
@@ -28,19 +27,12 @@ type PackageCheck struct {
 // there is no guarantee that the node will have the kismatic package repo configured.
 // For this reason, this check is a no-op when package installation is disabled.
 func (c PackageCheck) Check() (bool, error) {
+	if !c.InstallationDisabled {
+		return true, nil
+	}
 	installed, err := c.PackageManager.IsInstalled(c.PackageQuery)
 	if err != nil {
 		return false, fmt.Errorf("failed to determine if package is installed: %v", err)
-	}
-	if !c.InstallationDisabled {
-		if installed && c.ShouldNotBeInstalled {
-			return false, fmt.Errorf("package should not be installed")
-		}
-		return true, nil
-	}
-	// When installation is disabled, dont check what packages are installed
-	if c.ShouldNotBeInstalled {
-		return true, nil
 	}
 	if installed {
 		return true, nil

--- a/pkg/inspector/check/package.go
+++ b/pkg/inspector/check/package.go
@@ -1,7 +1,6 @@
 package check
 
 import (
-	"errors"
 	"fmt"
 )
 
@@ -20,6 +19,7 @@ func (p PackageQuery) String() string {
 // package is installed.
 type PackageCheck struct {
 	PackageQuery         PackageQuery
+	ShouldNotBeInstalled bool
 	PackageManager       PackageManager
 	InstallationDisabled bool
 }
@@ -29,12 +29,19 @@ type PackageCheck struct {
 // there is no guarantee that the node will have the kismatic package repo configured.
 // For this reason, this check is a no-op when package installation is disabled.
 func (c PackageCheck) Check() (bool, error) {
-	if !c.InstallationDisabled {
-		return true, nil
-	}
 	installed, err := c.PackageManager.IsInstalled(c.PackageQuery)
 	if err != nil {
 		return false, fmt.Errorf("failed to determine if package is installed: %v", err)
+	}
+	if !c.InstallationDisabled {
+		if installed && c.ShouldNotBeInstalled {
+			return false, fmt.Errorf("package should not be installed")
+		}
+		return true, nil
+	}
+	// When installation is disabled, dont check what packages are installed
+	if c.ShouldNotBeInstalled {
+		return true, nil
 	}
 	if installed {
 		return true, nil
@@ -45,7 +52,7 @@ func (c PackageCheck) Check() (bool, error) {
 		return false, fmt.Errorf("failed to determine if package is available for install: %v", err)
 	}
 	if !available {
-		return false, errors.New("package is not installed, and is not available in known package repositories")
+		return false, fmt.Errorf("package is not installed, and is not available in known package repositories")
 	}
-	return false, errors.New("package is not installed, but is available in a package repository")
+	return false, fmt.Errorf("package is not installed, but is available in a package repository")
 }

--- a/pkg/inspector/check/package.go
+++ b/pkg/inspector/check/package.go
@@ -6,9 +6,8 @@ import (
 
 // PackageQuery is a query for finding a package
 type PackageQuery struct {
-	Name       string
-	Version    string
-	AnyVersion bool
+	Name    string
+	Version string
 }
 
 func (p PackageQuery) String() string {

--- a/pkg/inspector/check/package_manager.go
+++ b/pkg/inspector/check/package_manager.go
@@ -88,7 +88,7 @@ func (m rpmManager) isPackageListed(p PackageQuery, list []byte) bool {
 		}
 		maybeName := strings.Split(f[0], ".")[0]
 		maybeVersion := f[1]
-		if p.Name == maybeName && (p.AnyVersion || p.Version == maybeVersion) {
+		if p.Name == maybeName && (p.Version == "" || p.Version == maybeVersion) {
 			return true
 		}
 	}
@@ -141,7 +141,7 @@ func (m debManager) isPackageListed(p PackageQuery) (bool, error) {
 		}
 		maybeName := strings.Split(f[1], ".")[0]
 		maybeVersion := f[2]
-		if p.Name == maybeName && (p.AnyVersion || p.Version == maybeVersion) {
+		if p.Name == maybeName && (p.Version == "" || p.Version == maybeVersion) {
 			return true, nil
 		}
 	}
@@ -149,7 +149,7 @@ func (m debManager) isPackageListed(p PackageQuery) (bool, error) {
 }
 
 func packageName(p PackageQuery, delimeter string) string {
-	if p.AnyVersion {
+	if p.Version == "" {
 		return p.Name
 	}
 

--- a/pkg/inspector/check/package_manager.go
+++ b/pkg/inspector/check/package_manager.go
@@ -139,6 +139,12 @@ func (m debManager) isPackageListed(p PackageQuery) (bool, error) {
 			// Ignore lines with unexpected format
 			continue
 		}
+		if f[0] == "un" {
+			// skip if we see "un"
+			// The "u" means that the "Desired Action" for the package is "Unknown".
+			// The "n" means that the "Status" of the package is "Not installed"
+			continue
+		}
 		maybeName := strings.Split(f[1], ".")[0]
 		maybeVersion := f[2]
 		if p.Name == maybeName && (p.Version == "" || p.Version == maybeVersion) {

--- a/pkg/inspector/check/package_manager_test.go
+++ b/pkg/inspector/check/package_manager_test.go
@@ -44,7 +44,7 @@ NetworkManager.x86_64           1:1.0.6-30.el7_2               @koji-override-1`
 	m := rpmManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"NetworkManager", "1:1.0.6-30.el7_2", false}
+	p := PackageQuery{"NetworkManager", "1:1.0.6-30.el7_2"}
 	ok, _ := m.IsAvailable(p)
 	if !ok {
 		t.Error("expected true, but got false")
@@ -60,7 +60,7 @@ func TestRPMPackageManagerPackageNotFound(t *testing.T) {
 	m := rpmManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"NonExistent", "1.0", false}
+	p := PackageQuery{"NonExistent", "1.0"}
 	ok, err := m.IsAvailable(p)
 	if ok {
 		t.Error("expected false, but got true")
@@ -79,7 +79,7 @@ NetworkManager.x86_64           1:1.0.6-30.el7_2               @koji-override-1`
 	m := rpmManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"NetworkManager", "1.0", false}
+	p := PackageQuery{"NetworkManager", "1:1.0.7-30.el7_2"}
 	ok, err := m.IsAvailable(p)
 	if ok {
 		t.Error("expected false, but got true")
@@ -98,7 +98,7 @@ NetworkManager.x86_64           1:1.0.6-30.el7_2               @koji-override-1`
 	m := rpmManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"NetworkManager", "1.0", true}
+	p := PackageQuery{"NetworkManager", ""}
 	ok, err := m.IsAvailable(p)
 	if !ok {
 		t.Error("expected true, but got false")
@@ -117,7 +117,7 @@ NetworkManager.x86_64           1:1.0.6-30.el7_2               @koji-override-1`
 	m := rpmManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"NetworkManagr", "1:1.0.6-30.el7_2", false}
+	p := PackageQuery{"NetworkManagr", "1:1.0.6-30.el7_2"}
 	ok, err := m.IsAvailable(p)
 	if ok {
 		t.Error("expected false, but got true")
@@ -134,7 +134,7 @@ func TestRPMPackageManagerExecError(t *testing.T) {
 	m := rpmManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"SomePkg", "1.0", false}
+	p := PackageQuery{"SomePkg", "1.0"}
 	ok, err := m.IsAvailable(p)
 	if ok {
 		t.Error("expected false, but got true")
@@ -157,7 +157,7 @@ ii  libc6:amd64                                           2.23-0ubuntu3         
 	m := debManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"libc6", "2.23", false}
+	p := PackageQuery{"libc6", "2.23"}
 	ok, _ := m.IsAvailable(p)
 	if !ok {
 		t.Errorf("expected true, but got false")
@@ -177,7 +177,7 @@ ii  libc6:amd64                                           2.23-0ubuntu3         
 	m := debManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"libc6", "2.30", true}
+	p := PackageQuery{"libc6", ""}
 	ok, _ := m.IsAvailable(p)
 	if !ok {
 		t.Errorf("expected true, but got false")
@@ -194,7 +194,7 @@ func TestDebPackageManagerPackageNotInstalledButAvailable(t *testing.T) {
 	m := debManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"libc6a", "1.0", false}
+	p := PackageQuery{"libc6a", "1.0"}
 	ok, err := m.IsAvailable(p)
 	if !ok {
 		t.Errorf("expected true, got false")
@@ -214,7 +214,7 @@ func TestDebPackageManagerPackageNotInstalledNotAvailable(t *testing.T) {
 	m := debManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"libc6a", "1.0", false}
+	p := PackageQuery{"libc6a", "1.0"}
 	ok, err := m.IsAvailable(p)
 	if ok {
 		t.Errorf("expected false, but got true")
@@ -231,7 +231,7 @@ func TestDebPackageManagerExecError(t *testing.T) {
 	m := debManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"", "", false}
+	p := PackageQuery{"", ""}
 	ok, err := m.IsInstalled(p)
 	if ok {
 		t.Error("expected false, but got true")
@@ -248,7 +248,7 @@ func TestDebPackageManagerExecError2(t *testing.T) {
 	m := debManager{
 		run: mock.run,
 	}
-	p := PackageQuery{"", "", false}
+	p := PackageQuery{"", ""}
 	ok, err := m.IsAvailable(p)
 	if ok {
 		t.Error("expected false, but got true")

--- a/pkg/inspector/check/package_manager_test.go
+++ b/pkg/inspector/check/package_manager_test.go
@@ -184,6 +184,26 @@ ii  libc6:amd64                                           2.23-0ubuntu3         
 	}
 }
 
+func TestDebPackageManagerUN(t *testing.T) {
+	out := `Desired=Unknown/Install/Remove/Purge/Hold
+	| Status=Not/Inst/Conf-files/Unpacked/halF-conf/Half-inst/trig-aWait/Trig-pend
+	|/ Err?=(none)/Reinst-required (Status,Err: uppercase=bad)
+	||/ Name                                         Version                     Architecture                Description
+	+++-============================================-===========================-===========================-==============================================================================================
+	un  docker                                       <none>                      <none>                      (no description available)`
+	mock := runMock{
+		dpkgOut: out,
+	}
+	m := debManager{
+		run: mock.run,
+	}
+	p := PackageQuery{"docker", ""}
+	ok, _ := m.IsInstalled(p)
+	if ok {
+		t.Errorf("expected false, but got true")
+	}
+}
+
 func TestDebPackageManagerPackageNotInstalledButAvailable(t *testing.T) {
 	mock := runMock{
 		dpkgOut:   "dpkg-query: no packages found matching libc6a",

--- a/pkg/inspector/check/package_not_installed.go
+++ b/pkg/inspector/check/package_not_installed.go
@@ -1,0 +1,41 @@
+package check
+
+import "fmt"
+
+type PackageNotInstalledCheck struct {
+	PackageQuery             PackageQuery
+	AcceptablePackageVersion string
+	PackageManager           PackageManager
+	InstallationDisabled     bool
+}
+
+// Check returns true if the specified package is not installed.
+// This will also return true if the version installed matches AcceptablePackageVersion.
+// When InstallationDisabled is true this check will always return true.
+func (c PackageNotInstalledCheck) Check() (bool, error) {
+	// don't check when installation is disabled
+	if c.InstallationDisabled {
+		return true, nil
+	}
+	// check for the package with optional version is installed
+	installed, err := c.PackageManager.IsInstalled(c.PackageQuery)
+	if err != nil {
+		return false, fmt.Errorf("failed to determine if package is installed: %v", err)
+	}
+	// return true if nothing is installed
+	if !installed {
+		return true, nil
+	}
+	if c.AcceptablePackageVersion == "" {
+		return false, fmt.Errorf("package should not be installed")
+	}
+	// check if the version installed is the acceptable version
+	acceptableVersionInstalled, err := c.PackageManager.IsInstalled(PackageQuery{Name: c.PackageQuery.Name, Version: c.AcceptablePackageVersion})
+	if err != nil {
+		return false, fmt.Errorf("failed to determine if package is installed: %v", err)
+	}
+	if acceptableVersionInstalled {
+		return true, nil
+	}
+	return false, nil
+}

--- a/pkg/inspector/check/package_test.go
+++ b/pkg/inspector/check/package_test.go
@@ -88,7 +88,7 @@ func TestPackageCheck(t *testing.T) {
 
 	for i, test := range tests {
 		c := PackageCheck{
-			PackageQuery:         PackageQuery{"somePkg", "someVersion", false},
+			PackageQuery:         PackageQuery{"somePkg", "someVersion"},
 			PackageManager:       stubPkgManager{installed: test.isInstalled, available: test.isAvailable},
 			InstallationDisabled: test.installationDisabled,
 			ShouldNotBeInstalled: test.shouldNotBeInstalled,

--- a/pkg/inspector/check/package_test.go
+++ b/pkg/inspector/check/package_test.go
@@ -20,9 +20,9 @@ func TestPackageCheck(t *testing.T) {
 		installationDisabled bool
 		isInstalled          bool
 		isAvailable          bool
-		shouldNotBeInstalled bool
-		expected             bool
-		errExpected          bool
+
+		expected    bool
+		errExpected bool
 	}{
 		{
 			installationDisabled: true,
@@ -68,22 +68,6 @@ func TestPackageCheck(t *testing.T) {
 			isAvailable:          false,
 			expected:             true,
 		},
-		{
-			installationDisabled: false,
-			isInstalled:          true,
-			isAvailable:          true,
-			shouldNotBeInstalled: true,
-			expected:             false,
-			errExpected:          true,
-		},
-		{
-			installationDisabled: true,
-			isInstalled:          true,
-			isAvailable:          true,
-			shouldNotBeInstalled: true,
-			expected:             true,
-			errExpected:          false,
-		},
 	}
 
 	for i, test := range tests {
@@ -91,7 +75,6 @@ func TestPackageCheck(t *testing.T) {
 			PackageQuery:         PackageQuery{"somePkg", "someVersion"},
 			PackageManager:       stubPkgManager{installed: test.isInstalled, available: test.isAvailable},
 			InstallationDisabled: test.installationDisabled,
-			ShouldNotBeInstalled: test.shouldNotBeInstalled,
 		}
 		ok, err := c.Check()
 		if err != nil && !test.errExpected {

--- a/pkg/inspector/check/package_test.go
+++ b/pkg/inspector/check/package_test.go
@@ -20,6 +20,7 @@ func TestPackageCheck(t *testing.T) {
 		installationDisabled bool
 		isInstalled          bool
 		isAvailable          bool
+		shouldNotBeInstalled bool
 		expected             bool
 		errExpected          bool
 	}{
@@ -67,6 +68,22 @@ func TestPackageCheck(t *testing.T) {
 			isAvailable:          false,
 			expected:             true,
 		},
+		{
+			installationDisabled: false,
+			isInstalled:          true,
+			isAvailable:          true,
+			shouldNotBeInstalled: true,
+			expected:             false,
+			errExpected:          true,
+		},
+		{
+			installationDisabled: true,
+			isInstalled:          true,
+			isAvailable:          true,
+			shouldNotBeInstalled: true,
+			expected:             true,
+			errExpected:          false,
+		},
 	}
 
 	for i, test := range tests {
@@ -74,6 +91,7 @@ func TestPackageCheck(t *testing.T) {
 			PackageQuery:         PackageQuery{"somePkg", "someVersion", false},
 			PackageManager:       stubPkgManager{installed: test.isInstalled, available: test.isAvailable},
 			InstallationDisabled: test.installationDisabled,
+			ShouldNotBeInstalled: test.shouldNotBeInstalled,
 		}
 		ok, err := c.Check()
 		if err != nil && !test.errExpected {

--- a/pkg/inspector/rule/check_mapper.go
+++ b/pkg/inspector/rule/check_mapper.go
@@ -32,7 +32,7 @@ func (m DefaultCheckMapper) GetCheckForRule(rule Rule) (check.Check, error) {
 		return nil, fmt.Errorf("Rule of type %T is not supported", r)
 	case PackageDependency:
 		pkgQuery := check.PackageQuery{Name: r.PackageName, Version: r.PackageVersion, AnyVersion: r.AnyVersion}
-		c = &check.PackageCheck{PackageQuery: pkgQuery, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled}
+		c = &check.PackageCheck{PackageQuery: pkgQuery, ShouldNotBeInstalled: r.ShouldNotBeInstalled, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled}
 	case ExecutableInPath:
 		c = &check.ExecutableInPathCheck{Name: r.Executable}
 	case FileContentMatches:

--- a/pkg/inspector/rule/check_mapper.go
+++ b/pkg/inspector/rule/check_mapper.go
@@ -31,7 +31,7 @@ func (m DefaultCheckMapper) GetCheckForRule(rule Rule) (check.Check, error) {
 	default:
 		return nil, fmt.Errorf("Rule of type %T is not supported", r)
 	case PackageDependency:
-		pkgQuery := check.PackageQuery{Name: r.PackageName, Version: r.PackageVersion, AnyVersion: r.AnyVersion}
+		pkgQuery := check.PackageQuery{Name: r.PackageName, Version: r.PackageVersion}
 		c = &check.PackageCheck{PackageQuery: pkgQuery, ShouldNotBeInstalled: r.ShouldNotBeInstalled, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled}
 	case ExecutableInPath:
 		c = &check.ExecutableInPathCheck{Name: r.Executable}

--- a/pkg/inspector/rule/check_mapper.go
+++ b/pkg/inspector/rule/check_mapper.go
@@ -32,7 +32,10 @@ func (m DefaultCheckMapper) GetCheckForRule(rule Rule) (check.Check, error) {
 		return nil, fmt.Errorf("Rule of type %T is not supported", r)
 	case PackageDependency:
 		pkgQuery := check.PackageQuery{Name: r.PackageName, Version: r.PackageVersion}
-		c = &check.PackageCheck{PackageQuery: pkgQuery, ShouldNotBeInstalled: r.ShouldNotBeInstalled, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled}
+		c = &check.PackageCheck{PackageQuery: pkgQuery, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled}
+	case PackageNotInstalled:
+		pkgQuery := check.PackageQuery{Name: r.PackageName, Version: r.PackageVersion}
+		c = check.PackageNotInstalledCheck{PackageQuery: pkgQuery, AcceptablePackageVersion: r.AcceptablePackageVersion, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled}
 	case ExecutableInPath:
 		c = &check.ExecutableInPathCheck{Name: r.Executable}
 	case FileContentMatches:

--- a/pkg/inspector/rule/encoding.go
+++ b/pkg/inspector/rule/encoding.go
@@ -37,7 +37,6 @@ type catchAllRule struct {
 	Meta                 `yaml:",inline"`
 	PackageName          string   `yaml:"packageName"`
 	PackageVersion       string   `yaml:"packageVersion"`
-	AnyVersion           bool     `yaml:"anyVersion"`
 	ShouldNotBeInstalled bool     `yaml:"shouldNotBeInstalled"`
 	Executable           string   `yaml:"executable"`
 	Port                 int      `yaml:"port"`
@@ -93,7 +92,6 @@ func buildRule(catchAll catchAllRule) (Rule, error) {
 		r := PackageDependency{
 			PackageName:          catchAll.PackageName,
 			PackageVersion:       catchAll.PackageVersion,
-			AnyVersion:           catchAll.AnyVersion,
 			ShouldNotBeInstalled: catchAll.ShouldNotBeInstalled,
 		}
 		r.Meta = meta

--- a/pkg/inspector/rule/encoding.go
+++ b/pkg/inspector/rule/encoding.go
@@ -34,19 +34,20 @@ func ReadFromFile(file string) ([]Rule, error) {
 // There might be a better way of doing this, but taking this
 // approach for now...
 type catchAllRule struct {
-	Meta              `yaml:",inline"`
-	PackageName       string   `yaml:"packageName"`
-	PackageVersion    string   `yaml:"packageVersion"`
-	AnyVersion        bool     `yaml:"anyVersion"`
-	Executable        string   `yaml:"executable"`
-	Port              int      `yaml:"port"`
-	ProcName          string   `yaml:"procName"`
-	File              string   `yaml:"file"`
-	ContentRegex      string   `yaml:"contentRegex"`
-	Timeout           string   `yaml:"timeout"`
-	SupportedVersions []string `yaml:"supportedVersions"`
-	Path              string   `yaml:"path"`
-	MinimumBytes      string   `yaml:"minimumBytes"`
+	Meta                 `yaml:",inline"`
+	PackageName          string   `yaml:"packageName"`
+	PackageVersion       string   `yaml:"packageVersion"`
+	AnyVersion           bool     `yaml:"anyVersion"`
+	ShouldNotBeInstalled bool     `yaml:"shouldNotBeInstalled"`
+	Executable           string   `yaml:"executable"`
+	Port                 int      `yaml:"port"`
+	ProcName             string   `yaml:"procName"`
+	File                 string   `yaml:"file"`
+	ContentRegex         string   `yaml:"contentRegex"`
+	Timeout              string   `yaml:"timeout"`
+	SupportedVersions    []string `yaml:"supportedVersions"`
+	Path                 string   `yaml:"path"`
+	MinimumBytes         string   `yaml:"minimumBytes"`
 }
 
 // UnmarshalRulesYAML unmarshals the data into a list of rules
@@ -90,9 +91,10 @@ func buildRule(catchAll catchAllRule) (Rule, error) {
 		return nil, fmt.Errorf("rule with kind %q is not supported", catchAll.Kind)
 	case "packagedependency":
 		r := PackageDependency{
-			PackageName:    catchAll.PackageName,
-			PackageVersion: catchAll.PackageVersion,
-			AnyVersion:     catchAll.AnyVersion,
+			PackageName:          catchAll.PackageName,
+			PackageVersion:       catchAll.PackageVersion,
+			AnyVersion:           catchAll.AnyVersion,
+			ShouldNotBeInstalled: catchAll.ShouldNotBeInstalled,
 		}
 		r.Meta = meta
 		return r, nil

--- a/pkg/inspector/rule/encoding.go
+++ b/pkg/inspector/rule/encoding.go
@@ -34,19 +34,19 @@ func ReadFromFile(file string) ([]Rule, error) {
 // There might be a better way of doing this, but taking this
 // approach for now...
 type catchAllRule struct {
-	Meta                 `yaml:",inline"`
-	PackageName          string   `yaml:"packageName"`
-	PackageVersion       string   `yaml:"packageVersion"`
-	ShouldNotBeInstalled bool     `yaml:"shouldNotBeInstalled"`
-	Executable           string   `yaml:"executable"`
-	Port                 int      `yaml:"port"`
-	ProcName             string   `yaml:"procName"`
-	File                 string   `yaml:"file"`
-	ContentRegex         string   `yaml:"contentRegex"`
-	Timeout              string   `yaml:"timeout"`
-	SupportedVersions    []string `yaml:"supportedVersions"`
-	Path                 string   `yaml:"path"`
-	MinimumBytes         string   `yaml:"minimumBytes"`
+	Meta                     `yaml:",inline"`
+	PackageName              string   `yaml:"packageName"`
+	PackageVersion           string   `yaml:"packageVersion"`
+	AcceptablePackageVersion string   `yaml:"acceptablePackageVersion"`
+	Executable               string   `yaml:"executable"`
+	Port                     int      `yaml:"port"`
+	ProcName                 string   `yaml:"procName"`
+	File                     string   `yaml:"file"`
+	ContentRegex             string   `yaml:"contentRegex"`
+	Timeout                  string   `yaml:"timeout"`
+	SupportedVersions        []string `yaml:"supportedVersions"`
+	Path                     string   `yaml:"path"`
+	MinimumBytes             string   `yaml:"minimumBytes"`
 }
 
 // UnmarshalRulesYAML unmarshals the data into a list of rules
@@ -90,9 +90,16 @@ func buildRule(catchAll catchAllRule) (Rule, error) {
 		return nil, fmt.Errorf("rule with kind %q is not supported", catchAll.Kind)
 	case "packagedependency":
 		r := PackageDependency{
-			PackageName:          catchAll.PackageName,
-			PackageVersion:       catchAll.PackageVersion,
-			ShouldNotBeInstalled: catchAll.ShouldNotBeInstalled,
+			PackageName:    catchAll.PackageName,
+			PackageVersion: catchAll.PackageVersion,
+		}
+		r.Meta = meta
+		return r, nil
+	case "packagenotinstalled":
+		r := PackageNotInstalled{
+			PackageName:              catchAll.PackageName,
+			PackageVersion:           catchAll.PackageVersion,
+			AcceptablePackageVersion: catchAll.AcceptablePackageVersion,
 		}
 		r.Meta = meta
 		return r, nil

--- a/pkg/inspector/rule/engine.go
+++ b/pkg/inspector/rule/engine.go
@@ -67,17 +67,19 @@ func (e *Engine) CloseChecks() error {
 }
 
 func shouldExecuteRule(rule Rule, facts []string) bool {
-	if len(rule.GetRuleMeta().When) == 0 {
-		// No conditions on the rule => always run
-		return true
-	}
 	// Run if and only if the all the conditions on the rule are
 	// satisfied by the facts
-	for _, whenCondition := range rule.GetRuleMeta().When {
+	for _, whenSlice := range rule.GetRuleMeta().When {
 		found := false
-		for _, l := range facts {
-			if whenCondition == l {
-				found = true
+		for _, whenCondition := range whenSlice {
+			for _, l := range facts {
+				if whenCondition == l {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
 			}
 		}
 		if !found {

--- a/pkg/inspector/rule/engine_test.go
+++ b/pkg/inspector/rule/engine_test.go
@@ -41,7 +41,7 @@ func TestEngine(t *testing.T) {
 	tests := []struct {
 		mapper          fakeRuleCheckMapper
 		rule            fakeRule
-		ruleWhen        []string
+		ruleWhen        [][]string
 		facts           []string
 		expectedResults []Result
 		expectErr       bool
@@ -87,8 +87,42 @@ func TestEngine(t *testing.T) {
 			rule: fakeRule{
 				name: "FailRule",
 			},
-			ruleWhen: []string{"ubuntu", "worker"},
+			ruleWhen: [][]string{[]string{"ubuntu"}, []string{"worker"}},
 			facts:    []string{"ubuntu", "worker", "otherFact"},
+			expectedResults: []Result{
+				{
+					Name:    "FailRule",
+					Success: false,
+					Error:   dummyError.Error(),
+				},
+			},
+		},
+		{
+			mapper: fakeRuleCheckMapper{
+				check: fakeCheck{ok: false, err: dummyError},
+			},
+			rule: fakeRule{
+				name: "FailRule",
+			},
+			ruleWhen: [][]string{[]string{"ubuntu"}, []string{"master", "worker"}},
+			facts:    []string{"ubuntu", "worker", "otherFact"},
+			expectedResults: []Result{
+				{
+					Name:    "FailRule",
+					Success: false,
+					Error:   dummyError.Error(),
+				},
+			},
+		},
+		{
+			mapper: fakeRuleCheckMapper{
+				check: fakeCheck{ok: false, err: dummyError},
+			},
+			rule: fakeRule{
+				name: "FailRule",
+			},
+			ruleWhen: [][]string{[]string{"centos", "rhel"}, []string{"worker"}},
+			facts:    []string{"centos", "worker", "otherFact"},
 			expectedResults: []Result{
 				{
 					Name:    "FailRule",
@@ -105,7 +139,7 @@ func TestEngine(t *testing.T) {
 			rule: fakeRule{
 				name: "FailRule",
 			},
-			ruleWhen:        []string{"ubuntu"},
+			ruleWhen:        [][]string{[]string{"ubuntu"}},
 			facts:           []string{"otherFact"},
 			expectedResults: []Result{},
 		},
@@ -117,7 +151,7 @@ func TestEngine(t *testing.T) {
 			rule: fakeRule{
 				name: "FailRule",
 			},
-			ruleWhen: []string{},
+			ruleWhen: [][]string{},
 			facts:    []string{"ubuntu"},
 			expectedResults: []Result{
 				{

--- a/pkg/inspector/rule/package.go
+++ b/pkg/inspector/rule/package.go
@@ -9,9 +9,8 @@ import (
 // that can be installed via an operating system's package manager.
 type PackageDependency struct {
 	Meta
-	PackageName          string
-	PackageVersion       string
-	ShouldNotBeInstalled bool
+	PackageName    string
+	PackageVersion string
 }
 
 // Name returns the name of the rule

--- a/pkg/inspector/rule/package.go
+++ b/pkg/inspector/rule/package.go
@@ -11,14 +11,13 @@ type PackageDependency struct {
 	Meta
 	PackageName          string
 	PackageVersion       string
-	AnyVersion           bool
 	ShouldNotBeInstalled bool
 }
 
 // Name returns the name of the rule
 func (p PackageDependency) Name() string {
 	name := fmt.Sprintf(`Package "%s %s"`, p.PackageName, p.PackageVersion)
-	if p.AnyVersion {
+	if p.PackageVersion == "" {
 		name = fmt.Sprintf(`Package "%s"`, p.PackageName)
 	}
 	return name
@@ -32,9 +31,6 @@ func (p PackageDependency) Validate() []error {
 	err := []error{}
 	if p.PackageName == "" {
 		err = append(err, errors.New("PackageName cannot be empty"))
-	}
-	if !p.AnyVersion && p.PackageVersion == "" {
-		err = append(err, errors.New("PackageVersion cannot be empty"))
 	}
 	if len(err) > 0 {
 		return err

--- a/pkg/inspector/rule/package.go
+++ b/pkg/inspector/rule/package.go
@@ -9,14 +9,19 @@ import (
 // that can be installed via an operating system's package manager.
 type PackageDependency struct {
 	Meta
-	PackageName    string
-	PackageVersion string
-	AnyVersion     bool
+	PackageName          string
+	PackageVersion       string
+	AnyVersion           bool
+	ShouldNotBeInstalled bool
 }
 
 // Name returns the name of the rule
 func (p PackageDependency) Name() string {
-	return fmt.Sprintf(`Package "%s %s"`, p.PackageName, p.PackageVersion)
+	name := fmt.Sprintf(`Package "%s %s"`, p.PackageName, p.PackageVersion)
+	if p.AnyVersion {
+		name = fmt.Sprintf(`Package "%s"`, p.PackageName)
+	}
+	return name
 }
 
 // IsRemoteRule returns true if the rule is to be run from outside of the node

--- a/pkg/inspector/rule/package_not_installed.go
+++ b/pkg/inspector/rule/package_not_installed.go
@@ -1,0 +1,38 @@
+package rule
+
+import (
+	"errors"
+	"fmt"
+)
+
+// The PackageNotInstalled validates that a specified package in not installed.
+type PackageNotInstalled struct {
+	Meta
+	PackageName              string
+	PackageVersion           string
+	AcceptablePackageVersion string
+}
+
+// Name returns the name of the rule
+func (p PackageNotInstalled) Name() string {
+	name := fmt.Sprintf(`Package "%s" should not be installed`, p.PackageName)
+	if p.AcceptablePackageVersion != "" {
+		name = fmt.Sprintf(`%s, only acceptable version is "%s"`, name, p.AcceptablePackageVersion)
+	}
+	return name
+}
+
+// IsRemoteRule returns true if the rule is to be run from outside of the node
+func (p PackageNotInstalled) IsRemoteRule() bool { return false }
+
+// Validate the rule
+func (p PackageNotInstalled) Validate() []error {
+	err := []error{}
+	if p.PackageName == "" {
+		err = append(err, errors.New("PackageName cannot be empty"))
+	}
+	if len(err) > 0 {
+		return err
+	}
+	return nil
+}

--- a/pkg/inspector/rule/package_test.go
+++ b/pkg/inspector/rule/package_test.go
@@ -5,19 +5,19 @@ import "testing"
 func TestPackageDependencyRuleValidation(t *testing.T) {
 	p := PackageDependency{}
 	errs := p.Validate()
-	if len(errs) != 2 {
-		t.Errorf("expected 2 errors, but got %d", len(errs))
+	if len(errs) != 1 {
+		t.Errorf("expected 1 errors, but got %d", len(errs))
 	}
 	p.PackageName = "foo"
-	if errs := p.Validate(); len(errs) != 1 {
-		t.Errorf("expected 1 error, but got %d", len(errs))
-	}
-	p.AnyVersion = true
 	if errs := p.Validate(); len(errs) != 0 {
-		t.Errorf("expected to be vakid, but got %v", errs)
+		t.Errorf("expected to be valid, but got %d", len(errs))
+	}
+	p.PackageVersion = ""
+	if errs := p.Validate(); len(errs) != 0 {
+		t.Errorf("expected to be valid, but got %v", errs)
 	}
 	p.PackageVersion = "1.0"
 	if errs := p.Validate(); len(errs) != 0 {
-		t.Errorf("expected 0 error, but got %d", len(errs))
+		t.Errorf("expected to be valid, but got %d", len(errs))
 	}
 }

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -50,18 +50,22 @@ const defaultRuleSet = `---
   when: 
   - ["etcd"]
   port: 2379
+  procName: docker-proxy # docker sets up a proxy for the etcd container
 - kind: TCPPortAvailable
   when: 
   - ["etcd"]
   port: 6666
+  procName: docker-proxy # docker sets up a proxy for the etcd container
 - kind: TCPPortAvailable
   when: 
   - ["etcd"]
   port: 2380
+  procName: docker-proxy # docker sets up a proxy for the etcd container
 - kind: TCPPortAvailable
   when: 
   - ["etcd"]
   port: 6660
+  procName: docker-proxy # docker sets up a proxy for the etcd container
 
 # Ports used by etcd are accessible
 - kind: TCPPortAccessible
@@ -90,20 +94,24 @@ const defaultRuleSet = `---
   when: 
   - ["master"]
   port: 6443
+  procName: kube-apiserver
 - kind: TCPPortAvailable
   when: 
   - ["master"]
   port: 8080
+  procName: kube-apiserver
 # kube-scheduler
 - kind: TCPPortAvailable
   when: 
   - ["master"]
   port: 10251
+  procName: kube-scheduler
 # kube-controller-manager
 - kind: TCPPortAvailable
   when: 
   - ["master"]
   port: 10252
+  procName: kube-controller
 
 # Ports used by K8s master are accessible
 # Port 8080 is not accessible from outside
@@ -131,31 +139,37 @@ const defaultRuleSet = `---
   when: 
   - ["master", "worker", "ingress", "storage"]
   port: 4194
+  procName: kubelet
 # kubelet localhost healthz
 - kind: TCPPortAvailable
   when: 
   - ["master", "worker", "ingress", "storage"]
   port: 10248
+  procName: kubelet
 # kube-proxy metrics
 - kind: TCPPortAvailable
   when: 
   - ["master", "worker", "ingress", "storage"]
   port: 10249
+  procName: kube-proxy
 # kube-proxy health
 - kind: TCPPortAvailable
   when: 
   - ["master", "worker", "ingress", "storage"]
   port: 10256
+  procName: kube-proxy
 # kubelet
 - kind: TCPPortAvailable
   when: 
   - ["master", "worker", "ingress", "storage"]
   port: 10250
+  procName: kubelet
 # kubelet no auth
 - kind: TCPPortAvailable
   when: 
   - ["master", "worker", "ingress", "storage"]
   port: 10255
+  procName: kubelet
 
 # Ports used by K8s worker are accessible
 # cAdvisor
@@ -182,6 +196,7 @@ const defaultRuleSet = `---
   when: 
   - ["ingress"]
   port: 80
+  procName: nginx
 - kind: TCPPortAccessible
   when: 
   - ["ingress"]
@@ -191,6 +206,7 @@ const defaultRuleSet = `---
   when: 
   - ["ingress"]
   port: 443
+  procName: nginx
 - kind: TCPPortAccessible
   when: 
   - ["ingress"]
@@ -201,6 +217,7 @@ const defaultRuleSet = `---
   when: 
   - ["ingress"]
   port: 10254
+  procName: nginx-ingress-c
 - kind: TCPPortAccessible
   when: 
   - ["ingress"]
@@ -212,6 +229,7 @@ const defaultRuleSet = `---
   when: 
   - ["storage"]
   port: 8081
+  procName: exechealthz
 - kind: TCPPortAccessible
   when: 
   - ["storage"]
@@ -233,6 +251,7 @@ const defaultRuleSet = `---
   when: 
   - ["storage"]
   port: 2049
+  procName: glusterfs
 - kind: TCPPortAccessible
   when: 
   - ["storage"]
@@ -242,6 +261,7 @@ const defaultRuleSet = `---
   when: 
   - ["storage"]
   port: 38465
+  procName: glusterfs
 - kind: TCPPortAccessible
   when: 
   - ["storage"]
@@ -251,6 +271,7 @@ const defaultRuleSet = `---
   when: 
   - ["storage"]
   port: 38466
+  procName: glusterfs
 - kind: TCPPortAccessible
   when: 
   - ["storage"]
@@ -260,6 +281,7 @@ const defaultRuleSet = `---
   when: 
   - ["storage"]
   port: 38467
+  procName: glusterfs
 - kind: TCPPortAccessible
   when: 
   - ["storage"]

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -5,6 +5,17 @@ import (
 	"strings"
 )
 
+/*
+- kind: __RuleName__
+  when:
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel", "centos"]
+  ...
+
+This rule will be executed when the node has these facts:
+  ("etcd" OR "master" OR "worker" OR "ingress" OR "storage") AND ("rhel" OR "centos")
+*/
+
 // DefaultRuleSet is the list of rules that are built into the inspector
 const defaultRuleSet = `---
 - kind: FreeSpace
@@ -22,432 +33,426 @@ const defaultRuleSet = `---
 
 # Executables required by kubelet
 - kind: ExecutableInPath
-  when: ["master","worker"]
+  when:
+  - ["master", "worker", "ingress", "storage"]
   executable: iptables
 - kind: ExecutableInPath
-  when: ["master","worker"]
+  when:
+  - ["master", "worker", "ingress", "storage"]
   executable: iptables-save
 - kind: ExecutableInPath
-  when: ["master","worker"]
+  when:
+  - ["master", "worker", "ingress", "storage"]
   executable: iptables-restore
 
 # Ports used by etcd are available
 - kind: TCPPortAvailable
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 2379
-  procName: docker-proxy # docker sets up a proxy for the etcd container
 - kind: TCPPortAvailable
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 6666
-  procName: docker-proxy # docker sets up a proxy for the etcd container
 - kind: TCPPortAvailable
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 2380
-  procName: docker-proxy # docker sets up a proxy for the etcd container
 - kind: TCPPortAvailable
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 6660
-  procName: docker-proxy # docker sets up a proxy for the etcd container
 
 # Ports used by etcd are accessible
 - kind: TCPPortAccessible
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 2379
   timeout: 5s
 - kind: TCPPortAccessible
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 6666
   timeout: 5s
 - kind: TCPPortAccessible
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 2380
   timeout: 5s
 - kind: TCPPortAccessible
-  when: ["etcd"]
+  when: 
+  - ["etcd"]
   port: 6660
   timeout: 5s
 
 # Ports used by K8s master are available
 - kind: TCPPortAvailable
-  when: ["master"]
+  when: 
+  - ["master"]
   port: 6443
-  procName: kube-apiserver
 - kind: TCPPortAvailable
-  when: ["master"]
+  when: 
+  - ["master"]
   port: 8080
-  procName: kube-apiserver
 # kube-scheduler
 - kind: TCPPortAvailable
-  when: ["master"]
+  when: 
+  - ["master"]
   port: 10251
-  procName: kube-scheduler
 # kube-controller-manager
 - kind: TCPPortAvailable
-  when: ["master"]
+  when: 
+  - ["master"]
   port: 10252
-  procName: kube-controller
 
 # Ports used by K8s master are accessible
 # Port 8080 is not accessible from outside
 - kind: TCPPortAccessible
-  when: ["master"]
+  when: 
+  - ["master"]
   port: 6443
   timeout: 5s
 # kube-scheduler
 - kind: TCPPortAccessible
-  when: ["master"]
+  when: 
+  - ["master"]
   port: 10251
   timeout: 5s
 # kube-controller-manager
 - kind: TCPPortAccessible
-  when: ["master"]
+  when: 
+  - ["master"]
   port: 10252
   timeout: 5s
 
 # Ports used by K8s worker are available
 # cAdvisor
 - kind: TCPPortAvailable
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 4194
-  procName: kubelet
 # kubelet localhost healthz
 - kind: TCPPortAvailable
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 10248
-  procName: kubelet
 # kube-proxy metrics
 - kind: TCPPortAvailable
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 10249
-  procName: kube-proxy
 # kube-proxy health
 - kind: TCPPortAvailable
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 10256
-  procName: kube-proxy
 # kubelet
 - kind: TCPPortAvailable
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 10250
-  procName: kubelet
 # kubelet no auth
 - kind: TCPPortAvailable
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 10255
-  procName: kubelet
 
 # Ports used by K8s worker are accessible
 # cAdvisor
 - kind: TCPPortAccessible
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 4194
   timeout: 5s
 # kube-proxy
 - kind: TCPPortAccessible
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 10256
   timeout: 5s
 # kubelet
 - kind: TCPPortAccessible
-  when: ["master","worker","ingress","storage"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
   port: 10250
   timeout: 5s
 
 # Port used by Ingress
 - kind: TCPPortAvailable
-  when: ["ingress"]
+  when: 
+  - ["ingress"]
   port: 80
-  procName: nginx
 - kind: TCPPortAccessible
-  when: ["ingress"]
+  when: 
+  - ["ingress"]
   port: 80
   timeout: 5s
 - kind: TCPPortAvailable
-  when: ["ingress"]
+  when: 
+  - ["ingress"]
   port: 443
-  procName: nginx
 - kind: TCPPortAccessible
-  when: ["ingress"]
+  when: 
+  - ["ingress"]
   port: 443
   timeout: 5s
 # healthz
 - kind: TCPPortAvailable
-  when: ["ingress"]
+  when: 
+  - ["ingress"]
   port: 10254
-  procName: nginx-ingress-c
 - kind: TCPPortAccessible
-  when: ["ingress"]
+  when: 
+  - ["ingress"]
   port: 10254
   timeout: 5s
 
-
-- kind: PackageDependency
-  when: ["etcd","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["master","ubuntu"]
-  packageName: kubelet
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["master","ubuntu"]
-  packageName: nfs-common
-  anyVersion: true
-- kind: PackageDependency
-  when: ["master","ubuntu"]
-  packageName: kubectl
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["master","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: kubelet
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: nfs-common
-  anyVersion: true
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: kubelet
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: nfs-common
-  anyVersion: true
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
-  packageName: kubelet
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
-  packageName: nfs-common
-  anyVersion: true
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: kubectl
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: kubectl
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
-  packageName: kubectl
-  packageVersion: 1.9.0-00
-
-
-- kind: PackageDependency
-  when: ["etcd","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["master","centos"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["master","centos"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["master","centos"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["master","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-
-
-- kind: PackageDependency
-  when: ["etcd","rhel"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["master","rhel"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["master","rhel"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["master","rhel"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["master","rhel"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","rhel"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["ingress","rhel"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["storage","rhel"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","rhel"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["worker","rhel"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["ingress","rhel"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","rhel"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["storage","rhel"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","rhel"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["worker","rhel"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","rhel"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","rhel"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-
-
-# Gluster packages
-- kind: PackageDependency
-  when: ["storage", "centos"]
-  packageName: glusterfs-server
-  packageVersion: 3.8.15-2.el7
-- kind: PackageDependency
-  when: ["storage", "rhel"]
-  packageName: glusterfs-server
-  packageVersion: 3.8.15-2.el7
-- kind: PackageDependency
-  when: ["storage", "ubuntu"]
-  packageName: glusterfs-server
-  packageVersion: 3.8.15-ubuntu1~xenial1
-
 # Port required for gluster-healthz
 - kind: TCPPortAvailable
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 8081
-  procName: exechealthz
 - kind: TCPPortAccessible
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 8081
   timeout: 5s
 
 # Ports required for NFS
+# Removed due to https://github.com/apprenda/kismatic/issues/784
+#- kind: TCPPortAvailable
+#  when: 
+#  - ["storage"]
+#  port: 111
+#- kind: TCPPortAccessible
+#  when: 
+#  - ["storage"]
+#  port: 111
+#  timeout: 5s
 - kind: TCPPortAvailable
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 2049
-  procName: glusterfs
 - kind: TCPPortAccessible
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 2049
   timeout: 5s
 - kind: TCPPortAvailable
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 38465
-  procName: glusterfs
 - kind: TCPPortAccessible
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 38465
   timeout: 5s
 - kind: TCPPortAvailable
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 38466
-  procName: glusterfs
 - kind: TCPPortAccessible
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 38466
   timeout: 5s
 - kind: TCPPortAvailable
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 38467
-  procName: glusterfs
 - kind: TCPPortAccessible
-  when: ["storage"]
+  when: 
+  - ["storage"]
   port: 38467
   timeout: 5s
+
+- kind: PackageDependency
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: docker-ce
+  packageVersion: 17.03.2~ce-0~ubuntu-xenial
+- kind: PackageDependency
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: kubelet
+  packageVersion: 1.9.0-00
+- kind: PackageDependency
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: nfs-common
+- kind: PackageDependency
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: kubectl
+  packageVersion: 1.9.0-00
+# https://docs.docker.com/engine/installation/linux/docker-ee/ubuntu/#uninstall-old-versions
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: docker
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: docker-engine
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: docker-ce
+  acceptablePackageVersion: 17.03.2~ce-0~ubuntu-xenial
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
+  packageName: docker-ee
+
+- kind: PackageDependency
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker-ce
+  packageVersion: 17.03.2.ce-1.el7.centos
+- kind: PackageDependency
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: kubelet
+  packageVersion: 1.9.0-0
+- kind: PackageDependency
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: nfs-utils
+- kind: PackageDependency
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: kubectl
+  packageVersion: 1.9.0-0
+# https://docs.docker.com/engine/installation/linux/docker-ee/centos/
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker-common
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker-selinux
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker-engine-selinux
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker-engine
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker-ce
+  acceptablePackageVersion: 17.03.2.ce-1.el7.centos
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
+  packageName: docker-ee
+
+- kind: PackageDependency
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker-ce
+  packageVersion: 17.03.2.ce-1.el7.centos
+- kind: PackageDependency
+  when: 
+  - [master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: kubelet
+  packageVersion: 1.9.0-0
+- kind: PackageDependency
+  when: 
+  - [master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: nfs-utils
+- kind: PackageDependency
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: kubectl
+  packageVersion: 1.9.0-0
+# https://docs.docker.com/engine/installation/linux/docker-ee/rhel/#os-requirements
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker-common
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker-selinux
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker-engine-selinux
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker-engine
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker-ce
+  acceptablePackageVersion: 17.03.2.ce-1.el7.centos
+- kind: PackageNotInstalled
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
+  packageName: docker-ee
+
+# Gluster packages
+- kind: PackageDependency
+  when: 
+  - ["storage"]
+  - ["centos"]
+  packageName: glusterfs-server
+  packageVersion: 3.8.15-2.el7
+- kind: PackageDependency
+  when: 
+  - ["storage"]
+  - ["rhel"]
+  packageName: glusterfs-server
+  packageVersion: 3.8.15-2.el7
+- kind: PackageDependency
+  when: 
+  - ["storage"] 
+  - ["ubuntu"]
+  packageName: glusterfs-server
+  packageVersion: 3.8.15-ubuntu1~xenial1
 `
 
 const upgradeRuleSet = `---
@@ -456,225 +461,96 @@ const upgradeRuleSet = `---
   minimumBytes: 1000000000
 
 - kind: PackageDependency
-  when: ["etcd","ubuntu"]
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
   packageName: docker-ce
   packageVersion: 17.03.2~ce-0~ubuntu-xenial
 - kind: PackageDependency
-  when: ["master","ubuntu"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
   packageName: kubelet
   packageVersion: 1.9.0-00
 - kind: PackageDependency
-  when: ["master","ubuntu"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
   packageName: nfs-common
-  anyVersion: true
 - kind: PackageDependency
-  when: ["master","ubuntu"]
-  packageName: kubectl
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["master","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
-  packageName: docker-ce
-  packageVersion: 17.03.2~ce-0~ubuntu-xenial
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: kubelet
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: nfs-common
-  anyVersion: true
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: kubelet
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: nfs-common
-  anyVersion: true
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
-  packageName: kubelet
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
-  packageName: nfs-common
-  anyVersion: true
-- kind: PackageDependency
-  when: ["worker","ubuntu"]
-  packageName: kubectl
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["ingress","ubuntu"]
-  packageName: kubectl
-  packageVersion: 1.9.0-00
-- kind: PackageDependency
-  when: ["storage","ubuntu"]
+  when: 
+  - ["master", "worker", "ingress", "storage"]
+  - ["ubuntu"]
   packageName: kubectl
   packageVersion: 1.9.0-00
 
 - kind: PackageDependency
-  when: ["etcd","centos"]
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["centos"]
   packageName: docker-ce
   packageVersion: 17.03.2.ce-1.el7.centos
 - kind: PackageDependency
-  when: ["master","centos"]
+  when: 
+  - ["master", "worker", "ingress, storage"]
+  - ["centos"]
   packageName: kubelet
   packageVersion: 1.9.0-0
 - kind: PackageDependency
-  when: ["master","centos"]
+  when: 
+  - ["master", "worker", "ingress, storage"]
+  - ["centos"]
   packageName: nfs-utils
-  anyVersion: true
 - kind: PackageDependency
-  when: ["master","centos"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["master","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","centos"]
+  when: 
+  - ["master", "worker", "ingress, storage"]
+  - ["centos"]
   packageName: kubectl
   packageVersion: 1.9.0-0
 
 - kind: PackageDependency
-  when: ["etcd","rhel"]
+  when: 
+  - ["etcd", "master", "worker", "ingress", "storage"]
+  - ["rhel"]
   packageName: docker-ce
   packageVersion: 17.03.2.ce-1.el7.centos
 - kind: PackageDependency
-  when: ["master","rhel"]
+  when: 
+  - ["master", "worker", "ingress, storage"]
+  - ["rhel"]
   packageName: kubelet
   packageVersion: 1.9.0-0
 - kind: PackageDependency
-  when: ["master","rhel"]
+  when: 
+  - ["master", "worker", "ingress, storage"]
+  - ["rhel"]
   packageName: nfs-utils
-  anyVersion: true
 - kind: PackageDependency
-  when: ["master","rhel"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["master","rhel"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["ingress","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["storage","centos"]
-  packageName: docker-ce
-  packageVersion: 17.03.2.ce-1.el7.centos
-- kind: PackageDependency
-  when: ["worker","rhel"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["worker","rhel"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["ingress","rhel"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","rhel"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["storage","rhel"]
-  packageName: kubelet
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","rhel"]
-  packageName: nfs-utils
-  anyVersion: true
-- kind: PackageDependency
-  when: ["worker","rhel"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["ingress","rhel"]
-  packageName: kubectl
-  packageVersion: 1.9.0-0
-- kind: PackageDependency
-  when: ["storage","rhel"]
+  when: 
+  - ["master", "worker", "ingress, storage"]
+  - ["rhel"]
   packageName: kubectl
   packageVersion: 1.9.0-0
 
 # Gluster packages
 - kind: PackageDependency
-  when: ["storage", "centos"]
-  packageName: glusterfs-server
-  packageVersion: 3.8.15-2.el7
-- kind: PackageDependency
-  when: ["storage", "rhel"]
-  packageName: glusterfs-server
-  packageVersion: 3.8.15-2.el7
-- kind: PackageDependency
-  when: ["storage", "ubuntu"]
+  when: 
+  - ["storage"] 
+  - ["ubuntu"]
   packageName: glusterfs-server
   packageVersion: 3.8.15-ubuntu1~xenial1
+- kind: PackageDependency
+  when: 
+  - ["storage"] 
+  - ["centos"]
+  packageName: glusterfs-server
+  packageVersion: 3.8.15-2.el7
+- kind: PackageDependency
+  when: 
+  - ["storage"] 
+  - ["rhel"]
+  packageName: glusterfs-server
+  packageVersion: 3.8.15-2.el7
 `
 
 // DefaultRules returns the list of rules that are built into the inspector

--- a/pkg/inspector/rule/types.go
+++ b/pkg/inspector/rule/types.go
@@ -3,7 +3,7 @@ package rule
 // Meta contains the rule's metadata
 type Meta struct {
 	Kind string
-	When []string
+	When [][]string
 }
 
 // GetRuleMeta returns the rule's metadata


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/672, fixes https://github.com/apprenda/kismatic/issues/780

Added new inspector rules to check for packages that should not be installed, ie `docker`
```
Run Cluster Pre-Flight Checks                                                   [ERROR]
- Task: run pre-flight checks using Kismatic Inspector from the master
=> The following checks failed on "worker001":
   - Port Available: 4194
   - Port Available: 10248
   - Port Available: 10249
   - Port Available: 10256
   - Port Available: 10250
   - Port Available: 10255
   - Port Available: 80
   - Port Available: 443
   - Port Available: 10254
   - Package "docker": package should not be installed
   - Package "docker-engine": package should not be installed
   - Port Accessible: 4194
   - Port Accessible: 10256
   - Port Accessible: 10250
   - Port Accessible: 80
   - Port Accessible: 443
   - Port Accessible: 10254
=> The following checks failed on "master001":
   - Port Available: 6443
   - Port Available: 8080
   - Port Available: 10251
   - Port Available: 10252
   - Port Available: 4194
   - Port Available: 10248
   - Port Available: 10249
   - Port Available: 10256
   - Port Available: 10250
   - Port Available: 10255
   - Package "docker": package should not be installed
   - Package "docker-engine": package should not be installed
   - Port Accessible: 6443
   - Port Accessible: 10251
   - Port Accessible: 10252
   - Port Accessible: 4194
   - Port Accessible: 10256
   - Port Accessible: 10250
=> The following checks failed on "etcd001":
   - Port Available: 2379
   - Port Available: 6666
   - Port Available: 2380
   - Port Available: 6660
   - Package "docker": package should not be installed
   - Package "docker-engine": package should not be installed
   - Port Accessible: 2379
   - Port Accessible: 6666
   - Port Accessible: 2380
   - Port Accessible: 6660
```

This also fixed some rules that didn't actually run, ie:
```
 # cAdvisor
 - kind: TCPPortAvailable
-  when: ["master","worker","ingress","storage"]
+  when: ["master|worker|ingress|storage"]
   port: 4194
```
The rule above would require the node to have all those roles prior to the change.
