### PR TITLE
Fixes issues where controller and server can clobber each other

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: d7ed159535dd81271076562ba9e50d1a8b64b3a5497f570c25ade5ba8ec16a1d
-updated: 2017-12-11T17:08:12.002723-05:00
+hash: b174a6695087d737a5f02f4435b439f906186dadbca817f51a8f54c738c2ee3c
+updated: 2017-12-13T13:46:47.963575266-05:00
 imports:
 - name: github.com/aws/aws-sdk-go
   version: 40f45e34986ba617a372d1590de273a0ca84a53d
@@ -90,6 +90,13 @@ imports:
   - go/client
   - go/x509
   - go/x509/pkix
+- name: github.com/google/go-cmp
+  version: 8099a9787ce5dc5984ed879a3bda47dc730a8e97
+  subpackages:
+  - cmp
+  - cmp/internal/diff
+  - cmp/internal/function
+  - cmp/internal/value
 - name: github.com/gosuri/uilive
   version: ac356e6e42cd31fcef8e6aec13ae9ed6fe87713e
 - name: github.com/inconshreveable/mousetrap

--- a/glide.yaml
+++ b/glide.yaml
@@ -36,3 +36,7 @@ import:
   version: ~1.2.0
 - package: github.com/onsi/ginkgo
   version: ~1.4.0
