### PR TITLE
Cluster components version labels

### DIFF
--- a/ansible/roles/calico-network-policy/templates/policy-controller.yaml
+++ b/ansible/roles/calico-network-policy/templates/policy-controller.yaml
@@ -25,6 +25,7 @@ spec:
       labels:
         tier: control-plane
         k8s-app: calico-kube-controllers
+        calico_kube_controller_component_version: "{{official_images.calico_kube_controller.version}}"
     spec:
       # The controllers must run in the host network namespace so that
       # it isn't governed by policy that would prevent it from working.

--- a/ansible/roles/calico-network-policy/templates/policy-controller.yaml
+++ b/ansible/roles/calico-network-policy/templates/policy-controller.yaml
@@ -16,6 +16,9 @@ metadata:
 spec:
   # The controllers can only have a single active instance.
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: calico-kube-controllers
   strategy:
     type: Recreate
   template:

--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -72,6 +72,8 @@ spec:
     metadata:
       labels:
         k8s-app: calico-node
+        calico_node_component_version: "{{official_images.calico_node.version}}"
+        calico_cni_component_version: "{{official_images.calico_cni.version}}"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/ansible/roles/contiv/templates/netmaster.yaml
+++ b/ansible/roles/contiv/templates/netmaster.yaml
@@ -48,6 +48,9 @@ metadata:
 spec:
   # The netmaster should have 1, 3, 5 nodes of which one is active at any given time.
   # More nodes are desired in a production environment for HA.
+  selector:
+    matchLabels:
+      k8s-app: contiv-netmaster
   template:
     metadata:
       name: contiv-netmaster

--- a/ansible/roles/contiv/templates/netmaster.yaml
+++ b/ansible/roles/contiv/templates/netmaster.yaml
@@ -54,6 +54,8 @@ spec:
       namespace: kube-system
       labels:
         k8s-app: contiv-netmaster
+        contiv_netplugin_component_version: "{{official_images.contiv_netplugin.version}}"
+        contiv_authproxy_component_version: "{{official_images.contiv_authproxy.version}}"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/ansible/roles/contiv/templates/netplugin.yaml
+++ b/ansible/roles/contiv/templates/netplugin.yaml
@@ -56,6 +56,7 @@ spec:
     metadata:
       labels:
         k8s-app: contiv-netplugin
+        contiv_netplugin_component_version: "{{official_images.contiv_netplugin.version}}"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/ansible/roles/heapster/templates/heapster.yaml
+++ b/ansible/roles/heapster/templates/heapster.yaml
@@ -34,6 +34,7 @@ spec:
       labels:
         task: monitoring
         k8s-app: heapster
+        heapster_component_version: "{{official_images.heapster.version}}"
     spec:
       serviceAccountName: heapster
       containers:

--- a/ansible/roles/heapster/templates/heapster.yaml
+++ b/ansible/roles/heapster/templates/heapster.yaml
@@ -29,6 +29,9 @@ metadata:
     kismatic/version: "{{ kismatic_short_version }}"
 spec:
   replicas: {{ heapster.options.heapster.replicas }}
+  selector:
+    matchLabels:
+      k8s-app: heapster
   template:
     metadata:
       labels:

--- a/ansible/roles/heapster/templates/influxdb.yaml
+++ b/ansible/roles/heapster/templates/influxdb.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
         task: monitoring
         k8s-app: influxdb
+        heapster_influxdb_component_version: "{{official_images.influxdb.version}}"
     spec:
       containers:
       - name: influxdb

--- a/ansible/roles/heapster/templates/influxdb.yaml
+++ b/ansible/roles/heapster/templates/influxdb.yaml
@@ -22,6 +22,9 @@ metadata:
     kismatic/version: "{{ kismatic_short_version }}"
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: influxdb
   template:
     metadata:
       labels:

--- a/ansible/roles/kube-dashboard/templates/kubernetes-dashboard.yaml
+++ b/ansible/roles/kube-dashboard/templates/kubernetes-dashboard.yaml
@@ -19,6 +19,7 @@ spec:
     metadata:
       labels:
         k8s-app: kubernetes-dashboard
