### PR TITLE
Separating Helm Ansible tasks and adding Helm RBAC resources

### DIFF
--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -8,37 +8,6 @@
       - group_vars/all.yaml
       - group_vars/container_images.yaml
 
-    tasks:
-      - name: "create new serviceaccount for tiller"
-        command: "kubectl -n kube-system create sa tiller"
-        register: out
-        failed_when: 'out.rc != 0 and out.stderr is defined and "Error from server (AlreadyExists)" not in out.stderr'
-      - name: "attach cluster-admin role to the service account tiller"
-        command: "kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller"
-        register: out
-        failed_when: 'out.rc != 0 and out.stderr is defined and "Error from server (AlreadyExists)" not in out.stderr'
-        
-      - name: "run helm init"
-        local_action: command ../../helm init --service-account=tiller -i="{{ images.helm }}" --upgrade {% if disconnected_installation|bool == true %}--skip-refresh{% endif %}
-        become: no
-        environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
-          
-      - name: "add kismatic helm repo"
-        local_action: command ../../helm repo add kismatic https://apprenda.github.io/kismatic-charts/
-        become: no
-        environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
-        when: disconnected_installation|bool != true
+  - roles:
+    - role: helm
 
-      - block:
-        - name: wait until the tiller pod is ready
-          command: kubectl get deployment tiller-deploy -n kube-system -o jsonpath='{.status.availableReplicas}'
-          register: readyReplicas
-          until: readyReplicas.stdout|int == 1
-          retries: 24
-          delay: 10
-          failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-        - name: fail if the tiller pod is not ready
-          fail:
-            msg: "Timed out waiting for the tiller pod to be in the ready state."
-          when: readyReplicas.stdout|int != 1
-        when: run_pod_validation|bool == true 

--- a/ansible/roles/helm/tasks/main.yaml
+++ b/ansible/roles/helm/tasks/main.yaml
@@ -1,0 +1,29 @@
+---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
+
+  - name: copy helm-rbac.yaml to remote
+    template:
+      src: helm-rbac.yaml
+      dest: "{{ kubernetes_spec_dir }}/helm-rbac.yaml"
+
+  - name: create helm serviceaccount and rolebinding
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/helm-rbac.yaml
+
+  - name: "run helm init"
+    local_action: command ../../helm init --service-account=tiller -i="{{ images.helm }}" --upgrade {% if disconnected_installation|bool == true %}--skip-refresh{% endif %}
+    become: no
+    environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
+
+  - name: "add kismatic helm repo"
+    local_action: command ../../helm repo add kismatic https://apprenda.github.io/kismatic-charts/
+    become: no
+    environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
+    when: disconnected_installation|bool != true
+
+  - block:
+    - name: validate tiller pod
+      include: validate.yaml
+      when: run_pod_validation|bool == true 

--- a/ansible/roles/helm/tasks/validate.yaml
+++ b/ansible/roles/helm/tasks/validate.yaml
@@ -1,0 +1,11 @@
+- name: wait until the tiller pod is ready
+  command: kubectl get deployment tiller-deploy -n kube-system -o jsonpath='{.status.availableReplicas}'
+  register: readyReplicas
+  until: readyReplicas.stdout|int == 1
+  retries: 24
+  delay: 10
+  failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+- name: fail if the tiller pod is not ready
+  fail:
+     msg: "Timed out waiting for the tiller pod to be in the ready state."
+  when: readyReplicas.stdout|int != 1

--- a/ansible/roles/helm/templates/helm-rbac.yaml
+++ b/ansible/roles/helm/templates/helm-rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: kube-system


### PR DESCRIPTION
@jaycoon began work on separating ansible tasks and adding Helm RBAC resources, but cannot trigger CI since he isn't one of the devs. This is a workaround for that.