### PR TITLE
Http server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ vendor-provision/*
 vendor-kuberang/*
 vendor-helm
 .glide
+pkg/server/server

--- a/glide.lock
+++ b/glide.lock
@@ -1,68 +1,68 @@
-hash: f1e1c7515c49bc69417f943bf7c8dc863edf1b0936bd768db5284244e97ca0d5
-updated: 2017-07-25T11:20:54.761474195-04:00
+hash: 17aa369a37ff61bea9dfb7ff4d5f66d8f86de5612e6a2a424b104a6f878e263e
+updated: 2017-10-31T08:43:18.631038736-04:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 40f45e34986ba617a372d1590de273a0ca84a53d
   subpackages:
   - aws
   - aws/awserr
+  - aws/awsutil
+  - aws/client
+  - aws/client/metadata
+  - aws/corehandlers
   - aws/credentials
+  - aws/credentials/ec2rolecreds
+  - aws/credentials/endpointcreds
+  - aws/credentials/stscreds
+  - aws/defaults
+  - aws/ec2metadata
+  - aws/endpoints
+  - aws/request
   - aws/session
+  - aws/signer/v4
+  - internal/shareddefaults
+  - private/protocol
+  - private/protocol/ec2query
+  - private/protocol/json/jsonutil
+  - private/protocol/jsonrpc
+  - private/protocol/query
+  - private/protocol/query/queryutil
+  - private/protocol/rest
+  - private/protocol/restjson
+  - private/protocol/restxml
+  - private/protocol/xml/xmlutil
   - service/ec2
   - service/efs
   - service/route53
   - service/s3
-  - internal/shareddefaults
-  - aws/client
-  - aws/corehandlers
-  - aws/credentials/stscreds
-  - aws/defaults
-  - aws/endpoints
-  - aws/request
-  - aws/awsutil
-  - aws/client/metadata
-  - aws/signer/v4
-  - private/protocol
-  - private/protocol/ec2query
-  - private/protocol/restjson
-  - private/protocol/restxml
   - service/sts
-  - aws/credentials/ec2rolecreds
-  - aws/credentials/endpointcreds
-  - aws/ec2metadata
-  - private/protocol/rest
-  - private/protocol/query/queryutil
-  - private/protocol/xml/xmlutil
-  - private/protocol/jsonrpc
-  - private/protocol/query
-  - private/protocol/json/jsonutil
 - name: github.com/blang/semver
-  version: b38d23b8782a487059e8fc8773e9a5b228a77cb6
+  version: 2ee87856327ba09384cabd113bc6b5d174e9ec0f
 - name: github.com/cloudflare/cfssl
   version: db0d0650b6496bfe8061ec56a92edd32d8e75c30
   subpackages:
-  - csr
+  - api
+  - api/client
+  - auth
+  - certdb
+  - cli
   - cli/genkey
   - config
+  - crypto/pkcs7
+  - csr
+  - errors
   - helpers
+  - helpers/derhelpers
+  - info
   - initca
   - log
+  - ocsp/config
   - signer
   - signer/local
-  - errors
-  - cli
-  - auth
-  - ocsp/config
-  - crypto/pkcs7
-  - helpers/derhelpers
-  - certdb
-  - info
-  - signer/universal
   - signer/remote
-  - api/client
-  - api
+  - signer/universal
 - name: github.com/cpuguy83/go-md2man
-  version: a65d4d2de4d5f7c74868dfa9b202a3c8be315aaa
+  version: 1d903dcb749992f3741d744c0f8376b4bd7eb3e1
   subpackages:
   - md2man
 - name: github.com/fatih/color
@@ -74,9 +74,9 @@ imports:
   repo: https://github.com/google/certificate-transparency
   subpackages:
   - go
+  - go/asn1
   - go/client
   - go/x509
-  - go/asn1
   - go/x509/pkix
 - name: github.com/gosuri/uilive
   version: ac356e6e42cd31fcef8e6aec13ae9ed6fe87713e
@@ -84,10 +84,12 @@ imports:
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jmespath/go-jmespath
   version: bd40a432e4c76585ef6b72d3fd96fb9b6dc7b68d
+- name: github.com/julienschmidt/httprouter
+  version: 8c199fb6259ffc1af525cc3ad52ee60ba8359669
 - name: github.com/mattn/go-colorable
   version: 3fa8c76f9daed4067e4a806fb7e4dc86455c6d6a
 - name: github.com/mattn/go-isatty
-  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+  version: 0360b2af4f38e8d38c7fce2a9f4e702702d73a39
 - name: github.com/michaelbironneau/garbler
   version: eaea49f3709333a999768eddd70d24eba599e78d
   subpackages:
@@ -102,35 +104,35 @@ imports:
   subpackages:
   - config
   - internal/codelocation
+  - internal/containernode
   - internal/failer
+  - internal/leafnodes
   - internal/remote
+  - internal/spec
+  - internal/spec_iterator
+  - internal/specrunner
   - internal/suite
   - internal/testingtproxy
   - internal/writer
   - reporters
   - reporters/stenographer
-  - types
-  - internal/spec_iterator
-  - internal/containernode
-  - internal/leafnodes
-  - internal/spec
-  - internal/specrunner
   - reporters/stenographer/support/go-colorable
   - reporters/stenographer/support/go-isatty
+  - types
 - name: github.com/onsi/gomega
   version: c893efa28eb45626cdaa76c9f653b62488858837
   subpackages:
+  - format
   - internal/assertion
   - internal/asyncassertion
+  - internal/oraclematcher
   - internal/testingtsupport
   - matchers
-  - types
-  - internal/oraclematcher
-  - format
   - matchers/support/goraph/bipartitegraph
   - matchers/support/goraph/edge
   - matchers/support/goraph/node
   - matchers/support/goraph/util
+  - types
 - name: github.com/packethost/packngo
   version: 8ff1de745a8a4fdc5323ffd9ac2bc55195ff671e
 - name: github.com/pkg/browser
@@ -144,19 +146,21 @@ imports:
   - doc
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+- name: github.com/urfave/negroni
+  version: fde5e16d32adc7ad637e9cd9ad21d4ebc6192535
 - name: golang.org/x/crypto
   version: 1f22c0103821b9390939b6776727195525381532
   subpackages:
-  - ssh
-  - pkcs12
   - curve25519
+  - pkcs12
   - pkcs12/internal/rc2
+  - ssh
 - name: golang.org/x/net
   version: ab5485076ff3407ad2d02db054635913f017b0ed
   subpackages:
-  - html/charset
   - html
   - html/atom
+  - html/charset
 - name: golang.org/x/sys
   version: 85d149506305e7abe0aca5ad5ac4b1fce82ccd11
   subpackages:
@@ -167,18 +171,18 @@ imports:
   - encoding
   - encoding/charmap
   - encoding/htmlindex
-  - transform
-  - encoding/internal/identifier
   - encoding/internal
+  - encoding/internal/identifier
   - encoding/japanese
   - encoding/korean
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
   - encoding/unicode
-  - language
-  - internal/utf8internal
-  - runes
   - internal/tag
+  - internal/utf8internal
+  - language
+  - runes
+  - transform
 - name: gopkg.in/yaml.v2
   version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,3 +20,7 @@ import:
   version: ~0.0.1
 - package: github.com/blang/semver
   version: ~3.5.0
+- package: github.com/urfave/negroni
+  version: ^0.2.0
+- package: github.com/julienschmidt/httprouter
+  version: ^1.1.0

--- a/pkg/cli/kismatic.go
+++ b/pkg/cli/kismatic.go
@@ -31,6 +31,7 @@ more documentation is availble at https://github.com/apprenda/kismatic`,
 	cmd.AddCommand(NewCmdDiagnostic(out))
 	cmd.AddCommand(NewCmdCertificates(out))
 	cmd.AddCommand(NewCmdSeedRegistry(out, stderr))
+	cmd.AddCommand(NewCmdServer(out))
 
 	return cmd, nil
 }

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	nethttp "net/http"
+
+	"github.com/apprenda/kismatic/pkg/server/http"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	defaultTimeout = 10 * time.Second
+)
+
+type serverOptions struct {
+	port     string
+	certFile string
+	keyFile  string
+}
+
+func NewCmdServer(stdout io.Writer) *cobra.Command {
+	var options serverOptions
+	cmd := &cobra.Command{
+		Use:   "server",
+		Short: "server starts an http server",
+		Long: `
+Start an HTTP server to manage KET clusters. The API has endpoints to create, mutate, delete and view clusters.
+
+A local datastore will be created to persist the state of the clusters managed by this server.
+
+If cert-file or key-file are not provided, a self-signed CA will be used to create the required key-pair for TLS. 
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return cmd.Usage()
+			}
+			return doServer(stdout, options)
+		},
+	}
+	cmd.Flags().StringVarP(&options.port, "port", "p", "443", "port to start the server on")
+	cmd.Flags().StringVar(&options.certFile, "cert-file", "", "path to the TLS cert file")
+	cmd.Flags().StringVar(&options.keyFile, "key-file", "", "path to the TLS key file")
+	return cmd
+}
+
+func doServer(stdout io.Writer, options serverOptions) error {
+	logger := http.DefaultLogger(stdout, "[kismatic] ")
+	server, err := http.New(logger, options.port, options.certFile, options.keyFile, defaultTimeout, defaultTimeout)
+	if err != nil {
+		logger.Fatalf("Error creating server: %v", err)
+	}
+
+	// setup interrupt channgel for graceful shutdown
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		logger.Println("Starting server...")
+		if err := server.RunTLS(); err != nethttp.ErrServerClosed {
+			logger.Fatalf("Error starting server: %v", err)
+		}
+	}()
+
+	<-stop
+
+	if err := server.Shutdown(30 * time.Second); err != nil {
+		logger.Fatalf("Error shutting down server: %v", err)
+	}
+	return nil
+}

--- a/pkg/server/http/certificate.go
+++ b/pkg/server/http/certificate.go
@@ -1,0 +1,54 @@
+package http
+
+import (
+	"bytes"
+	"time"
+
+	"github.com/apprenda/kismatic/pkg/tls"
+	"github.com/cloudflare/cfssl/csr"
+)
+
+const selfSignedCSR = `
+{
+  "CN": "Kubernetes",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "US",
+      "L": "Troy",
+      "O": "Kubernetes",
+      "OU": "CA",
+      "ST": "New York"
+    }
+  ]
+}
+`
+
+const expiry = 8760 * time.Hour
+
+func selfSignedCert() (key, cert []byte, err error) {
+	caKey, caCert, err := tls.NewCACertFromReader(bytes.NewBufferString(selfSignedCSR), "kismatic", expiry.String())
+	if err != nil {
+		return nil, nil, err
+	}
+	certHosts := []string{"127.0.0.1", "localhost", "0.0.0.0"}
+	req := csr.CertificateRequest{
+		CN:    "localhost",
+		Hosts: certHosts,
+		KeyRequest: &csr.BasicKeyRequest{
+			A: "rsa",
+			S: 2048,
+		},
+	}
+	ca := &tls.CA{
+		Key:  caKey,
+		Cert: caCert,
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	return tls.NewCert(ca, req, 8760*time.Hour)
+}

--- a/pkg/server/http/handler/healthz.go
+++ b/pkg/server/http/handler/healthz.go
@@ -1,0 +1,13 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+// Healthz returns 200
+// In the future we should report the status of the database and any other dependency
+func Healthz(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+	w.Write([]byte("ok"))
+}

--- a/pkg/server/http/handler/healthz_test.go
+++ b/pkg/server/http/handler/healthz_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func TestHealthzHandler(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	// Create a request to pass to our handler
+	req, err := http.NewRequest("GET", "/healthz", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We create a ResponseRecorder (which satisfies http.ResponseWriter) to record the response
+	rr := httptest.NewRecorder()
+
+	// Call their ServeHTTP method directly and pass in our Request and ResponseRecorder
+	r := httprouter.New()
+	r.GET("/healthz", Healthz)
+	r.ServeHTTP(rr, req)
+
+	// Check the status code is as expected
+	if status := rr.Code; status != http.StatusOK {
+		t.Fatalf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	// Check the response body is as expected
+	expected := `ok`
+	if rr.Body.String() != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v",
+			rr.Body.String(), expected)
+	}
+}

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -1,0 +1,121 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"crypto/tls"
+
+	"github.com/apprenda/kismatic/pkg/server/http/handler"
+	"github.com/julienschmidt/httprouter"
+	"github.com/urfave/negroni"
+)
+
+// Server to run an HTTPs server
+type Server interface {
+	RunTLS() error
+	Shutdown(timeout time.Duration) error
+}
+
+type loggerHttpServer struct {
+	httpServer *http.Server
+	logger     *log.Logger
+}
+
+// New creates a configured http server
+// If certificates are not provided, a self signed CA will be used
+// Use 0 for no read and write timeouts
+func New(logger *log.Logger, port string, certFile string, keyFile string, readTimeout time.Duration, writeTimeout time.Duration) (Server, error) {
+	if logger == nil {
+		return nil, fmt.Errorf("logger cannot be nil")
+	}
+	if port == "" {
+		return nil, fmt.Errorf("port cannot be empty")
+	}
+	addr := fmt.Sprintf(":%s", port)
+	if readTimeout < 0 {
+		return nil, fmt.Errorf("readTimeout cannot be negative")
+	}
+	if readTimeout == 0 {
+		logger.Printf("ReadTimeout is set to 0 and will never timeout, you may want to provide a timeout value\n")
+	}
+	if writeTimeout < 0 {
+		return nil, fmt.Errorf("writeTimeout cannot be negative")
+	}
+	if writeTimeout == 0 {
+		logger.Printf("WriteTimeout is set to 0 and will never timeout, you may want to provide a timeout value\n")
+	}
+	// use self signed CA
+	var keyPair tls.Certificate
+	if certFile == "" || keyFile == "" {
+		logger.Printf("Using self-signed certificate\n")
+		key, cert, err := selfSignedCert()
+		if err != nil {
+			return nil, fmt.Errorf("could not get self-signed certificate key-pair: %v", err)
+		}
+		if keyPair, err = tls.X509KeyPair(cert, key); err != nil {
+			return nil, fmt.Errorf("could not parse key-pair: %v", err)
+		}
+	} else {
+		var err error
+		if keyPair, err = tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+			return nil, fmt.Errorf("could not load provided key-pair: %v", err)
+		}
+	}
+	tlsConfig := &tls.Config{Certificates: []tls.Certificate{keyPair}}
+
+	// setup routes
+	router := httprouter.New()
+	router.GET("/healthz", handler.Healthz)
+
+	// use our own logger format
+	l := negroni.NewLogger()
+	l.Logger = logger
+	// use our own logger format
+	r := negroni.NewRecovery()
+	r.Logger = logger
+	r.PrintStack = false
+	h := negroni.New(r, l)
+	h.UseHandler(router)
+
+	s := &loggerHttpServer{
+		httpServer: &http.Server{
+			Addr:         addr,
+			TLSConfig:    tlsConfig,
+			Handler:      h,
+			ReadTimeout:  readTimeout,
+			WriteTimeout: writeTimeout,
+		},
+		logger: logger,
+	}
+
+	return s, nil
+}
+
+// RunTLS support
+func (s *loggerHttpServer) RunTLS() error {
+	s.logger.Printf("Listening on 0.0.0.0%s\n", s.httpServer.Addr)
+	return s.httpServer.ListenAndServeTLS("", "")
+}
+
+// Shutdown will gracefully shutdown the server
+func (s *loggerHttpServer) Shutdown(timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	s.logger.Println("Shutting down the server...")
+	if err := s.httpServer.Shutdown(ctx); err != nil {
+		return err
+	}
+	s.logger.Println("Server stopped")
+
+	return nil
+}
+
+// DefaultLogger returns a logger the specified writer and prefix
+func DefaultLogger(out io.Writer, prefix string) *log.Logger {
+	return log.New(out, prefix, log.Ldate|log.Ltime)
+}

--- a/pkg/server/http/server_test.go
+++ b/pkg/server/http/server_test.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestNewHTTPServer(t *testing.T) {
+	if testing.Short() {
+		return
+	}
+	tests := []struct {
+		logger       *log.Logger
+		port         string
+		certFile     string
+		keyFile      string
+		readTimeout  time.Duration
+		writeTimeout time.Duration
+		valid        bool
+	}{
+		{
+			logger:       DefaultLogger(os.Stdout, "[tester] "),
+			port:         "443",
+			readTimeout:  10 * time.Second,
+			writeTimeout: 5 * time.Second,
+			valid:        true,
+		},
+		{
+			logger:       DefaultLogger(os.Stdout, "[tester] "),
+			port:         "",
+			readTimeout:  10 * time.Second,
+			writeTimeout: 5 * time.Second,
+			valid:        false,
+		},
+		{
+			logger:       DefaultLogger(os.Stdout, "[tester] "),
+			port:         "443",
+			readTimeout:  -1,
+			writeTimeout: 5 * time.Second,
+			valid:        false,
+		},
+		{
+			logger:       DefaultLogger(os.Stdout, "[tester] "),
+			port:         "443",
+			readTimeout:  10 * time.Second,
+			writeTimeout: -1,
+			valid:        false,
+		},
+		{
+			logger:       DefaultLogger(os.Stdout, "[tester] "),
+			port:         "443",
+			certFile:     "foo",
+			keyFile:      "bar",
+			readTimeout:  10 * time.Second,
+			writeTimeout: 5 * time.Second,
+			valid:        false,
+		},
+	}
+	for _, test := range tests {
+		_, err := New(test.logger, test.port, test.certFile, test.keyFile, test.readTimeout, test.writeTimeout)
+		if test.valid && err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !test.valid && err == nil {
+			t.Fatal("expected error, did not get one")
+		}
+	}
+}

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	nethttp "net/http"
+
+	"github.com/apprenda/kismatic/pkg/server/http"
+)
+
+const (
+	defaultTimeout = 10 * time.Second
+	defaultPort    = "8443"
+)
+
+func main() {
+	port := defaultPort
+	if os.Getenv("PORT") != "" {
+		port = os.Getenv("PORT")
+	}
+	logger := http.DefaultLogger(os.Stdout, "[kismatic] ")
+	server, err := http.New(logger, port, "", "", defaultTimeout, defaultTimeout)
+	if err != nil {
+		logger.Fatalf("Error creating server: %v", err)
+	}
+
+	// setup interrupt channgel for graceful shutdown
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		logger.Println("Starting server...")
+		if err := server.RunTLS(); err != nethttp.ErrServerClosed {
+			logger.Fatalf("Error starting server: %v", err)
+		}
+	}()
+
+	<-stop
+
+	if err := server.Shutdown(30 * time.Second); err != nil {
+		logger.Fatalf("Error shutting down server: %v\n", err)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/878

Added a new `server` package that will contain all code for the KET API.
* Using [httprouter](https://github.com/julienschmidt/httprouter) - a lightweight router
* Using [negroni](https://github.com/urfave/negroni) - some important middleware(Logger, Recovery)
* Added a `/heatlhz` route
* Added a `main()` for simpler/faster testing cycle

Added the new `server` command

TODO:
- [ ] Regenerate CLI docs