+- package: github.com/google/go-cmp
+  version: ~0.1.0
+  subpackages:
+  - cmp

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -124,10 +124,11 @@ func doServer(stdout io.Writer, options serverOptions) error {
 
 	ctrl := controller.New(
 		logger,
-		controller.DefaultExecutorCreator(assetsDir),
+		controller.DefaultExecutorCreator(),
 		controller.DefaultProvisionerCreator(terraform),
 		clusterStore,
 		10*time.Minute,
+		assetsDir,
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	go ctrl.Run(ctx)

--- a/pkg/controller/cluster.go
+++ b/pkg/controller/cluster.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/apprenda/kismatic/pkg/install"
@@ -10,6 +11,8 @@ import (
 )
 
 const (
+	planning        = "planning"
+	planningFailed  = "planningFailed"
 	planned         = "planned"
 	provisioning    = "provisioning"
 	provisionFailed = "provisionFailed"
@@ -26,8 +29,11 @@ const (
 
 // The clusterController manages the lifecycle of a single cluster.
 type clusterController struct {
-	clusterName    string
-	clusterSpec    store.Cluster
+	clusterName string
+	clusterSpec store.ClusterSpec
+	// TODO: The plan is only stored in memory. If the controller goes down, it
+	// will be lost.
+	installPlan    install.Plan
 	log            *log.Logger
 	executor       install.Executor
 	newProvisioner func(store.Cluster) provision.Provisioner
@@ -46,21 +52,21 @@ func (c *clusterController) run(watch <-chan struct{}) {
 			c.log.Printf("error getting cluster from store: %v", err)
 			continue
 		}
-		c.log.Printf("cluster %q - current state: %s, desired state: %s, can continue: %v", c.clusterName, cluster.CurrentState, cluster.DesiredState, cluster.CanContinue)
+		c.log.Printf("cluster %q - current state: %s, desired state: %s, waiting for retry: %v", c.clusterName, cluster.Status.CurrentState, cluster.Spec.DesiredState, cluster.Status.WaitingForManualRetry)
 
-		// If the plan has changed, set the current state to planned.
-		if !cmp.Equal(cluster.Plan, c.clusterSpec.Plan) {
-			cluster.CurrentState = planned
+		// If the cluster spec has changed and we are not trying to destroy, we need to plan again
+		if !cmp.Equal(cluster.Spec, c.clusterSpec) && cluster.Spec.DesiredState != destroyed {
+			cluster.Status.CurrentState = planning
 		}
 
-		// If we have reached the desired state, don't do anything. Similarly,
-		// if we can't continue due to a failure, don't do anything.
-		if cluster.CurrentState == cluster.DesiredState || !cluster.CanContinue {
+		// If we have reached the desired state or we are waiting for a manual
+		// retry, don't do anything
+		if cluster.Status.CurrentState == cluster.Spec.DesiredState || cluster.Status.WaitingForManualRetry {
 			continue
 		}
 
 		// Transition the cluster to the next state
-		updatedCluster := c.transition(*cluster)
+		transitionedCluster := c.transition(*cluster)
 
 		// Transitions are long - O(minutes). Get the latest cluster spec from
 		// the store before updating it.
@@ -72,22 +78,20 @@ func (c *clusterController) run(watch <-chan struct{}) {
 			continue
 		}
 
-		// Update a subset of the fields in the cluster spec.
-		cluster.Plan = updatedCluster.Plan
-		cluster.CurrentState = updatedCluster.CurrentState
-		cluster.CanContinue = updatedCluster.CanContinue
+		// Update the cluster status with the latest
+		cluster.Status = transitionedCluster.Status
 		err = c.clusterStore.Put(c.clusterName, *cluster)
 		if err != nil {
-			c.log.Printf("error storing cluster state: %v. The cluster's current state is %q and desired state is %q", err, cluster.CurrentState, cluster.DesiredState)
+			c.log.Printf("error storing cluster state: %v. The cluster's current state is %q and desired state is %q", err, cluster.Status.CurrentState, cluster.Spec.DesiredState)
 			continue
 		}
 
 		// Update the controller's state of the world to the latest state.
-		c.clusterSpec = *cluster
+		c.clusterSpec = cluster.Spec
 
 		// If the cluster has been destroyed, remove the cluster from the store
 		// and stop the controller
-		if cluster.CurrentState == destroyed {
+		if cluster.Status.CurrentState == destroyed {
 			err := c.clusterStore.Delete(c.clusterName)
 			if err != nil {
 				// At this point, the cluster has already been destroyed, but we
@@ -109,138 +113,200 @@ func (c *clusterController) run(watch <-chan struct{}) {
 // Once the action is done, an updated cluster spec is returned that reflects
 // the outcome of the action.
 func (c *clusterController) transition(cluster store.Cluster) store.Cluster {
-	if cluster.CurrentState == cluster.DesiredState {
+	if cluster.Spec.DesiredState == cluster.Status.CurrentState {
 		return cluster
 	}
-	switch cluster.CurrentState {
+	// Figure out where to go from the current state
+	switch cluster.Status.CurrentState {
+	case "": // This is the initial state
+		cluster.Status.CurrentState = planning
+		return cluster
+	case planning:
+		return c.plan(cluster)
 	case planned:
-		cluster.CurrentState = provisioning
+		cluster.Status.CurrentState = provisioning
+		return cluster
+	case planningFailed:
+		if cluster.Spec.DesiredState == destroyed {
+			cluster.Status.CurrentState = destroying
+			return cluster
+		}
+		cluster.Status.CurrentState = planning
 		return cluster
 	case provisioning:
 		return c.provision(cluster)
 	case provisioned:
-		if cluster.DesiredState == destroyed {
-			cluster.CurrentState = destroying
+		if cluster.Spec.DesiredState == destroyed {
+			cluster.Status.CurrentState = destroying
 			return cluster
 		}
-		cluster.CurrentState = installing
+		cluster.Status.CurrentState = installing
 		return cluster
 	case provisionFailed:
-		if cluster.DesiredState == destroyed {
-			cluster.CurrentState = destroying
+		if cluster.Spec.DesiredState == destroyed {
+			cluster.Status.CurrentState = destroying
 			return cluster
 		}
-		cluster.CurrentState = provisioning
+		cluster.Status.CurrentState = provisioning
 		return cluster
 	case destroying:
 		return c.destroy(cluster)
 	case installing:
 		return c.install(cluster)
 	case installFailed:
-		if cluster.DesiredState == destroyed {
-			cluster.CurrentState = destroying
+		if cluster.Spec.DesiredState == destroyed {
+			cluster.Status.CurrentState = destroying
 			return cluster
 		}
-		cluster.CurrentState = installing
+		cluster.Status.CurrentState = installing
 		return cluster
 	case installed:
-		if cluster.DesiredState == destroyed {
-			cluster.CurrentState = destroying
+		if cluster.Spec.DesiredState == destroyed {
+			cluster.Status.CurrentState = destroying
 			return cluster
 		}
-		c.log.Printf("cluster %q: cannot transition to %q from the 'installed' state", c.clusterName, cluster.DesiredState)
-		cluster.CanContinue = false
+		c.log.Printf("cluster %q: cannot transition to %q from the 'installed' state", c.clusterName, cluster.Spec.DesiredState)
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	default:
-		// Log a message, and set CanContinue to false so that we don't get
+		// Log a message, and set WaitingForManualRetry to true so that we don't get
 		// stuck in an infinte loop. The only thing the user can do in this case
 		// is delete the cluster and file a bug, as this scenario should not
 		// happen.
-		c.log.Printf("cluster %q: the desired state is %q, but there is no transition defined for the cluster's current state %q", c.clusterName, cluster.DesiredState, cluster.CurrentState)
-		cluster.CanContinue = false
+		c.log.Printf("cluster %q: the desired state is %q, but there is no transition defined for the cluster's current state %q", c.clusterName, cluster.Spec.DesiredState, cluster.Status.CurrentState)
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	}
+}
+
+func (c *clusterController) plan(cluster store.Cluster) store.Cluster {
+	c.log.Printf("planning installation for cluster %q", c.clusterName)
+	plan, err := buildPlan(c.clusterName, cluster.Spec, c.installPlan.Cluster.AdminPassword)
+	if err != nil {
+		c.log.Printf("error planning installation for cluster %q: %v", c.clusterName, err)
+		cluster.Status.CurrentState = planningFailed
+		cluster.Status.WaitingForManualRetry = true
+		return cluster
+	}
+	c.installPlan = *plan
+	cluster.Status.CurrentState = planned
+	return cluster
 }
 
 func (c *clusterController) provision(cluster store.Cluster) store.Cluster {
 	c.log.Printf("provisioning infrastructure for cluster %q", c.clusterName)
 	provisioner := c.newProvisioner(cluster)
-	updatedPlan, err := provisioner.Provision(cluster.Plan)
+	updatedPlan, err := provisioner.Provision(c.installPlan)
 	if err != nil {
 		c.log.Printf("error provisioning infrastructure for cluster %q: %v", c.clusterName, err)
-		cluster.CurrentState = provisionFailed
-		cluster.CanContinue = false
+		cluster.Status.CurrentState = provisionFailed
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	}
-	cluster.Plan = *updatedPlan
-	cluster.CurrentState = provisioned
+	c.installPlan = *updatedPlan
+	cluster.Status.CurrentState = provisioned
+	cluster.Status.ClusterIP = updatedPlan.Master.LoadBalancedFQDN
 	return cluster
 }
 
 func (c *clusterController) destroy(cluster store.Cluster) store.Cluster {
 	c.log.Printf("destroying cluster %q", c.clusterName)
 	provisioner := c.newProvisioner(cluster)
-	err := provisioner.Destroy(cluster.Plan.Cluster.Name)
+	err := provisioner.Destroy(c.clusterName)
 	if err != nil {
 		c.log.Printf("error destroying cluster %q: %v", c.clusterName, err)
-		cluster.CurrentState = destroyFailed
-		cluster.CanContinue = false
+		cluster.Status.CurrentState = destroyFailed
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	}
-	cluster.CurrentState = destroyed
+	cluster.Status.CurrentState = destroyed
 	return cluster
 }
 
 func (c *clusterController) install(cluster store.Cluster) store.Cluster {
 	c.log.Printf("installing cluster %q", c.clusterName)
-	plan := cluster.Plan
+	plan := c.installPlan
 
 	err := c.executor.RunPreFlightCheck(&plan)
 	if err != nil {
 		c.log.Printf("cluster %q: error running preflight checks: %v", c.clusterName, err)
-		cluster.CurrentState = installFailed
-		cluster.CanContinue = false
+		cluster.Status.CurrentState = installFailed
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	}
 
 	err = c.executor.GenerateCertificates(&plan, false)
 	if err != nil {
 		c.log.Printf("cluster %q: error generating certificates: %v", c.clusterName, err)
-		cluster.CurrentState = installFailed
-		cluster.CanContinue = false
+		cluster.Status.CurrentState = installFailed
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	}
 
 	err = c.executor.GenerateKubeconfig(plan)
 	if err != nil {
 		c.log.Printf("cluster %q: error generating kubeconfig file: %v", c.clusterName, err)
-		cluster.CurrentState = installFailed
-		cluster.CanContinue = false
+		cluster.Status.CurrentState = installFailed
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	}
 
 	err = c.executor.Install(&plan, true)
 	if err != nil {
 		c.log.Printf("cluster %q: error installing the cluster: %v", c.clusterName, err)
-		cluster.CurrentState = installFailed
-		cluster.CanContinue = false
+		cluster.Status.CurrentState = installFailed
+		cluster.Status.WaitingForManualRetry = true
 		return cluster
 	}
 
 	// Skip the smoketest if the user asked us to skip the installation of a
 	// networking stack
 	if !plan.NetworkConfigured() {
-		cluster.CurrentState = installed
+		cluster.Status.CurrentState = installed
 		return cluster
 	}
 
 	err = c.executor.RunSmokeTest(&plan)
 	if err != nil {
 		c.log.Printf("cluster %q: error running smoke test against the cluster: %v", c.clusterName, err)
-		cluster.CurrentState = installFailed
+		cluster.Status.CurrentState = installFailed
 		return cluster
 	}
 
-	cluster.CurrentState = installed
+	cluster.Status.CurrentState = installed
 	return cluster
+}
+
+func buildPlan(name string, clusterSpec store.ClusterSpec, existingPassword string) (*install.Plan, error) {
+	// Build the plan template
+	planTemplate := install.PlanTemplateOptions{
+		AdminPassword: existingPassword,
+		EtcdNodes:     clusterSpec.EtcdCount,
+		MasterNodes:   clusterSpec.MasterCount,
+		WorkerNodes:   clusterSpec.WorkerCount,
+		IngressNodes:  clusterSpec.IngressCount,
+	}
+	planner := &install.BytesPlanner{}
+	if err := install.WritePlanTemplate(planTemplate, planner); err != nil {
+		return nil, fmt.Errorf("could not decode request body: %v", err)
+	}
+	var p *install.Plan
+	p, err := planner.Read()
+	if err != nil {
+		return nil, fmt.Errorf("could not read plan: %v", err)
+	}
+	// Set values in the plan
+	p.Cluster.Name = name
+	p.Provisioner = install.Provisioner{Provider: clusterSpec.Provisioner.Provider}
+
+	// Set values that depend on the cloud where the cluster will run
+	// TODO: Handle provisioner specific options (e.g. AWS Region)
+	switch clusterSpec.Provisioner.Provider {
+	case "aws":
+		p.Provisioner.AWSOptions = &install.AWSProvisionerOptions{}
+		// nothing
+	case "azure":
+		p.AddOns.CNI.Provider = "weave"
+	}
+	return p, nil
 }

--- a/pkg/controller/cluster_test.go
+++ b/pkg/controller/cluster_test.go
@@ -125,7 +125,9 @@ func TestClusterControllerTriggeredByWatch(t *testing.T) {
 	writerDone := make(chan struct{})
 	defer func() { close(writerDone) }()
 	go func(done <-chan struct{}) {
-		cluster := store.Cluster{CurrentState: planned, DesiredState: installed, CanContinue: true}
+		cluster := store.Cluster{
+			Spec: store.ClusterSpec{DesiredState: installed},
+		}
 		err = clusterStore.Put(clusterName, cluster)
 		if err != nil {
 			t.Fatalf("error storing cluster")
@@ -163,7 +165,7 @@ done:
 			if err != nil {
 				t.Fatalf("error unmarshaling from store")
 			}
-			if cluster.CurrentState == cluster.DesiredState {
+			if cluster.Status.CurrentState == cluster.Spec.DesiredState {
 				break done
 			}
 		case <-time.After(5 * time.Second):
@@ -198,7 +200,9 @@ func TestClusterControllerReconciliationLoop(t *testing.T) {
 	// Create a new cluster in the store before starting the controller.
 	// The controller should pick it up in the reconciliation loop.
 	clusterName := "testCluster"
-	cluster := store.Cluster{CurrentState: planned, DesiredState: installed, CanContinue: true}
+	cluster := store.Cluster{
+		Spec: store.ClusterSpec{DesiredState: installed},
+	}
 	err = clusterStore.Put(clusterName, cluster)
 	if err != nil {
 		t.Fatalf("error storing cluster")
@@ -228,7 +232,7 @@ done:
 			if err != nil {
 				t.Fatalf("error unmarshaling from store")
 			}
-			if cluster.CurrentState == cluster.DesiredState {
+			if cluster.Status.CurrentState == cluster.Spec.DesiredState {
 				break done
 			}
 		case <-time.After(5 * time.Second):

--- a/pkg/controller/cluster_test.go
+++ b/pkg/controller/cluster_test.go
@@ -91,7 +91,7 @@ func TestClusterControllerTriggeredByWatch(t *testing.T) {
 	logger := log.New(os.Stdout, "[cluster controller] ", log.Ldate|log.Ltime)
 
 	// Stub out dependencies
-	executorCreator := func(string) (install.Executor, error) { return dummyExec{}, nil }
+	executorCreator := func(string, string) (install.Executor, error) { return dummyExec{}, nil }
 
 	tmpFile, err := ioutil.TempFile("", "cluster-controller-tests")
 	if err != nil {
@@ -116,7 +116,11 @@ func TestClusterControllerTriggeredByWatch(t *testing.T) {
 	defer cancel()
 
 	clusterName := "testCluster"
-	c := New(logger, executorCreator, provisioner, clusterStore, 10*time.Minute)
+	assetsDir, err := ioutil.TempDir("", "cluster-controller-tests-assets")
+	if err != nil {
+		t.Fatalf("failed to create assets dir: %v", err)
+	}
+	c := New(logger, executorCreator, provisioner, clusterStore, 10*time.Minute, assetsDir)
 	go c.Run(ctx)
 
 	// Create a new cluster in the store
@@ -181,7 +185,7 @@ func TestClusterControllerReconciliationLoop(t *testing.T) {
 	logger := log.New(os.Stdout, "[cluster controller] ", log.Ldate|log.Ltime)
 
 	// Stub out dependencies
-	executorCreator := func(string) (install.Executor, error) { return dummyExec{}, nil }
+	executorCreator := func(string, string) (install.Executor, error) { return dummyExec{}, nil }
 
 	tmpFile, err := ioutil.TempFile("", "cluster-controller-tests")
 	if err != nil {
@@ -215,7 +219,11 @@ func TestClusterControllerReconciliationLoop(t *testing.T) {
 	// Start the controller
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	c := New(logger, executorCreator, provisioner, clusterStore, 1*time.Second)
+	assetsDir, err := ioutil.TempDir("", "cluster-controller-tests-assets")
+	if err != nil {
+		t.Fatalf("failed to create assets dir: %v", err)
+	}
+	c := New(logger, executorCreator, provisioner, clusterStore, 1*time.Second, assetsDir)
 	go c.Run(ctx)
 
 	// Assert that the cluster reaches desired state

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -76,16 +76,16 @@ func DefaultExecutorCreator(rootDir string) ExecutorCreator {
 // on the clouds we support.
 func DefaultProvisionerCreator(terraform provision.Terraform) ProvisionerCreator {
 	return func(cluster store.Cluster) provision.Provisioner {
-		switch cluster.Plan.Provisioner.Provider {
+		switch cluster.Spec.Provisioner.Provider {
 		case "aws":
 			p := provision.AWS{
-				AccessKeyID:     cluster.ProvisionerCredentials.AWS.AccessKeyId,
-				SecretAccessKey: cluster.ProvisionerCredentials.AWS.SecretAccessKey,
+				AccessKeyID:     cluster.Spec.Provisioner.Credentials.AWS.AccessKeyId,
+				SecretAccessKey: cluster.Spec.Provisioner.Credentials.AWS.SecretAccessKey,
 				Terraform:       terraform,
 			}
 			return p
 		default:
-			panic(fmt.Sprintf("provider not supported: %q", cluster.Plan.Provisioner.Provider))
+			panic(fmt.Sprintf("provider not supported: %q", cluster.Spec.Provisioner.Provider))
 		}
 	}
 }

--- a/pkg/controller/multicluster.go
+++ b/pkg/controller/multicluster.go
@@ -78,7 +78,7 @@ func (mcc *multiClusterController) Run(ctx context.Context) {
 				}
 				cc := clusterController{
 					clusterName:    clusterName,
-					clusterSpec:    cluster,
+					clusterSpec:    cluster.Spec,
 					log:            mcc.log,
 					executor:       executor,
 					clusterStore:   mcc.clusterStore,
@@ -114,7 +114,7 @@ func (mcc *multiClusterController) Run(ctx context.Context) {
 					}
 					cc := clusterController{
 						clusterName:    clusterName,
-						clusterSpec:    cluster,
+						clusterSpec:    cluster.Spec,
 						log:            mcc.log,
 						executor:       executor,
 						clusterStore:   mcc.clusterStore,

--- a/pkg/provision/aws.go
+++ b/pkg/provision/aws.go
@@ -81,7 +81,7 @@ func (aws AWS) Provision(plan install.Plan) (*install.Plan, error) {
 		PrivateSSHKeyPath: privKeyPath,
 		PublicSSHKeyPath:  pubKeyPath,
 	}
-	b, err := json.Marshal(data)
+	b, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/http/handler/clusters_test.go
+++ b/pkg/server/http/handler/clusters_test.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apprenda/kismatic/pkg/install"
 	"github.com/apprenda/kismatic/pkg/store"
 	"github.com/julienschmidt/httprouter"
 )
@@ -224,10 +223,12 @@ func TestValidationShouldError(t *testing.T) {
 
 func TestUpdateValidationShouldError(t *testing.T) {
 	tests := []struct {
+		name  string
 		cu    clusterUpdate
 		valid bool
 	}{
 		{
+			name: "updating with no changes is valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -246,28 +247,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 2,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: true,
 		},
 		{
+			name: "updating the number of ingress nodes is valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -286,28 +277,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 0,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: true,
 		},
 		{
+			name: "updating the number of worker nodes is valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -326,28 +307,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 3,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: true,
 		},
 		{
+			name: "updating the name of the cluster is not valid",
 			cu: clusterUpdate{
 				id: "bar",
 				request: ClusterRequest{
@@ -366,28 +337,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 2,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: false,
 		},
 		{
+			name: "updating the name of the cluster is not valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -406,68 +367,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 2,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: false,
 		},
 		{
-			cu: clusterUpdate{
-				id: "foo",
-				request: ClusterRequest{
-					Name:         "foo",
-					DesiredState: "installed",
-					Provisioner: Provisioner{
-						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
-						},
-					},
-					EtcdCount:    3,
-					MasterCount:  2,
-					WorkerCount:  5,
-					IngressCount: 2,
-				},
-				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "bar",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
-					},
-				},
-			},
-			valid: false,
-		},
-		{
+			name: "updating the number of etcd nodes is not valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -486,28 +397,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 2,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: false,
 		},
 		{
+			name: "updating master nodes to zero is not valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -526,28 +427,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 2,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: false,
 		},
 		{
+			name: "updating the worker nodes to zero is not valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -566,28 +457,18 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: 2,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
 			valid: false,
 		},
 		{
+			name: "updating the number of ingress nodes to < 0 is not valid",
 			cu: clusterUpdate{
 				id: "foo",
 				request: ClusterRequest{
@@ -606,22 +487,11 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					IngressCount: -1,
 				},
 				inStore: store.Cluster{
-					Plan: install.Plan{
-						Cluster: install.Cluster{
-							Name: "foo",
-						},
-						Etcd: install.NodeGroup{
-							ExpectedCount: 3,
-						},
-						Master: install.MasterNodeGroup{
-							ExpectedCount: 2,
-						},
-						Worker: install.NodeGroup{
-							ExpectedCount: 5,
-						},
-						Ingress: install.OptionalNodeGroup{
-							ExpectedCount: 2,
-						},
+					Spec: store.ClusterSpec{
+						EtcdCount:    3,
+						MasterCount:  2,
+						WorkerCount:  5,
+						IngressCount: 2,
 					},
 				},
 			},
@@ -629,10 +499,12 @@ func TestUpdateValidationShouldError(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		ok, errs := test.cu.validate()
-		if ok != test.valid {
-			t.Errorf("test %d: expect %t, but got %t: %v", i, test.valid, ok, errs)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			ok, errs := test.cu.validate()
+			if ok != test.valid {
+				t.Errorf("test %d: expect %t, but got %t: %v", i, test.valid, ok, errs)
+			}
+		})
 	}
 }
 
@@ -777,7 +649,7 @@ func TestCreateUpdateGetGetAllandDelete(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if resp.CurrentState != "planned" || resp.WorkerCount != 6 {
+	if resp.WorkerCount != 6 {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), resp)
 	}
@@ -844,7 +716,7 @@ func TestCreateUpdateGetGetAllandDelete(t *testing.T) {
 	r.DELETE("/clusters/:name", clustersAPI.Delete)
 	r.ServeHTTP(rr, req)
 	if status := rr.Code; status != http.StatusAccepted {
-		t.Errorf("handler returned wrong status code: got %v want %v: %s",
+		t.Errorf("handler returned wrong status code: got %d want %v: %d",
 			status, http.StatusAccepted, rr.Code)
 	}
 	expected = "ok\n"

--- a/pkg/store/cluster.go
+++ b/pkg/store/cluster.go
@@ -3,22 +3,46 @@ package store
 import (
 	"context"
 	"encoding/json"
-
-	"github.com/apprenda/kismatic/pkg/install"
 )
 
+// Cluster defines a Kubernetes cluster in KET
 type Cluster struct {
-	DesiredState           string
-	CurrentState           string
-	CanContinue            bool
-	Plan                   install.Plan
-	ProvisionerCredentials ProvisionerCredentials
+	Spec   ClusterSpec
+	Status ClusterStatus
 }
 
+// The ClusterSpec describes the specifications for the cluster. In other words,
+// the desired state and desired configuration of the cluster.
+type ClusterSpec struct {
+	DesiredState string
+	EtcdCount    int
+	MasterCount  int
+	WorkerCount  int
+	IngressCount int
+	Provisioner  Provisioner
+}
+
+// The ClusterStatus is the current status of the cluster.
+type ClusterStatus struct {
+	CurrentState          string
+	WaitingForManualRetry bool
+	ClusterIP             string
+}
+
+// The Provisioner specifies the infrastructure provisioner that should be used
+// for the cluster.
+type Provisioner struct {
+	Provider    string
+	Credentials ProvisionerCredentials
+}
+
+// ProvisionerCredentials are the credentials necessary for connecting to the
+// infrastructure provisioner.
 type ProvisionerCredentials struct {
 	AWS AWSCredentials
 }
 
+// AWSCredentials are the credentials for interacting with the AWS API.
 type AWSCredentials struct {
 	AccessKeyId     string
 	SecretAccessKey string
@@ -40,6 +64,8 @@ type cs struct {
 	Store  WatchedStore
 }
 
+// NewClusterStore returns a ClusterStore that manages clusters under the given
+// bucket.
 func NewClusterStore(store WatchedStore, bucket string) ClusterStore {
 	return cs{Store: store, Bucket: bucket}
 }


### PR DESCRIPTION
As described in #962, the controller and server overwrite their changes during operation. This is a problem because any change requested by the user can be wiped by the controller when it finishes an in-flight operation.

To avoid this issue, the controller should only be able to touch the current state field, while the server should only touch the desired state field. Given that these fields live in the same type and that controller operations are long-running, the controller needs to re-read the cluster object before updating it to pick up any changes that might have occurred while performing the operation. Ideally, this would be done in a transaction, but the current implementation of the store does not expose them. We will have to address this in a follow up issue.

Another outstanding issue is that of changing the plan file, as both the controller and server are currently manipulating the plan. We can get away with it for now because they touch different fields, but it might become a problem in the future. I am starting to think that the plan file should be considered an implementation detail that is handled by the controller, but this needs more thought.

