### PR TITLE
Exposing the kube-dns metrics port

### DIFF
--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -102,9 +102,6 @@ spec:
         - --config-dir=/kube-dns-config
         #- --kube-master-url={{ kubernetes_master_ip }}
         - --v=2
-        # env:
-        # - name: PROMETHEUS_PORT
-        #   value: "10055"
         ports:
         - containerPort: 10053
           name: dns-local
@@ -121,6 +118,8 @@ spec:
           value: "{{ kubernetes_load_balanced_fqdn }}"
         - name: KUBERNETES_SERVICE_PORT
           value: "{{ kubernetes_master_secure_port }}"
+        - name: PROMETHEUS_PORT
+          value: "10055"
         # - containerPort: 10055
         #   name: metrics
         #   protocol: TCP


### PR DESCRIPTION
Uncommenting the PROMETHEUS_PORT environment variable to expose kube-dns metrics.