### PR TITLE
Expose Calico MTU options in the plan file

### DIFF
--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -28,7 +28,7 @@ data:
         "etcd_cert_file": "{{ kubernetes_certificates.etcd_client }}",
         "etcd_ca_cert_file": "{{ kubernetes_certificates.ca }}",
         "log_level": "{{ cni.options.calico.log_level }}",
-        "mtu": 1500,
+        "mtu": {{ cni.options.calico.workload_mtu }},
         "ipam": {
             "type": "calico-ipam"
         },
@@ -124,7 +124,7 @@ spec:
               value: "{{ cni.options.calico.log_level }}"
             # Set MTU for tunnel device used if ipip is enabled
             - name: FELIX_IPINIPMTU
-              value: "1440"
+              value: "{{ cni.options.calico.felix_input_mtu }}"
             # Set to enable the Prometheus metrics server in Felix.
             - name: FELIX_PROMETHEUSMETRICSENABLED
               value: "true"

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -55,6 +55,8 @@
       * [calico](#add_onscnioptionscalico)
         * [mode](#add_onscnioptionscalicomode)
         * [log_level](#add_onscnioptionscalicolog_level)
+        * [workload_mtu](#add_onscnioptionscalicoworkload_mtu)
+        * [felix_input_mtu](#add_onscnioptionscalicofelix_input_mtu)
   * [dns](#add_onsdns)
     * [disable](#add_onsdnsdisable)
   * [heapster](#add_onsheapster)
@@ -577,6 +579,26 @@
 | **Required** |  No |
 | **Default** | `info` | 
 | **Options** |  `warning`, `info`, `debug`
+
+###  add_ons.cni.options.calico.workload_mtu
+
+ MTU for the workload interface, configures the CNI config 
+
+| | |
+|----------|-----------------|
+| **Kind** |  int |
+| **Required** |  No |
+| **Default** | `1500` | 
+
+###  add_ons.cni.options.calico.felix_input_mtu
+
+ MTU for the tunnel device used if IPIP is enabled 
+
+| | |
+|----------|-----------------|
+| **Kind** |  int |
+| **Required** |  No |
+| **Default** | `1440` | 
 
 ###  add_ons.dns
 

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -89,8 +89,10 @@ type ClusterCatalog struct {
 		Provider string
 		Options  struct {
 			Calico struct {
-				Mode     string
-				LogLevel string `yaml:"log_level"`
+				Mode          string
+				LogLevel      string `yaml:"log_level"`
+				WorkloadMTU   int    `yaml:"workload_mtu"`
+				FelixInputMTU int    `yaml:"felix_input_mtu"`
 			}
 		}
 	}

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -726,6 +726,8 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		cc.CNI.Provider = p.AddOns.CNI.Provider
 		cc.CNI.Options.Calico.Mode = p.AddOns.CNI.Options.Calico.Mode
 		cc.CNI.Options.Calico.LogLevel = p.AddOns.CNI.Options.Calico.LogLevel
+		cc.CNI.Options.Calico.WorkloadMTU = p.AddOns.CNI.Options.Calico.WorkloadMTU
+		cc.CNI.Options.Calico.FelixInputMTU = p.AddOns.CNI.Options.Calico.FelixInputMTU
 
 		if cc.CNI.Provider == cniProviderContiv {
 			cc.InsecureNetworkingEtcd = true

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -112,6 +112,13 @@ func setDefaults(p *Plan) {
 	if p.AddOns.CNI.Options.Calico.LogLevel == "" {
 		p.AddOns.CNI.Options.Calico.LogLevel = "info"
 	}
+	if p.AddOns.CNI.Options.Calico.FelixInputMTU == 0 {
+		p.AddOns.CNI.Options.Calico.FelixInputMTU = 1440
+	}
+
+	if p.AddOns.CNI.Options.Calico.WorkloadMTU == 0 {
+		p.AddOns.CNI.Options.Calico.WorkloadMTU = 1500
+	}
 
 	if p.AddOns.HeapsterMonitoring == nil {
 		p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
@@ -295,6 +302,8 @@ func buildPlanFromTemplateOptions(templateOpts PlanTemplateOptions) Plan {
 	p.AddOns.CNI.Provider = cniProviderCalico
 	p.AddOns.CNI.Options.Calico.Mode = "overlay"
 	p.AddOns.CNI.Options.Calico.LogLevel = "info"
+	p.AddOns.CNI.Options.Calico.WorkloadMTU = 1500
+	p.AddOns.CNI.Options.Calico.FelixInputMTU = 1440
 	// Heapster
 	p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
 	p.AddOns.HeapsterMonitoring.Options.Heapster.Replicas = 2
@@ -436,6 +445,8 @@ var commentMap = map[string][]string{
 	"add_ons.cni.provider":                               []string{"Selecting 'custom' will result in a CNI ready cluster, however it is up to", "you to configure a plugin after the install.", "Options: 'calico','weave','contiv','custom'."},
 	"add_ons.cni.options.calico.mode":                    []string{"Options: 'overlay','routed'."},
 	"add_ons.cni.options.calico.log_level":               []string{"Options: 'warning','info','debug'."},
+	"add_ons.cni.options.calico.workload_mtu":            []string{"MTU for the workload interface, configures the CNI config."},
+	"add_ons.cni.options.calico.felix_input_mtu":         []string{"MTU for the tunnel device used if IPIP is enabled."},
 	"add_ons.heapster.options.influxdb.pvc_name":         []string{"Provide the name of the persistent volume claim that you will create", "after installation. If not specified, the data will be stored in", "ephemeral storage."},
 	"add_ons.heapster.options.heapster.service_type":     []string{"Specify kubernetes ServiceType. Defaults to 'ClusterIP'.", "Options: 'ClusterIP','NodePort','LoadBalancer','ExternalName'."},
 	"add_ons.heapster.options.heapster.sink":             []string{"Specify the sink to store heapster data. Defaults to an influxdb pod", "running on the cluster."},

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -325,6 +325,12 @@ type CalicoOptions struct {
 	// +default=info
 	// +options=warning,info,debug
 	LogLevel string `yaml:"log_level"`
+	// MTU for the workload interface, configures the CNI config
+	// +default=1500
+	WorkloadMTU int `yaml:"workload_mtu"`
+	// MTU for the tunnel device used if IPIP is enabled
+	// +default=1440
+	FelixInputMTU int `yaml:"felix_input_mtu"`
 }
 
 // The DNS add-on configuration

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -134,6 +134,12 @@ add_ons:
         # Options: 'warning','info','debug'.
         log_level: info
 
+        # MTU for the workload interface, configures the CNI config.
+        workload_mtu: 1500
+
+        # MTU for the tunnel device used if IPIP is enabled.
+        felix_input_mtu: 1440
+
   dns:
     disable: false
 

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -134,6 +134,12 @@ add_ons:
         # Options: 'warning','info','debug'.
         log_level: info
 
+        # MTU for the workload interface, configures the CNI config.
+        workload_mtu: 1500
+
+        # MTU for the tunnel device used if IPIP is enabled.
+        felix_input_mtu: 1440
+
   dns:
     disable: false
 


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/968

New options look like:
```
# Add-ons are additional components that KET installs on the cluster.
add_ons:
  cni:
    disable: false

    # Selecting 'custom' will result in a CNI ready cluster, however it is up to
    # you to configure a plugin after the install.
    # Options: 'calico','weave','contiv','custom'.
    provider: calico
    options:
      calico:

        # Options: 'overlay','routed'.
        mode: overlay

        # Options: 'warning','info','debug'.
        log_level: info

        # MTU for the workload interface, configures the CNI config.
        workload_mtu: 1500

        # MTU for the tunnel device used if IPIP is enabled.
        felix_input_mtu: 1440
```