### PR TITLE
Use a separate executor for each cluster

### DIFF
--- a/pkg/cli/add_worker.go
+++ b/pkg/cli/add_worker.go
@@ -67,7 +67,6 @@ func doAddWorker(out io.Writer, planFile string, opts *addWorkerOpts, newWorker 
 	}
 	execOpts := install.ExecutorOptions{
 		GeneratedAssetsDirectory: opts.GeneratedAssetsDirectory,
-		RestartServices:          opts.RestartServices,
 		OutputFormat:             opts.OutputFormat,
 		Verbose:                  opts.Verbose,
 	}
@@ -104,7 +103,7 @@ func doAddWorker(out io.Writer, planFile string, opts *addWorkerOpts, newWorker 
 			return err
 		}
 	}
-	updatedPlan, err := executor.AddWorker(plan, newWorker)
+	updatedPlan, err := executor.AddWorker(plan, newWorker, opts.RestartServices)
 	if err != nil {
 		return err
 	}

--- a/pkg/cli/apply.go
+++ b/pkg/cli/apply.go
@@ -19,6 +19,7 @@ type applyCmd struct {
 	verbose            bool
 	outputFormat       string
 	skipPreFlight      bool
+	restartServices    bool
 }
 
 type applyOpts struct {
@@ -42,7 +43,6 @@ func NewCmdApply(out io.Writer, installOpts *installOpts) *cobra.Command {
 			planner := &install.FilePlanner{File: installOpts.planFilename}
 			executorOpts := install.ExecutorOptions{
 				GeneratedAssetsDirectory: applyOpts.generatedAssetsDir,
-				RestartServices:          applyOpts.restartServices,
 				OutputFormat:             applyOpts.outputFormat,
 				Verbose:                  applyOpts.verbose,
 			}
@@ -60,6 +60,7 @@ func NewCmdApply(out io.Writer, installOpts *installOpts) *cobra.Command {
 				verbose:            applyOpts.verbose,
 				outputFormat:       applyOpts.outputFormat,
 				skipPreFlight:      applyOpts.skipPreFlight,
+				restartServices:    applyOpts.restartServices,
 			}
 			return applyCmd.run()
 		},
@@ -107,7 +108,7 @@ func (c *applyCmd) run() error {
 	util.PrettyPrintOk(c.out, "Generated kubeconfig file in the %q directory", c.generatedAssetsDir)
 
 	// Perform the installation
-	if err := c.executor.Install(plan); err != nil {
+	if err := c.executor.Install(plan, c.restartServices); err != nil {
 		return fmt.Errorf("error installing: %v", err)
 	}
 

--- a/pkg/cli/fakes_test.go
+++ b/pkg/cli/fakes_test.go
@@ -39,7 +39,7 @@ func (fe *fakeExecutor) GenerateCertificates(*install.Plan, bool) error {
 	return nil
 }
 
-func (fe *fakeExecutor) GenerateKubeconfig(plan install.Plan, generatedAssetsDir string) error {
+func (fe *fakeExecutor) GenerateKubeconfig(plan install.Plan) error {
 	return nil
 }
 

--- a/pkg/cli/fakes_test.go
+++ b/pkg/cli/fakes_test.go
@@ -31,7 +31,7 @@ type fakeExecutor struct {
 	err           error
 }
 
-func (fe *fakeExecutor) AddWorker(p *install.Plan, newWorker install.Node) (*install.Plan, error) {
+func (fe *fakeExecutor) AddWorker(p *install.Plan, newWorker install.Node, restartServices bool) (*install.Plan, error) {
 	return nil, nil
 }
 
@@ -43,7 +43,7 @@ func (fe *fakeExecutor) GenerateKubeconfig(plan install.Plan) error {
 	return nil
 }
 
-func (fe *fakeExecutor) Install(p *install.Plan) error {
+func (fe *fakeExecutor) Install(p *install.Plan, restartServices bool) error {
 	fe.installCalled = true
 	return fe.err
 }
@@ -60,7 +60,7 @@ func (fe *fakeExecutor) RunUpgradePreFlightCheck(*install.Plan, install.Listable
 	return nil
 }
 
-func (fe *fakeExecutor) UpgradeNodes(install.Plan, []install.ListableNode, bool, int) error {
+func (fe *fakeExecutor) UpgradeNodes(install.Plan, []install.ListableNode, bool, int, bool) error {
 	return nil
 }
 
@@ -80,7 +80,7 @@ func (fe *fakeExecutor) RunSmokeTest(p *install.Plan) error {
 	return nil
 }
 
-func (fe *fakeExecutor) RunPlay(string, *install.Plan) error {
+func (fe *fakeExecutor) RunPlay(string, *install.Plan, bool) error {
 	return nil
 }
 

--- a/pkg/cli/step.go
+++ b/pkg/cli/step.go
@@ -39,7 +39,6 @@ func NewCmdStep(out io.Writer, opts *installOpts) *cobra.Command {
 			}
 			execOpts := install.ExecutorOptions{
 				GeneratedAssetsDirectory: stepCmd.generatedAssetsDir,
-				RestartServices:          stepCmd.restartServices,
 				OutputFormat:             stepCmd.outputFormat,
 				Verbose:                  stepCmd.verbose,
 			}
@@ -77,7 +76,7 @@ func (c stepCmd) run() error {
 		return fmt.Errorf("error reading plan file: %v", err)
 	}
 	util.PrintHeader(c.out, "Running Task", '=')
-	if err := c.executor.RunPlay(c.task, plan); err != nil {
+	if err := c.executor.RunPlay(c.task, plan, c.restartServices); err != nil {
 		return err
 	}
 	util.PrintColor(c.out, util.Green, "\nTask completed successfully\n\n")

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -120,7 +120,6 @@ func doUpgrade(in io.Reader, out io.Writer, opts *upgradeOpts) error {
 	planner := install.FilePlanner{File: planFile}
 	executorOpts := install.ExecutorOptions{
 		GeneratedAssetsDirectory: opts.generatedAssetsDir,
-		RestartServices:          opts.restartServices,
 		OutputFormat:             opts.outputFormat,
 		Verbose:                  opts.verbose,
 		DryRun:                   opts.dryRun,
@@ -365,7 +364,7 @@ func upgradeNodes(in io.Reader, out io.Writer, plan install.Plan, opts upgradeOp
 	}
 
 	// Run the upgrade on the nodes that need it
-	if err := executor.UpgradeNodes(plan, toUpgrade, opts.online, opts.maxParallelWorkers); err != nil {
+	if err := executor.UpgradeNodes(plan, toUpgrade, opts.online, opts.maxParallelWorkers, opts.restartServices); err != nil {
 		return fmt.Errorf("Failed to upgrade nodes: %v", err)
 	}
 	return nil

--- a/pkg/controller/cluster.go
+++ b/pkg/controller/cluster.go
@@ -125,7 +125,7 @@ func (c *clusterController) install(plan install.Plan) (string, bool) {
 		return installFailed, false
 	}
 
-	err = c.executor.Install(&plan)
+	err = c.executor.Install(&plan, true)
 	if err != nil {
 		c.log.Printf("error installing the cluster: %v", err)
 		return installFailed, false

--- a/pkg/controller/cluster.go
+++ b/pkg/controller/cluster.go
@@ -23,10 +23,9 @@ const (
 
 // The clusterController manages the lifecycle of a single cluster.
 type clusterController struct {
-	log                *log.Logger
-	executor           install.Executor
-	clusterStore       store.ClusterStore
-	generatedAssetsDir string
+	log          *log.Logger
+	executor     install.Executor
+	clusterStore store.ClusterStore
 }
 
 func (c *clusterController) run(clusterName string, watch <-chan struct{}) {
@@ -120,7 +119,7 @@ func (c *clusterController) install(plan install.Plan) (string, bool) {
 		return installFailed, false
 	}
 
-	err = c.executor.GenerateKubeconfig(plan, c.generatedAssetsDir)
+	err = c.executor.GenerateKubeconfig(plan)
 	if err != nil {
 		c.log.Printf("error generating kubeconfig file: %v", err)
 		return installFailed, false

--- a/pkg/controller/cluster_test.go
+++ b/pkg/controller/cluster_test.go
@@ -18,7 +18,7 @@ type dummyExec struct {
 	installSleep time.Duration
 }
 
-func (e dummyExec) Install(p *install.Plan) error {
+func (e dummyExec) Install(p *install.Plan, restartServices bool) error {
 	time.Sleep(e.installSleep)
 	return nil
 }
@@ -47,11 +47,11 @@ func (e dummyExec) RunSmokeTest(*install.Plan) error {
 	return nil
 }
 
-func (e dummyExec) AddWorker(*install.Plan, install.Node) (*install.Plan, error) {
+func (e dummyExec) AddWorker(*install.Plan, install.Node, bool) (*install.Plan, error) {
 	panic("not implemented")
 }
 
-func (e dummyExec) RunPlay(string, *install.Plan) error {
+func (e dummyExec) RunPlay(string, *install.Plan, bool) error {
 	panic("not implemented")
 }
 
@@ -63,7 +63,7 @@ func (e dummyExec) DeleteVolume(*install.Plan, string) error {
 	panic("not implemented")
 }
 
-func (e dummyExec) UpgradeNodes(plan install.Plan, nodesToUpgrade []install.ListableNode, onlineUpgrade bool, maxParallelWorkers int) error {
+func (e dummyExec) UpgradeNodes(plan install.Plan, nodesToUpgrade []install.ListableNode, onlineUpgrade bool, maxParallelWorkers int, restartServices bool) error {
 	panic("not implemented")
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -22,10 +22,10 @@ type ClusterController interface {
 type ExecutorCreator func(clusterName string) (install.Executor, error)
 
 // New returns a cluster controller
-func New(l *log.Logger, execCreater ExecutorCreator, cs store.ClusterStore, reconFreq time.Duration) ClusterController {
+func New(l *log.Logger, execCreator ExecutorCreator, cs store.ClusterStore, reconFreq time.Duration) ClusterController {
 	return &multiClusterController{
 		log:                l,
-		newExecutor:        execCreater,
+		newExecutor:        execCreator,
 		clusterStore:       cs,
 		reconcileFreq:      reconFreq,
 		clusterControllers: make(map[string]chan<- struct{}),
@@ -55,7 +55,6 @@ func DefaultExecutorCreator(rootDir string) ExecutorCreator {
 		executorOpts := install.ExecutorOptions{
 			GeneratedAssetsDirectory: filepath.Join(rootDir, clusterName, "generated"),
 			RunsDirectory:            filepath.Join(rootDir, clusterName, "runs"),
-			RestartServices:          true,
 			OutputFormat:             "simple",
 			Verbose:                  true,
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -2,7 +2,10 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/apprenda/kismatic/pkg/install"
@@ -14,14 +17,52 @@ type ClusterController interface {
 	Run(ctx context.Context)
 }
 
+// ExecutorCreator creates executors that can be used for executing actions
+// against a specific cluster.
+type ExecutorCreator func(clusterName string) (install.Executor, error)
+
 // New returns a cluster controller
-func New(l *log.Logger, e install.Executor, cs store.ClusterStore, genAssetsDir string, reconFreq time.Duration) ClusterController {
+func New(l *log.Logger, execCreater ExecutorCreator, cs store.ClusterStore, reconFreq time.Duration) ClusterController {
 	return &multiClusterController{
 		log:                l,
-		executor:           e,
+		newExecutor:        execCreater,
 		clusterStore:       cs,
 		reconcileFreq:      reconFreq,
-		generatedAssetsDir: genAssetsDir,
 		clusterControllers: make(map[string]chan<- struct{}),
+	}
+}
+
+// DefaultExecutorCreator creates an executor that can be used to run operations
+// against a single cluster. The given rootDir is used as the root directory
+// under which new directories are created for each executor.
+//
+// The following directory structure is created under the rootDir for each
+// cluster executor:
+// - clusterName/
+//     - kismatic.log
+//     - generated/
+//     - runs/
+func DefaultExecutorCreator(rootDir string) ExecutorCreator {
+	return func(clusterName string) (install.Executor, error) {
+		err := os.MkdirAll(filepath.Join(rootDir, clusterName), 0600)
+		if err != nil {
+			return nil, fmt.Errorf("error creating directories for executor: %v", err)
+		}
+		logFile, err := os.Create(filepath.Join(rootDir, clusterName, "kismatic.log"))
+		if err != nil {
+			return nil, fmt.Errorf("error creating log file for executor: %v", err)
+		}
+		executorOpts := install.ExecutorOptions{
+			GeneratedAssetsDirectory: filepath.Join(rootDir, clusterName, "generated"),
+			RunsDirectory:            filepath.Join(rootDir, clusterName, "runs"),
+			RestartServices:          true,
+			OutputFormat:             "simple",
+			Verbose:                  true,
+		}
+		executor, err := install.NewExecutor(logFile, logFile, executorOpts)
+		if err != nil {
+			return nil, err
+		}
+		return executor, nil
 	}
 }

--- a/pkg/install/add_worker.go
+++ b/pkg/install/add_worker.go
@@ -12,7 +12,7 @@ var errMissingClusterCA = errors.New("The Certificate Authority's private key an
 
 // AddWorker adds a worker node to the original cluster described in the plan.
 // If successful, the updated plan is returned.
-func (ae *ansibleExecutor) AddWorker(originalPlan *Plan, newWorker Node) (*Plan, error) {
+func (ae *ansibleExecutor) AddWorker(originalPlan *Plan, newWorker Node, restartServices bool) (*Plan, error) {
 	if err := checkAddWorkerPrereqs(ae.pki, newWorker); err != nil {
 		return nil, err
 	}
@@ -33,6 +33,9 @@ func (ae *ansibleExecutor) AddWorker(originalPlan *Plan, newWorker Node) (*Plan,
 	cc, err := ae.buildClusterCatalog(&updatedPlan)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate ansible vars: %v", err)
+	}
+	if restartServices {
+		cc.EnableRestart()
 	}
 	util.PrintHeader(ae.stdout, "Adding Worker Node to Cluster", '=')
 	t := task{

--- a/pkg/install/add_worker_test.go
+++ b/pkg/install/add_worker_test.go
@@ -21,7 +21,7 @@ func mustGetTempDir(t *testing.T) string {
 
 func TestAddWorkerCertMissingCAMissing(t *testing.T) {
 	e := ansibleExecutor{
-		options:             ExecutorOptions{RestartServices: true, RunsDirectory: mustGetTempDir(t)},
+		options:             ExecutorOptions{RunsDirectory: mustGetTempDir(t)},
 		stdout:              ioutil.Discard,
 		consoleOutputFormat: ansible.RawFormat,
 		pki:                 &fakePKI{},
@@ -33,7 +33,7 @@ func TestAddWorkerCertMissingCAMissing(t *testing.T) {
 		},
 	}
 	newWorker := Node{}
-	newPlan, err := e.AddWorker(originalPlan, newWorker)
+	newPlan, err := e.AddWorker(originalPlan, newWorker, true)
 	if newPlan != nil {
 		t.Errorf("add worker returned an updated plan")
 	}
@@ -48,7 +48,7 @@ func TestAddWorkerCertMissingCAExists(t *testing.T) {
 		caExists: true,
 	}
 	e := ansibleExecutor{
-		options:             ExecutorOptions{RestartServices: true, RunsDirectory: mustGetTempDir(t)},
+		options:             ExecutorOptions{RunsDirectory: mustGetTempDir(t)},
 		stdout:              ioutil.Discard,
 		consoleOutputFormat: ansible.RawFormat,
 		pki:                 pki,
@@ -69,7 +69,7 @@ func TestAddWorkerCertMissingCAExists(t *testing.T) {
 		},
 	}
 	newWorker := Node{}
-	_, err := e.AddWorker(originalPlan, newWorker)
+	_, err := e.AddWorker(originalPlan, newWorker, true)
 	if err != nil {
 		t.Errorf("unexpected error while adding worker: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestAddWorkerCertMissingCAExists(t *testing.T) {
 
 func TestAddWorkerPlanIsUpdated(t *testing.T) {
 	e := ansibleExecutor{
-		options:             ExecutorOptions{RestartServices: true, RunsDirectory: mustGetTempDir(t)},
+		options:             ExecutorOptions{RunsDirectory: mustGetTempDir(t)},
 		stdout:              ioutil.Discard,
 		consoleOutputFormat: ansible.RawFormat,
 		pki: &fakePKI{
@@ -113,7 +113,7 @@ func TestAddWorkerPlanIsUpdated(t *testing.T) {
 	newWorker := Node{
 		Host: "test",
 	}
-	updatedPlan, err := e.AddWorker(originalPlan, newWorker)
+	updatedPlan, err := e.AddWorker(originalPlan, newWorker, true)
 	if err != nil {
 		t.Errorf("unexpected error while adding worker: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestAddWorkerPlanIsUpdated(t *testing.T) {
 
 func TestAddWorkerPlanNotUpdatedAfterFailure(t *testing.T) {
 	e := ansibleExecutor{
-		options:             ExecutorOptions{RestartServices: true, RunsDirectory: mustGetTempDir(t)},
+		options:             ExecutorOptions{RunsDirectory: mustGetTempDir(t)},
 		stdout:              ioutil.Discard,
 		consoleOutputFormat: ansible.RawFormat,
 		pki: &fakePKI{
@@ -163,7 +163,7 @@ func TestAddWorkerPlanNotUpdatedAfterFailure(t *testing.T) {
 	newWorker := Node{
 		Host: "test",
 	}
-	updatedPlan, err := e.AddWorker(originalPlan, newWorker)
+	updatedPlan, err := e.AddWorker(originalPlan, newWorker, true)
 	if err == nil {
 		t.Errorf("expected an error, but didn't get one")
 	}
@@ -176,7 +176,7 @@ func TestAddWorkerRestartServicesEnabled(t *testing.T) {
 	fakeRunner := fakeRunner{}
 	e := ansibleExecutor{
 		certsDir:            mustGetTempDir(t),
-		options:             ExecutorOptions{RestartServices: true, RunsDirectory: mustGetTempDir(t)},
+		options:             ExecutorOptions{RunsDirectory: mustGetTempDir(t)},
 		stdout:              ioutil.Discard,
 		consoleOutputFormat: ansible.RawFormat,
 		pki: &fakePKI{
@@ -207,7 +207,7 @@ func TestAddWorkerRestartServicesEnabled(t *testing.T) {
 	newWorker := Node{
 		Host: "test",
 	}
-	_, err := e.AddWorker(originalPlan, newWorker)
+	_, err := e.AddWorker(originalPlan, newWorker, true)
 	if err != nil {
 		t.Errorf("unexpected error")
 	}
@@ -265,7 +265,7 @@ func TestAddWorkerHostsFilesDNSEnabled(t *testing.T) {
 	newWorker := Node{
 		Host: "test",
 	}
-	_, err := e.AddWorker(originalPlan, newWorker)
+	_, err := e.AddWorker(originalPlan, newWorker, false)
 	if err != nil {
 		t.Errorf("unexpected error")
 	}

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -30,7 +30,7 @@ type Executor interface {
 	PreFlightExecutor
 	Install(p *Plan) error
 	GenerateCertificates(p *Plan, useExistingCA bool) error
-	GenerateKubeconfig(p Plan, generatedAssetsDir string) error
+	GenerateKubeconfig(p Plan) error
 	RunSmokeTest(*Plan) error
 	AddWorker(*Plan, Node) (*Plan, error)
 	RunPlay(string, *Plan) error
@@ -277,8 +277,8 @@ func (ae *ansibleExecutor) GenerateCertificates(p *Plan, useExistingCA bool) err
 	return nil
 }
 
-func (ae *ansibleExecutor) GenerateKubeconfig(p Plan, generatedAssetsDir string) error {
-	return GenerateKubeconfig(&p, generatedAssetsDir)
+func (ae *ansibleExecutor) GenerateKubeconfig(p Plan) error {
+	return GenerateKubeconfig(&p, ae.options.GeneratedAssetsDirectory)
 }
 
 // Install the cluster according to the installation plan

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -28,15 +28,15 @@ type PreFlightExecutor interface {
 // The Executor will carry out the installation plan
 type Executor interface {
 	PreFlightExecutor
-	Install(p *Plan) error
+	Install(p *Plan, restartServices bool) error
 	GenerateCertificates(p *Plan, useExistingCA bool) error
 	GenerateKubeconfig(p Plan) error
 	RunSmokeTest(*Plan) error
-	AddWorker(*Plan, Node) (*Plan, error)
-	RunPlay(string, *Plan) error
+	AddWorker(*Plan, Node, bool) (*Plan, error)
+	RunPlay(name string, p *Plan, restartServices bool) error
 	AddVolume(*Plan, StorageVolume) error
 	DeleteVolume(*Plan, string) error
-	UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode, onlineUpgrade bool, maxParallelWorkers int) error
+	UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode, onlineUpgrade bool, maxParallelWorkers int, restartServices bool) error
 	ValidateControlPlane(plan Plan) error
 	UpgradeClusterServices(plan Plan) error
 }
@@ -51,9 +51,6 @@ type ExecutorOptions struct {
 	// GeneratedAssetsDirectory is the location where generated assets
 	// are to be stored
 	GeneratedAssetsDirectory string
-	// RestartServices determines whether the cluster services should be
-	// restarted during the installation.
-	RestartServices bool
 	// OutputFormat sets the format of the executor
 	OutputFormat string
 	// Verbose output from the executor
@@ -282,11 +279,14 @@ func (ae *ansibleExecutor) GenerateKubeconfig(p Plan) error {
 }
 
 // Install the cluster according to the installation plan
-func (ae *ansibleExecutor) Install(p *Plan) error {
+func (ae *ansibleExecutor) Install(p *Plan, restartServices bool) error {
 	// Build the ansible inventory
 	cc, err := ae.buildClusterCatalog(p)
 	if err != nil {
 		return err
+	}
+	if restartServices {
+		cc.EnableRestart()
 	}
 	t := task{
 		name:           "apply",
@@ -323,10 +323,7 @@ func (ae *ansibleExecutor) RunPreFlightCheck(p *Plan) error {
 	if err != nil {
 		return err
 	}
-	cc, err = setPreflightOptions(*p, *cc)
-	if err != nil {
-		return err
-	}
+	cc = setPreflightOptions(*p, *cc)
 	t := task{
 		name:           "preflight",
 		playbook:       "preflight.yaml",
@@ -344,10 +341,7 @@ func (ae *ansibleExecutor) RunNewWorkerPreFlightCheck(p Plan, node Node) error {
 	if err != nil {
 		return err
 	}
-	cc, err = setPreflightOptions(p, *cc)
-	if err != nil {
-		return err
-	}
+	cc = setPreflightOptions(p, *cc)
 	p.Worker.ExpectedCount++
 	p.Worker.Nodes = append(p.Worker.Nodes, node)
 	t := task{
@@ -368,10 +362,7 @@ func (ae *ansibleExecutor) RunUpgradePreFlightCheck(p *Plan, node ListableNode) 
 	if err != nil {
 		return err
 	}
-	cc, err = setPreflightOptions(*p, *cc)
-	if err != nil {
-		return err
-	}
+	cc = setPreflightOptions(*p, *cc)
 	t := task{
 		name:           "upgrade-preflight",
 		playbook:       "upgrade-preflight.yaml",
@@ -384,16 +375,19 @@ func (ae *ansibleExecutor) RunUpgradePreFlightCheck(p *Plan, node ListableNode) 
 	return ae.execute(t)
 }
 
-func setPreflightOptions(p Plan, cc ansible.ClusterCatalog) (*ansible.ClusterCatalog, error) {
+func setPreflightOptions(p Plan, cc ansible.ClusterCatalog) *ansible.ClusterCatalog {
 	cc.KismaticPreflightCheckerLinux = filepath.Join("inspector", "linux", "amd64", "kismatic-inspector")
 	cc.EnablePackageInstallation = !p.Cluster.DisablePackageInstallation
-	return &cc, nil
+	return &cc
 }
 
-func (ae *ansibleExecutor) RunPlay(playName string, p *Plan) error {
+func (ae *ansibleExecutor) RunPlay(playName string, p *Plan, restartServices bool) error {
 	cc, err := ae.buildClusterCatalog(p)
 	if err != nil {
 		return err
+	}
+	if restartServices {
+		cc.EnableRestart()
 	}
 	t := task{
 		name:           "step",
@@ -487,7 +481,7 @@ func (ae *ansibleExecutor) DeleteVolume(plan *Plan, name string) error {
 // which phase of the upgrade we are in. For example, when upgrading a node that is both an etcd and master,
 // the etcd components and the master components will be upgraded when we are in the upgrade etcd nodes
 // phase.
-func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode, onlineUpgrade bool, maxParallelWorkers int) error {
+func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode, onlineUpgrade bool, maxParallelWorkers int, restartServices bool) error {
 	// Nodes can have multiple roles. For this reason, we need to keep track of which nodes
 	// have been upgraded to avoid re-upgrading them.
 	upgradedNodes := map[string]bool{}
@@ -496,7 +490,7 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 		for _, role := range nodeToUpgrade.Roles {
 			if role == "etcd" {
 				node := nodeToUpgrade
-				if err := ae.upgradeNodes(plan, onlineUpgrade, node); err != nil {
+				if err := ae.upgradeNodes(plan, onlineUpgrade, restartServices, node); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Node.Host, err)
 				}
 				upgradedNodes[node.Node.IP] = true
@@ -513,7 +507,7 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 		for _, role := range nodeToUpgrade.Roles {
 			if role == "master" {
 				node := nodeToUpgrade
-				if err := ae.upgradeNodes(plan, onlineUpgrade, node); err != nil {
+				if err := ae.upgradeNodes(plan, onlineUpgrade, restartServices, node); err != nil {
 					return fmt.Errorf("error upgrading node %q: %v", node.Node.Host, err)
 				}
 				upgradedNodes[node.Node.IP] = true
@@ -534,7 +528,7 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 				limitNodes = append(limitNodes, node)
 				// don't forget to run the remaining nodes if its < maxParallelWorkers
 				if len(limitNodes) == maxParallelWorkers || n == len(nodesToUpgrade)-1 {
-					if err := ae.upgradeNodes(plan, onlineUpgrade, limitNodes...); err != nil {
+					if err := ae.upgradeNodes(plan, onlineUpgrade, restartServices, limitNodes...); err != nil {
 						return fmt.Errorf("error upgrading node %q: %v", node.Node.Host, err)
 					}
 					// empty the slice
@@ -548,13 +542,16 @@ func (ae *ansibleExecutor) UpgradeNodes(plan Plan, nodesToUpgrade []ListableNode
 	return nil
 }
 
-func (ae *ansibleExecutor) upgradeNodes(plan Plan, onlineUpgrade bool, nodes ...ListableNode) error {
+func (ae *ansibleExecutor) upgradeNodes(plan Plan, onlineUpgrade bool, restartServices bool, nodes ...ListableNode) error {
 	inventory := buildInventoryFromPlan(&plan)
 	cc, err := ae.buildClusterCatalog(&plan)
 	if err != nil {
 		return err
 	}
 	cc.OnlineUpgrade = onlineUpgrade
+	if restartServices {
+		cc.EnableRestart()
+	}
 	var limit []string
 	nodeRoles := make(map[string][]string)
 	for _, node := range nodes {
@@ -700,9 +697,6 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	if cc.DockerDirectLVMEnabled {
 		cc.DockerDirectLVMBlockDevicePath = p.Docker.Storage.DirectLVM.BlockDevice
 		cc.DockerDirectLVMDeferredDeletionEnabled = p.Docker.Storage.DirectLVM.EnableDeferredDeletion
-	}
-	if ae.options.RestartServices {
-		cc.EnableRestart()
 	}
 
 	if p.Ingress.Nodes != nil && len(p.Ingress.Nodes) > 0 {


### PR DESCRIPTION
Fixes #907 

Each cluster needs it's own directory structure separate from other clusters. This directory will include the runs dir, the generated assets dir, and a log file where all logs will be stored. It might make sense to have a log dir where multiple log files are created, but that will require more work.