### PR TITLE
Added more API endpoints

### DIFF
--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -1,5 +1,8 @@
 # Plan File Reference
 ## Index
+* [provisioner](#provisioner)
+  * [provider](#provisionerprovider)
+  * [options](#provisioneroptions)
 * [cluster](#cluster)
   * [name](#clustername)
   * [admin_password](#clusteradmin_password)
@@ -131,6 +134,24 @@
   * [nfs_volume](#nfsnfs_volume)
     * [nfs_host](#nfsnfs_volumenfs_host)
     * [mount_path](#nfsnfs_volumemount_path)
+##  provisioner
+
+ Infrastructure provisioner 
+
+###  provisioner.provider
+
+ The provider where the infrastructue will be provisioned to. The provisioner will expect provider specific ENV variables to be set. Options: aws 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  provisioner.options
+
+ AWS specific options. Only set if using "aws" provider 
+
 ##  cluster
 
  Kubernetes cluster configuration 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 38cc9f8fa9f6dbc1a778dd747bc3aa0f1ed80f6e3ca6a2e2a2cb950a015ffafa
-updated: 2017-11-06T09:06:34.715332742-05:00
+hash: fb3da16a5093d86bb1350dce9f7e44a41591b4b253154dc61a8d3aa35c73e654
+updated: 2017-11-15T09:50:43.005879-05:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 40f45e34986ba617a372d1590de273a0ca84a53d
@@ -67,6 +67,14 @@ imports:
   version: 1d903dcb749992f3741d744c0f8376b4bd7eb3e1
   subpackages:
   - md2man
+- name: github.com/dsnet/compress
+  version: c4dbed65594871659ea7347a85e1b8dcd97b9990
+  subpackages:
+  - bzip2
+  - bzip2/internal/sais
+  - internal
+  - internal/errors
+  - internal/prefix
 - name: github.com/fatih/color
   version: 87d4004f2ab62d0d255e0a38f1680aa534549fe3
 - name: github.com/fortytw2/leaktest
@@ -94,6 +102,10 @@ imports:
   version: 3fa8c76f9daed4067e4a806fb7e4dc86455c6d6a
 - name: github.com/mattn/go-isatty
   version: 0360b2af4f38e8d38c7fce2a9f4e702702d73a39
+- name: github.com/mholt/archiver
+  version: cdc68dd1f170b8dfc1a0d2231b5bb0967ed67006
+  subpackages:
+  - cmd/archiver
 - name: github.com/michaelbironneau/garbler
   version: eaea49f3709333a999768eddd70d24eba599e78d
   subpackages:
@@ -103,6 +115,8 @@ imports:
 - name: github.com/mreiferson/go-httpclient
   version: 63fe23f7434723dc904c901043af07931f293c47
   repo: https://github.com/mreiferson/go-httpclient
+- name: github.com/nwaples/rardecode
+  version: e06696f847aeda6f39a8f0b7cdff193b7690aef6
 - name: github.com/onsi/ginkgo
   version: 8382b23d18dbaaff8e5f7e83784c53ebb8ec2f47
   subpackages:
@@ -150,8 +164,14 @@ imports:
   - doc
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
+- name: github.com/ulikunitz/xz
+  version: 0c6b41e72360850ca4f98dc341fd999726ea007f
+  subpackages:
+  - internal/hash
+  - internal/xlog
+  - lzma
 - name: github.com/urfave/negroni
-  version: fde5e16d32adc7ad637e9cd9ad21d4ebc6192535
+  version: 5dbbc83f748fc3ad38585842b0aedab546d0ea1e
 - name: golang.org/x/crypto
   version: 1f22c0103821b9390939b6776727195525381532
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -28,3 +28,7 @@ import:
   version: ^1.3.1
 - package: github.com/fortytw2/leaktest
   version: ~1.1.0
+- package: github.com/mholt/archiver
+  version: ^2.0.0
+  subpackages:
+  - cmd/archiver

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -80,7 +80,7 @@ func doServer(stdout io.Writer, options serverOptions) error {
 	// Needs to be an absoulute path for the HTTP server
 	pwd, err := os.Getwd()
 	if err != nil {
-		logger.Fatalf("Could not get current directory for assets")
+		logger.Fatalf("Could not get current directory for assets: %v", err)
 	}
 	assetsDir := path.Join(pwd, assetsFolder)
 	err = os.MkdirAll(assetsDir, 0700)
@@ -89,7 +89,7 @@ func doServer(stdout io.Writer, options serverOptions) error {
 	}
 
 	// create handlers
-	clusterAPI := handler.Clusters{Store: clusterStore, AssetsDir: assetsDir}
+	clusterAPI := handler.Clusters{Store: clusterStore, AssetsDir: assetsDir, Logger: logger}
 
 	// Setup the HTTP server
 	server := http.HttpServer{

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -7,6 +7,7 @@ import (
 	nethttp "net/http"
 	"os"
 	"os/signal"
+	"path"
 	"syscall"
 	"time"
 
@@ -22,6 +23,7 @@ const (
 	loggerPrefix   = "[kismatic] "
 	defaultTimeout = 10 * time.Second
 	clustersBucket = "kismatic"
+	assetsFolder   = "assets"
 )
 
 type serverOptions struct {
@@ -63,10 +65,10 @@ func doServer(stdout io.Writer, options serverOptions) error {
 
 	// Create the store
 	s, err := store.New(options.dbFile, 0600, logger)
-	defer s.Close()
 	if err != nil {
 		logger.Fatalf("Error creating store: %v", err)
 	}
+	defer s.Close()
 	err = s.CreateBucket(clustersBucket)
 	if err != nil {
 		logger.Fatalf("Error creating bucket in store: %v", err)
@@ -74,8 +76,20 @@ func doServer(stdout io.Writer, options serverOptions) error {
 
 	clusterStore := store.NewClusterStore(s, clustersBucket)
 
+	// Create a dir where all the controller-related files will be stored
+	// Needs to be an absoulute path for the HTTP server
+	pwd, err := os.Getwd()
+	if err != nil {
+		logger.Fatalf("Could not get current directory for assets")
+	}
+	assetsDir := path.Join(pwd, assetsFolder)
+	err = os.MkdirAll(assetsDir, 0700)
+	if err != nil {
+		logger.Fatalf("Error creating assets directory %q: %v", assetsDir, err)
+	}
+
 	// create handlers
-	clusterAPI := handler.Clusters{Store: clusterStore}
+	clusterAPI := handler.Clusters{Store: clusterStore, AssetsDir: assetsDir}
 
 	// Setup the HTTP server
 	server := http.HttpServer{
@@ -103,15 +117,9 @@ func doServer(stdout io.Writer, options serverOptions) error {
 		BinaryPath: "./../../bin/terraform",
 	}
 
-	// Create a dir where all the controller-related files will be stored
-	rootDir := "server"
-	err = os.MkdirAll(rootDir, 0700)
-	if err != nil {
-		logger.Fatalf("error creating directory %q: %v", rootDir, err)
-	}
 	ctrl := controller.New(
 		logger,
-		controller.DefaultExecutorCreator(rootDir),
+		controller.DefaultExecutorCreator(assetsDir),
 		controller.DefaultProvisionerCreator(terraform),
 		clusterStore,
 		10*time.Minute,

--- a/pkg/cli/version.go
+++ b/pkg/cli/version.go
@@ -29,7 +29,7 @@ func NewCmdVersion(buildDate string, out io.Writer) *cobra.Command {
 				GoVersion: runtime.Version(),
 			}
 			if outFormat == "json" {
-				b, err := json.MarshalIndent(v, "", "    ")
+				b, err := json.MarshalIndent(v, "", "  ")
 				if err != nil {
 					return fmt.Errorf("error marshaling data: %v", err)
 				}

--- a/pkg/cli/volume_list.go
+++ b/pkg/cli/volume_list.go
@@ -252,7 +252,7 @@ func print(out io.Writer, resp *ListResponse, format string) error {
 		w.Flush()
 	} else if format == "json" {
 		// pretty prtin JSON
-		prettyResp, err := json.MarshalIndent(resp, "", "    ")
+		prettyResp, err := json.MarshalIndent(resp, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshal error: %v", err)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -79,8 +79,8 @@ func DefaultProvisionerCreator(terraform provision.Terraform) ProvisionerCreator
 		switch cluster.Plan.Provisioner.Provider {
 		case "aws":
 			p := provision.AWS{
-				KeyID:     cluster.AwsID,
-				Secret:    cluster.AwsKey,
+				KeyID:     cluster.ProvisionerCredentials.AWS.AccessKeyId,
+				Secret:    cluster.ProvisionerCredentials.AWS.SecretAccessKey,
 				Terraform: terraform,
 			}
 			return p

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -46,7 +46,7 @@ func New(l *log.Logger, execCreator ExecutorCreator, provisionerCreator Provisio
 // cluster executor:
 // - clusterName/
 //     - kismatic.log
-//     - generated/
+//     - assets/
 //     - runs/
 func DefaultExecutorCreator(rootDir string) ExecutorCreator {
 	return func(clusterName string) (install.Executor, error) {
@@ -59,7 +59,7 @@ func DefaultExecutorCreator(rootDir string) ExecutorCreator {
 			return nil, fmt.Errorf("error creating log file for executor: %v", err)
 		}
 		executorOpts := install.ExecutorOptions{
-			GeneratedAssetsDirectory: filepath.Join(rootDir, clusterName, "generated"),
+			GeneratedAssetsDirectory: filepath.Join(rootDir, clusterName, "assets"),
 			RunsDirectory:            filepath.Join(rootDir, clusterName, "runs"),
 			OutputFormat:             "simple",
 			Verbose:                  true,

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -78,29 +78,16 @@ type Plan struct {
 
 type Provisioner struct {
 	// The provider where the infrastructue will be provisioned to.
-	// The provider will expect provider specific ENV variables to be set.
+	// The provisioner will expect provider specific ENV variables to be set.
 	// Options: aws
 	Provider string
-	// Options that are specific to the chosen infrastructure provider.
-	AWSOptions *AWSProviderOptions `yaml:"options,omitempty"`
+	// AWS specific options.
+	// Only set if using "aws" provider
+	AWSOptions *AWSProvisionerOptions `yaml:"options,omitempty"`
 }
 
-// AWSProviderOptions contains specific options used when provisioning infrastructue
-// TODO determine what those are
-type AWSProviderOptions struct {
-	Region            string `json:"region"`
-	AccessKey         string `json:"access_key"`
-	SecretKey         string `json:"secret_key"`
-	PrivateSSHKeyPath string `json:"private_ssh_key_path"`
-	PublicSSHKey      string `json:"public_ssh_key"`
-	ClusterName       string `json:"cluster_name"`
-	AMI               string `json:"ami"`
-	EC2InstanceType   string `json:"instance_size"`
-	MasterCount       int    `json:"master_count"`
-	EtcdCount         int    `json:"etcd_count"`
-	WorkerCount       int    `json:"worker_count"`
-	IngressCount      int    `json:"ingress_count"`
-	StorageCount      int    `json:"storage_count"`
+// AWSProvisionerOptions contains specific options used when provisioning infrastructue
+type AWSProvisionerOptions struct {
 }
 
 // Cluster describes a Kubernetes cluster

--- a/pkg/server/http/handler/clusters.go
+++ b/pkg/server/http/handler/clusters.go
@@ -10,6 +10,7 @@ import (
 	"path"
 
 	"github.com/apprenda/kismatic/pkg/store"
+	"github.com/apprenda/kismatic/pkg/util"
 
 	"github.com/apprenda/kismatic/pkg/install"
 	"github.com/julienschmidt/httprouter"
@@ -17,21 +18,134 @@ import (
 
 var ErrClusterNotFound = errors.New("cluster details not found in the store")
 
-type ClusterRequest struct {
-	Name         string
-	DesiredState string
-	AwsID        string
-	AwsKey       string
-	Etcd         int
-	Master       int
-	Worker       int
+// TODO should this be extracted from the install pkg?
+type validatable interface {
+	validate() (bool, []error)
 }
 
+type validator struct {
+	errs []error
+}
+
+func newValidator() *validator {
+	return &validator{
+		errs: []error{},
+	}
+}
+
+func (v *validator) addError(err ...error) {
+	v.errs = append(v.errs, err...)
+}
+
+func (v *validator) validate(obj validatable) {
+	if ok, err := obj.validate(); !ok {
+		v.addError(err...)
+	}
+}
+
+func (v *validator) valid() (bool, []error) {
+	if len(v.errs) > 0 {
+		return false, v.errs
+	}
+	return true, nil
+}
+
+func (r *ClusterRequest) validate() (bool, []error) {
+	v := newValidator()
+	if r.Name == "" {
+		v.addError(fmt.Errorf("name cannot be empty"))
+	}
+	if r.DesiredState == "" {
+		v.addError(fmt.Errorf("desiredState cannot be empty"))
+	} else {
+		if !util.Contains(r.DesiredState, validStates) {
+			v.addError(fmt.Errorf("%s is not a valid desiredState, options are: %v", r.DesiredState, validStates))
+		}
+	}
+	if r.EtcdCount <= 0 {
+		v.addError(fmt.Errorf("cluster.etcdCount must be greater than 0"))
+	}
+	if r.MasterCount <= 0 {
+		v.addError(fmt.Errorf("cluster.masterCount must be greater than 0"))
+	}
+	if r.WorkerCount <= 0 {
+		v.addError(fmt.Errorf("cluster.workerCount must be greater than 0"))
+	}
+	if r.IngressCount < 0 {
+		v.addError(fmt.Errorf("cluster.ingressCount must be greater than or equal to 0"))
+	}
+	v.validate(&r.Provisioner)
+	return v.valid()
+}
+
+func (p *Provisioner) validate() (bool, []error) {
+	v := newValidator()
+	if p.Provider == "" {
+		v.addError(fmt.Errorf("provisioner.provider cannot be empty"))
+	} else {
+		if !util.Contains(p.Provider, validProvisionerProviders) {
+			v.addError(fmt.Errorf("%s is not a valid provisioner.provider, options are: %v", p.Provider, validProvisionerProviders))
+		}
+		switch p.Provider {
+		case "aws":
+			if p.AWSOptions == nil || p.AWSOptions.AccessKeyID == "" {
+				v.addError(fmt.Errorf("provisioner.options.accessKeyID cannot be empty"))
+			}
+			if p.AWSOptions == nil || p.AWSOptions.SecretAccessKey == "" {
+				v.addError(fmt.Errorf("provisioner.options.secretAccessKey cannot be empty"))
+			}
+		}
+	}
+	return v.valid()
+}
+
+func formatErrs(errs []error) []string {
+	out := make([]string, 0)
+	for _, err := range errs {
+		out = append(out, err.Error())
+	}
+	return out
+}
+
+type ClusterRequest struct {
+	Name         string      `json:"name"`
+	DesiredState string      `json:"desiredState"`
+	ClusterIP    string      `json:"clusterIP"`
+	EtcdCount    int         `json:"etcdCount"`
+	MasterCount  int         `json:"masterCount"`
+	WorkerCount  int         `json:"workerCount"`
+	IngressCount int         `json:"ingressCount"`
+	Provisioner  Provisioner `json:"provisioner"`
+}
+
+var validStates = []string{"installed"}
+var validProvisionerProviders = []string{"aws"}
+
 type ClusterResponse struct {
-	Name         string
-	DesiredState string
-	CurrentState string
-	install.Plan
+	Name         string      `json:"name"`
+	DesiredState string      `json:"desiredState"`
+	CurrentState string      `json:"currentState"`
+	ClusterIP    string      `json:"clusterIP"`
+	EtcdCount    int         `json:"etcdCount"`
+	MasterCount  int         `json:"masterCount"`
+	WorkerCount  int         `json:"workerCount"`
+	IngressCount int         `json:"ingressCount"`
+	Provisioner  Provisioner `json:"provisioner"`
+}
+
+type Provisioner struct {
+	// Options: aws
+	Provider   string                 `json:"provider"`
+	AWSOptions *AWSProvisionerOptions `json:"options,omitempty"`
+}
+
+type Cluster struct {
+}
+
+type AWSProvisionerOptions struct {
+	*install.AWSProvisionerOptions
+	AccessKeyID     string `json:"accessKeyID"`
+	SecretAccessKey string `json:"secretAccessKey"`
 }
 
 type Clusters struct {
@@ -40,11 +154,34 @@ type Clusters struct {
 	Logger    *log.Logger
 }
 
-// TODO add validation to all requests
 func (api Clusters) Create(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	req := &ClusterRequest{}
 	if err := json.NewDecoder(r.Body).Decode(req); err != nil {
 		http.Error(w, fmt.Sprintf("could not decode body: %s\n", err.Error()), http.StatusBadRequest)
+		return
+	}
+	// validate request
+	valid, errs := req.validate()
+	if !valid {
+		bytes, err := json.MarshalIndent(formatErrs(errs), "", "  ")
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			api.Logger.Println(errorf("could not marshall response: %v", err))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		http.Error(w, string(bytes), http.StatusBadRequest)
+		return
+	}
+	// confirm the name is unique
+	exists, err := existsInStore(req.Name, api.Store)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		api.Logger.Println(errorf(err.Error()))
+		return
+	}
+	if exists {
+		w.WriteHeader(http.StatusConflict)
 		return
 	}
 	if err := putToStore(req, api.Store); err != nil {
@@ -68,7 +205,9 @@ func (api Clusters) Get(w http.ResponseWriter, r *http.Request, p httprouter.Par
 		return
 	}
 
-	err = json.NewEncoder(w).Encode(clusterResp)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(clusterResp)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		api.Logger.Println(errorf("could not marshall response: %v", err))
@@ -85,7 +224,9 @@ func (api Clusters) GetAll(w http.ResponseWriter, r *http.Request, p httprouter.
 		return
 	}
 
-	err = json.NewEncoder(w).Encode(clustersResp)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(clustersResp)
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 		api.Logger.Println(errorf("could not marshall response: %v", err))
@@ -170,9 +311,10 @@ func (api Clusters) GetLogs(w http.ResponseWriter, r *http.Request, p httprouter
 func putToStore(req *ClusterRequest, cs store.ClusterStore) error {
 	// build the plan template
 	planTemplate := install.PlanTemplateOptions{
-		EtcdNodes:   req.Etcd,
-		MasterNodes: req.Master,
-		WorkerNodes: req.Worker,
+		EtcdNodes:    req.EtcdCount,
+		MasterNodes:  req.MasterCount,
+		WorkerNodes:  req.WorkerCount,
+		IngressNodes: req.IngressCount,
 	}
 	planner := &install.BytesPlanner{}
 	if err := install.WritePlanTemplate(planTemplate, planner); err != nil {
@@ -185,15 +327,24 @@ func putToStore(req *ClusterRequest, cs store.ClusterStore) error {
 	}
 	// set some defaults in the plan
 	p.Cluster.Name = req.Name
-	p.Provisioner.Provider = "aws"
+	p.Provisioner = install.Provisioner{Provider: req.Provisioner.Provider, AWSOptions: req.Provisioner.AWSOptions.AWSProvisionerOptions}
 	sc := store.Cluster{
 		DesiredState: req.DesiredState,
 		CurrentState: "planned",
 		Plan:         *p,
 		CanContinue:  true,
-		AwsID:        req.AwsID,
-		AwsKey:       req.AwsKey,
 	}
+	switch p.Provisioner.Provider {
+	case "aws":
+		creds := store.ProvisionerCredentials{
+			AWS: store.AWSCredentials{
+				AccessKeyId:     req.Provisioner.AWSOptions.AccessKeyID,
+				SecretAccessKey: req.Provisioner.AWSOptions.SecretAccessKey,
+			},
+		}
+		sc.ProvisionerCredentials = creds
+	}
+
 	if err := cs.Put(req.Name, sc); err != nil {
 		return fmt.Errorf("could not put to the store: %v", err)
 	}
@@ -216,13 +367,8 @@ func getFromStore(name string, cs store.ClusterStore) (*ClusterResponse, error) 
 	if sc == nil {
 		return nil, ErrClusterNotFound
 	}
-	resp := &ClusterResponse{
-		Name:         name,
-		DesiredState: sc.DesiredState,
-		CurrentState: sc.CurrentState,
-		Plan:         sc.Plan,
-	}
-	return resp, nil
+	resp := buildResponse(name, *sc)
+	return &resp, nil
 }
 
 func getAllFromStore(cs store.ClusterStore) ([]ClusterResponse, error) {
@@ -230,18 +376,37 @@ func getAllFromStore(cs store.ClusterStore) ([]ClusterResponse, error) {
 	if err != nil {
 		return nil, fmt.Errorf("could not get from the store: %v", err)
 	}
-	resp := make([]ClusterResponse, len(msc))
+	resp := make([]ClusterResponse, 0)
 	if msc == nil {
 		return resp, nil
 	}
 	for key, sc := range msc {
-		r := ClusterResponse{
-			Name:         key,
-			DesiredState: sc.DesiredState,
-			CurrentState: sc.CurrentState,
-			Plan:         sc.Plan,
-		}
-		resp = append(resp, r)
+		resp = append(resp, buildResponse(key, sc))
 	}
 	return resp, nil
+}
+
+func buildResponse(name string, sc store.Cluster) ClusterResponse {
+	provisioner := Provisioner{
+		Provider: sc.Plan.Provisioner.Provider,
+	}
+	switch sc.Plan.Provisioner.Provider {
+	case "aws":
+		if sc.Plan.Provisioner.AWSOptions != nil {
+			provisioner.AWSOptions = &AWSProvisionerOptions{
+				AWSProvisionerOptions: sc.Plan.Provisioner.AWSOptions,
+			}
+		}
+	}
+	return ClusterResponse{
+		Name:         name,
+		DesiredState: sc.DesiredState,
+		CurrentState: sc.CurrentState,
+		ClusterIP:    sc.Plan.Master.LoadBalancedFQDN,
+		EtcdCount:    sc.Plan.Etcd.ExpectedCount,
+		MasterCount:  sc.Plan.Master.ExpectedCount,
+		WorkerCount:  sc.Plan.Worker.ExpectedCount,
+		IngressCount: sc.Plan.Ingress.ExpectedCount,
+		Provisioner:  provisioner,
+	}
 }

--- a/pkg/server/http/handler/log.go
+++ b/pkg/server/http/handler/log.go
@@ -1,0 +1,7 @@
+package handler
+
+import "fmt"
+
+func errorf(format string, v ...interface{}) string {
+	return fmt.Sprintf("ERROR %s", fmt.Sprintf(format, v))
+}

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -77,7 +77,9 @@ func (s *HttpServer) Init() error {
 	// setup routes
 	router := httprouter.New()
 	router.GET("/healthz", handler.Healthz)
+	router.GET("/clusters", s.ClustersAPI.GetAll)
 	router.GET("/clusters/:name", s.ClustersAPI.Get)
+	router.DELETE("/clusters/:name", s.ClustersAPI.Delete)
 	router.POST("/clusters", s.ClustersAPI.Create)
 
 	// use our own logger format

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -81,6 +81,8 @@ func (s *HttpServer) Init() error {
 	router.GET("/clusters/:name", s.ClustersAPI.Get)
 	router.DELETE("/clusters/:name", s.ClustersAPI.Delete)
 	router.POST("/clusters", s.ClustersAPI.Create)
+	router.GET("/clusters/:name/kubeconfig", s.ClustersAPI.GetKubeconfig)
+	router.GET("/clusters/:name/logs", s.ClustersAPI.GetLogs)
 
 	// use our own logger format
 	l := negroni.NewLogger()

--- a/pkg/server/http/server.go
+++ b/pkg/server/http/server.go
@@ -83,10 +83,11 @@ func (s *HttpServer) Init() error {
 	router.POST("/clusters", s.ClustersAPI.Create)
 	router.GET("/clusters/:name/kubeconfig", s.ClustersAPI.GetKubeconfig)
 	router.GET("/clusters/:name/logs", s.ClustersAPI.GetLogs)
+	router.GET("/clusters/:name/assets", s.ClustersAPI.GetAssets)
 
 	// use our own logger format
 	l := negroni.NewLogger()
-	l.Logger = s.Logger
+	l.ALogger = s.Logger
 	// use our own logger format
 	r := negroni.NewRecovery()
 	r.Logger = s.Logger

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"syscall"
@@ -25,19 +26,29 @@ func main() {
 		port = os.Getenv("PORT")
 	}
 	logger := http.DefaultLogger(os.Stdout, "[kismatic] ")
-	s, err := store.New("/tmp/kismatic", 0644, logger)
-	defer s.Close()
+
+	storeFile, err := ioutil.TempFile("/tmp", "ket-server-store")
+	if err != nil {
+		logger.Fatalf("error creating temp directory: %v", err)
+	}
+	s, err := store.New(storeFile.Name(), 0644, logger)
 	if err != nil {
 		logger.Fatalf("Error opening store: %v", err)
 	}
+	defer s.Close()
 	if err := s.CreateBucket(bucket); err != nil {
 		logger.Fatalf("Error creating bucket: %v", err)
 	}
 
 	clusterStore := store.NewClusterStore(s, bucket)
 
+	assetsDir, err := ioutil.TempDir("/tmp", "ket-server-assets")
+	if err != nil {
+		logger.Fatalf("error creating assets directory %q: %v", assetsDir, err)
+	}
+
 	// create handlers
-	clusterAPI := handler.Clusters{Store: clusterStore}
+	clusterAPI := handler.Clusters{Store: clusterStore, AssetsDir: assetsDir}
 
 	// Setup the HTTP server
 	server := http.HttpServer{

--- a/pkg/server/main.go
+++ b/pkg/server/main.go
@@ -48,7 +48,7 @@ func main() {
 	}
 
 	// create handlers
-	clusterAPI := handler.Clusters{Store: clusterStore, AssetsDir: assetsDir}
+	clusterAPI := handler.Clusters{Store: clusterStore, AssetsDir: assetsDir, Logger: logger}
 
 	// Setup the HTTP server
 	server := http.HttpServer{

--- a/pkg/store/cluster.go
+++ b/pkg/store/cluster.go
@@ -8,12 +8,20 @@ import (
 )
 
 type Cluster struct {
-	DesiredState string
-	CurrentState string
-	CanContinue  bool
-	Plan         install.Plan
-	AwsID        string
-	AwsKey       string
+	DesiredState           string
+	CurrentState           string
+	CanContinue            bool
+	Plan                   install.Plan
+	ProvisionerCredentials ProvisionerCredentials
+}
+
+type ProvisionerCredentials struct {
+	AWS AWSCredentials
+}
+
+type AWSCredentials struct {
+	AccessKeyId     string
+	SecretAccessKey string
 }
 
 // ClusterStore is a smaller interface into the store

--- a/pkg/store/cluster.go
+++ b/pkg/store/cluster.go
@@ -23,6 +23,7 @@ type ClusterStore interface {
 	Get(key string) (*Cluster, error)
 	Put(key string, cluster Cluster) error
 	GetAll() (map[string]Cluster, error)
+	Delete(key string) error
 	Watch(ctx context.Context, buffer uint) <-chan WatchResponse
 }
 
@@ -74,6 +75,10 @@ func (s cs) GetAll() (map[string]Cluster, error) {
 		m[e.Key] = c
 	}
 	return m, nil
+}
+
+func (s cs) Delete(key string) error {
+	return s.Store.Delete(s.Bucket, key)
 }
 
 func (s cs) Watch(ctx context.Context, buffer uint) <-chan WatchResponse {


### PR DESCRIPTION
Added 4 new endpoints:
```
GET "/clusters"  #returns all clusters
DELETE "/clusters/:name"
GET "/clusters/:name/kubeconfig"
GET "/clusters/:name/logs"
GET "/clusters/:name/assets"
```

Sample POST request
```
{
  "name": "foo",
  "desiredState": "installed",
  "etcdCount": 1,
  "masterCount": 1,
  "workerCount": 1,
  "ingressCount": 0,
  "provisioner": {
    "provider": "aws",
    "options": {
      "accessKeyID": "__AWS_ACCESS_KEY_ID__",
      "secretAccessKey": "__AWS_SECRET_ACCESS_KEY__"
    }
  }
}
```
Sample response
```
{
  "name": "foo",
  "desiredState": "installed",
  "currentState": "provisionFailed",
  "clusterIP": "",
  "etcdCount": 1,
  "masterCount": 1,
  "workerCount": 1,
  "ingressCount": 0,
  "provisioner": {
    "provider": "aws"
  }
}
```