### PR TITLE
Enable KET to run in parallel, finally fix ssh default

### DIFF
--- a/integration/validate_test.go
+++ b/integration/validate_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"io"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -41,6 +42,29 @@ var _ = Describe("kismatic install validate tests", func() {
 						Fail("Unexpected error generating fake SSH key: %v")
 					}
 					ValidateKismaticMiniWithBadSSH(node, node.SSHUser, badSSHKey)
+				})
+			})
+		})
+	})
+
+	Describe("Running validation with relative path key", func() {
+		Context("Using Ubuntu 16.04", func() {
+			ItOnAWS("should result in an ssh validation error", func(aws infrastructureProvisioner) {
+				WithMiniInfrastructure(Ubuntu1604LTS, aws, func(node NodeDeets, sshKey string) {
+					from, err := os.Open(sshKey)
+					if err != nil {
+						Fail("Unexpected error opening SSH key: %v")
+					}
+					to, err := os.OpenFile("./ssh-key.pem", os.O_RDWR|os.O_CREATE, 0600)
+					if err != nil {
+						Fail("Unexpected error creating file for copied SSH key: %v")
+					}
+					defer to.Close()
+					_, err = io.Copy(to, from)
+					if err != nil {
+						Fail("Unexpected error copying SSH key: %v")
+					}
+					ValidateKismaticMini(node, node.SSHUser, "./ssh-key.pem")
 				})
 			})
 		})

--- a/pkg/ansible/runner.go
+++ b/pkg/ansible/runner.go
@@ -117,24 +117,17 @@ func (r *runner) startPlaybook(playbookFile string, inv Inventory, cc ClusterCat
 	if err != nil {
 		return nil, fmt.Errorf("error writing cluster catalog data to yaml: %v", err)
 	}
-	clusterCatalogFile := filepath.Join(r.ansibleDir, "clustercatalog.yaml")
-	if err = ioutil.WriteFile(clusterCatalogFile, yamlBytes, 0644); err != nil {
+	clusterCatalogFile := filepath.Join(r.runDir, "clustercatalog.yaml")
+	if err := ioutil.WriteFile(clusterCatalogFile, yamlBytes, 0644); err != nil {
 		return nil, fmt.Errorf("error writing cluster catalog file to %q: %v", clusterCatalogFile, err)
 	}
 
-	inventoryFile := filepath.Join(r.ansibleDir, "inventory.ini")
+	inventoryFile := filepath.Join(r.runDir, "inventory.ini")
 	if err := ioutil.WriteFile(inventoryFile, inv.ToINI(), 0644); err != nil {
 		return nil, fmt.Errorf("error writing inventory file to %q: %v", inventoryFile, err)
 	}
 
-	if err := copyFileContents(clusterCatalogFile, filepath.Join(r.runDir, "clustercatalog.yaml")); err != nil {
-		return nil, fmt.Errorf("error copying clustercatalog.yaml to %q: %v", r.runDir, err)
-	}
-	if err := copyFileContents(inventoryFile, filepath.Join(r.runDir, "inventory.ini")); err != nil {
-		return nil, fmt.Errorf("error copying inventory.ini to %q: %v", r.runDir, err)
-	}
-
-	cmd := exec.Command(filepath.Join(r.ansibleDir, "bin", "ansible-playbook"), "-i", inventoryFile, "-s", playbook, "--extra-vars", "@"+clusterCatalogFile)
+	cmd := exec.Command(filepath.Join(r.ansibleDir, "bin", "ansible-playbook"), "-i", filepath.Join(r.runDir, "inventory.ini"), "-s", playbook, "--extra-vars", "@"+filepath.Join(r.runDir, "clustercatalog.yaml"))
 	cmd.Stdout = r.out
 	cmd.Stderr = r.errOut
 

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -8,12 +8,14 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
 
 	"github.com/apprenda/kismatic/pkg/util"
 	garbler "github.com/michaelbironneau/garbler/lib"
+	homedir "github.com/mitchellh/go-homedir"
 
 	yaml "gopkg.in/yaml.v2"
 )
@@ -277,7 +279,7 @@ func buildPlanFromTemplateOptions(templateOpts PlanTemplateOptions) Plan {
 
 	// Set SSH defaults
 	p.Cluster.SSH.User = "kismaticuser"
-	p.Cluster.SSH.Key = "kismaticuser.key"
+	p.Cluster.SSH.Key = sshKey()
 	p.Cluster.SSH.Port = 22
 
 	// Set Networking defaults
@@ -386,6 +388,16 @@ func generateAlphaNumericPassword() (string, error) {
 		}
 		attempts++
 	}
+}
+
+func sshKey() string {
+	key := "kismaticuser.key"
+	home, err := homedir.Dir()
+	// fallback to returning just the key
+	if err != nil {
+		return key
+	}
+	return filepath.Join(home, ".ssh", key)
 }
 
 // The comment map contains is keyed by the value that should be commented

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -51,7 +51,7 @@ cluster:
     user: kismaticuser
 
     # Absolute path to the ssh private key we should use to manage nodes.
-    ssh_key: kismaticuser.key
+    ssh_key: /root/.ssh/kismaticuser.key
     ssh_port: 22
 
   # Override configuration of Kubernetes components.

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -51,7 +51,7 @@ cluster:
     user: kismaticuser
 
     # Absolute path to the ssh private key we should use to manage nodes.
-    ssh_key: kismaticuser.key
+    ssh_key: /root/.ssh/kismaticuser.key
     ssh_port: 22
 
   # Override configuration of Kubernetes components.

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -217,9 +217,6 @@ func (s *SSHConfig) validate() (bool, []error) {
 	if _, err := os.Stat(s.Key); os.IsNotExist(err) {
 		v.addError(fmt.Errorf("SSH Key file was not found at %q", s.Key))
 	}
-	if !filepath.IsAbs(s.Key) {
-		v.addError(errors.New("SSH Key field must be an absolute path"))
-	}
 	if s.Port < 1 || s.Port > 65535 {
 		v.addError(fmt.Errorf("SSH port %d is invalid. Port must be in the range 1-65535", s.Port))
 	}


### PR DESCRIPTION
* Fixes a few things that would prevent KET from running in parallel. 
  * Don't generate run files in the `ansible` directory
  * Prefix the runs directories with the cluster name
* Finally fixes the `ssh.key` not having to be an absolute path, it now defaults to the key inside the `$HOME/.ssh` directory.