### PR TITLE
Upgrade NGINX Ingress Controller to version 0.9.0 #854

### DIFF
--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -43,10 +43,10 @@ official_images:
     version: 2.0.5
   defaultbackend:
     name: gcr.io/google_containers/defaultbackend
-    version: 1.0
+    version: 1.4
   nginx_ingress_controller:
-    name: gcr.io/google_containers/nginx-ingress-controller
-    version: 0.8.3
+    name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    version: 0.9.0
   nginx:
     name: nginx
     version: stable-alpine
@@ -62,24 +62,24 @@ official_images:
   kube_dnsmasq:
     name: gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64
     version: 1.14.5
-  kubedns_sidecar: 
+  kubedns_sidecar:
     name: gcr.io/google_containers/k8s-dns-sidecar-amd64
     version: 1.14.5
-  kubernetes_dashboard: 
+  kubernetes_dashboard:
     name: gcr.io/google_containers/kubernetes-dashboard-amd64
     version: v1.6.3
-  apprenda_tcp_healthz: 
+  apprenda_tcp_healthz:
     name: apprenda/tcp-healthz-amd64
     version: v1.0.0
-  helm: 
+  helm:
     name: gcr.io/kubernetes-helm/tiller
     version: v2.7.0
-  heapster: 
+  heapster:
     name: gcr.io/google_containers/heapster-amd64
     version: v1.4.3
-  influxdb: 
+  influxdb:
     name: gcr.io/google_containers/heapster-influxdb-amd64
-    version: v1.1.1  
-  rescheduler: 
+    version: v1.1.1
+  rescheduler:
     name: gcr.io/google-containers/rescheduler
     version: v0.3.1

--- a/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
+++ b/ansible/roles/kube-ingress/templates/nginx-ingress-controller.yaml
@@ -10,6 +10,8 @@ spec:
         name: ingress
       annotations:
         kismatic/version: "{{ kismatic_short_version }}"
+        prometheus.io/port: "10254"
+        prometheus.io/scrape: "true"
     spec:
       terminationGracePeriodSeconds: 60
       hostNetwork: true # required in a CNI networkd
@@ -49,3 +51,21 @@ spec:
         args:
         - /nginx-ingress-controller
         - --default-backend-service=kube-system/default-http-backend
+        - --configmap=$(POD_NAMESPACE)/nginx-conf
+        - --profiling=false
+        - --annotations-prefix=ingress.kubernetes.io
+---
+apiVersion: v1
+data:
+  enable-vts-status: "true"
+  access-log-path: "/dev/stdout"
+  error-log-path: "/dev/stdout"
+  error-log-level: "warn"
+  proxy-connect-timeout: "60"
+  proxy-read-timeout: "60"
+  proxy-send-timeout: "60"
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: kube-system
+


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/854

Have made the following changes:

- Upgraded NGINX Ingress Controller to version 0.9.0
- Upgraded the defaultbackend image to version 1.4
- Added the Prometheus scrape annotation to the NGINX Ingress controller
- Added a config map to the NGINX Ingress Controller to enable VTS metrics
- Turned off profiling on the NGINX Ingress Controller

Fixes #854 

cc @aledbf @jonmosco @jarkomes @mrgleeco @willvrny 