### PR TITLE
Cluster controller: Add support for destroy

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"path"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -114,7 +115,8 @@ func doServer(stdout io.Writer, options serverOptions) error {
 
 	// Setup provisioner
 	terraform := provision.Terraform{
-		BinaryPath: "./../../bin/terraform",
+		Output:     os.Stdout,
+		BinaryPath: filepath.Join(pwd, "terraform/bin/terraform"),
 	}
 
 	ctrl := controller.New(

--- a/pkg/controller/multicluster.go
+++ b/pkg/controller/multicluster.go
@@ -70,12 +70,13 @@ func (mcc *multiClusterController) Run(ctx context.Context) {
 					continue
 				}
 				cc := clusterController{
+					clusterName:    clusterName,
 					log:            mcc.log,
 					executor:       executor,
 					clusterStore:   mcc.clusterStore,
 					newProvisioner: mcc.provisionerCreator,
 				}
-				go cc.run(clusterName, newChan)
+				go cc.run(newChan)
 			}
 
 			var cluster store.Cluster
@@ -111,20 +112,22 @@ func (mcc *multiClusterController) Run(ctx context.Context) {
 						continue
 					}
 					cc := clusterController{
+						clusterName:    clusterName,
 						log:            mcc.log,
 						executor:       executor,
 						clusterStore:   mcc.clusterStore,
 						newProvisioner: mcc.provisionerCreator,
 					}
-					go cc.run(clusterName, newChan)
+					go cc.run(newChan)
 				}
 			}
 
-			// Remove any lingering workers if we have them
+			// Remove lingering cluster controllers, if any
 			for clusterName, ch := range mcc.clusterControllers {
 				_, found := definedClusters[clusterName]
 				if !found {
 					close(ch)
+					delete(mcc.clusterControllers, clusterName)
 				}
 			}
 

--- a/pkg/provision/provision.go
+++ b/pkg/provision/provision.go
@@ -42,15 +42,7 @@ type tfOutputVar struct {
 // a given cluster.
 type Provisioner interface {
 	Provision(install.Plan) (*install.Plan, error)
-	Destroy(string) error
-}
-
-// Creates a new terraform struct with specified logger.
-func NewTerraform(logger *log.Logger) *Terraform {
-	tf := &Terraform{}
-	tf.BinaryPath = terraformBinaryPath
-	tf.Logger = logger
-	return tf
+	Destroy(clusterName string) error
 }
 
 func (tf Terraform) getTerraformNodes(clusterName, role string) (*tfNodeGroup, error) {

--- a/pkg/server/http/handler/clusters.go
+++ b/pkg/server/http/handler/clusters.go
@@ -209,9 +209,9 @@ func (api Clusters) Get(w http.ResponseWriter, r *http.Request, p httprouter.Par
 		if err == ErrClusterNotFound {
 			w.WriteHeader(http.StatusNotFound)
 		} else {
+			api.Logger.Println(errorf(err.Error()))
 			w.WriteHeader(http.StatusInternalServerError)
 		}
-		api.Logger.Println(errorf(err.Error()))
 		return
 	}
 


### PR DESCRIPTION
Hooked up the destroy functionality on the controller. We can now destroy clusters using the DELETE request.