+        kube_dashboard_component_version: "{{official_images.kubernetes_dashboard.version}}"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -54,6 +54,9 @@ spec:
     metadata:
       labels:
         k8s-app: kube-dns
+        kubedns_component_version: "{{official_images.kubedns.version}}"
+        kubedns_dnsmasq_component_version: "{{official_images.kube_dnsmasq.version}}"
+        kubedns_sidecar_component_version: "{{official_images.kubedns_sidecar.version}}"
       annotations:
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:

--- a/ansible/roles/kube-ingress/templates/default-backend.yaml
+++ b/ansible/roles/kube-ingress/templates/default-backend.yaml
@@ -5,6 +5,9 @@ metadata:
   name: default-http-backend
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      app: default-http-backend
   template:
     metadata:
       labels:

--- a/ansible/roles/kube-ingress/templates/default-backend.yaml
+++ b/ansible/roles/kube-ingress/templates/default-backend.yaml
@@ -9,6 +9,7 @@ spec:
     metadata:
       labels:
         app: default-http-backend
+        ingress_default_backend_component_version: "{{official_images.defaultbackend.version}}"
       annotations:
         kismatic/version: "{{ kismatic_short_version }}"
     spec:

--- a/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
+++ b/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
@@ -4,6 +4,9 @@ metadata:
   name: ingress
   namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      name: ingress
   template:
     metadata:
       labels:

--- a/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
+++ b/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
@@ -8,6 +8,7 @@ spec:
     metadata:
       labels:
         name: ingress
+        ingress_nginx_controller_component_version: "{{official_images.nginx_ingress_controller.version}}"
       annotations:
         kismatic/version: "{{ kismatic_short_version }}"
     spec:

--- a/ansible/roles/rescheduler/templates/rescheduler.yaml
+++ b/ansible/roles/rescheduler/templates/rescheduler.yaml
@@ -7,7 +7,7 @@ metadata:
     scheduler.alpha.kubernetes.io/critical-pod: ''
   labels:
     k8s-app: rescheduler
-    version: {{ official_images.rescheduler.version }}
+    rescheduler_component_version: "{{ official_images.rescheduler.version }}"
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "Rescheduler"
 spec:

--- a/ansible/roles/weave/templates/weave.yaml
+++ b/ansible/roles/weave/templates/weave.yaml
@@ -65,6 +65,8 @@ items:
           labels:
             name: weave-net
             k8s-app: weave-net
+            weave_component_version: "{{official_images.weave.version}}"
+            weave_npc_component_version: "{{official_images.weave_npc.version}}"
           annotations:
             scheduler.alpha.kubernetes.io/critical-pod: ''
         spec:

--- a/ansible/roles/weave/templates/weave.yaml
+++ b/ansible/roles/weave/templates/weave.yaml
@@ -60,6 +60,9 @@ items:
         k8s-app: weave-net
       namespace: kube-system
     spec:
+      selector:
+        matchLabels:
+          k8s-app: weave-net
       template:
         metadata:
           labels:


### PR DESCRIPTION
This adds version labels to cluster components as requested in issue #629.

I've added these labels to pods as this seemed like a better resource to label. Also if using a log forwarder for getting metadata it will fetch the labels from the pod.

I've added labels for all containers to cover when a resource has multiple containers with different versions.

The only component missing this label in Tiller as it is installed via `helm init`. To add this we'd need to install Tiller via normal Kubernetes resource files.

I also set explicit selectors on components that were missing them as they would default to using all labels on a pod which includes the version label. This version is likely to change between upgrades. In Kubernetes deployment `apps/v1beta2` selectors will become mandatory:

>In API version apps/v1beta2, .spec.selector and .metadata.labels no longer default to .spec.template.metadata.labels if not set. So they must be set explicitly. Also note that .spec.selector is immutable after creation of the Deployment in apps/v1beta2 - [Kubernetes Docs](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#selector)