### PR TITLE
Expose docker log driver options

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -55,9 +55,9 @@ docker_certificates_cert_path: "{{ docker_install_dir }}/{{ docker_certificates_
 docker_certificates_key_path: "{{ docker_install_dir }}/{{ docker_certificates_key_file_name }}"
 #===============================================================================
 # docker configuration
-# docker_direct_lvm_enabled: no default
-# docker_direct_lvm_block_device_path: no default
-# docker_direct_lvm_deferred_deletion_enabled: no default
+# docker.storage.directlvm.enabled: no default
+# docker.storage.directlvm.block_device: no default
+# docker.storage.directlvm.enable_deferred_deletion: no default
 docker_device_mapper_thin_pool_autoextend_threshold: 80
 docker_device_mapper_thin_pool_autoextend_percent: 20
 docker_system_d: /etc/systemd/system/docker.service.d

--- a/ansible/roles/docker-storage/tasks/direct_lvm.yaml
+++ b/ansible/roles/docker-storage/tasks/direct_lvm.yaml
@@ -5,7 +5,7 @@
       state: present
   - name: create docker volume group
     lvg:
-      pvs: "{{ docker_direct_lvm_block_device_path }}"
+      pvs: "{{ docker.storage.directlvm.block_device }}"
       state: present
       vg: docker
   - name: create thinpool logical volume

--- a/ansible/roles/docker-storage/tasks/main.yaml
+++ b/ansible/roles/docker-storage/tasks/main.yaml
@@ -1,4 +1,4 @@
 ---
   - name: configure devicemapper in direct-lvm mode
     include: direct_lvm.yaml
-    when: "ansible_os_family == 'RedHat' and docker_direct_lvm_enabled|bool == true"
+    when: "ansible_os_family == 'RedHat' and docker.storage.directlvm.enabled|bool == true"

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -7,7 +7,6 @@
     template:
       src: daemon.json
       dest: /etc/docker/daemon.json
-    when: docker_direct_lvm_enabled|bool == true
   # start and verify that Docker installed successfully and is running
   - name: start docker service
     service:

--- a/ansible/roles/docker/templates/daemon.json
+++ b/ansible/roles/docker/templates/daemon.json
@@ -1,8 +1,19 @@
 {
+{% if docker.storage.directlvm.enabled %}
   "storage-driver": "devicemapper",
    "storage-opts": [
      "dm.thinpooldev=/dev/mapper/docker-thinpool",
      "dm.use_deferred_removal=true",
-     "dm.use_deferred_deletion={{docker_direct_lvm_deferred_deletion_enabled}}"
-   ]
+     "dm.use_deferred_deletion={{docker.storage.directlvm.enable_deferred_deletion}}"
+   ]{% if docker.logs.driver != "" %},{% endif %}
+{% endif %}
+
+{% if docker.logs.driver != "" %}
+  "log-driver": "{{ docker.logs.driver }}"{% if docker.logs.opts | length > 0 %},{% endif %}
+
+{% if docker.logs.opts | length > 0 %}
+  "log-opts": 
+{{ docker.logs.opts | to_nice_json(indent=4) }}
+{% endif %}
+{% endif %}
 }

--- a/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
+++ b/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
@@ -1,7 +1,7 @@
 ---
   - name: stat the block device path
     stat:
-      path: "{{ docker_direct_lvm_block_device_path }}"
+      path: "{{ docker.storage.directlvm.block_device }}"
     register: block_device_stat
   - name: fail if the block device does not exists
     fail:
@@ -9,10 +9,10 @@
     when: block_device_stat.stat.exists == False
   - name: fail if the provided path is not a block device
     fail:
-      msg: "{{ docker_direct_lvm_block_device_path }} is not a block device."
+      msg: "{{ docker.storage.directlvm.block_device }} is not a block device."
     when: block_device_stat.stat.isblk == False
   - name: fail if the block device is already mounted
     fail:
       msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
     with_items: "{{ ansible_mounts }}"
-    when: item.device == "{{ docker_direct_lvm_block_device_path }}"
+    when: item.device == "{{ docker.storage.directlvm.block_device }}"

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -87,7 +87,7 @@
 
   - name: validate devicemapper direct-lvm block device
     include: direct_lvm_preflight.yaml
-    when: "ansible_os_family == 'RedHat' and docker_direct_lvm_enabled|bool == true"
+    when: "ansible_os_family == 'RedHat' and docker.storage.directlvm.enabled|bool == true"
 
     # Run from the install node, 
     # Check if the helm repos can be reached

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -27,3 +27,17 @@ space allows for auto-extending the logical volumes when they start to fill up a
 The threshold for auto-extension is set to 80% of the size of the volume.
 
 For more information on `devicemapper` see https://docs.docker.com/engine/userguide/storagedriver/device-mapper-driver/#configure-direct-lvm-mode-for-production
+
+## Log Driver (KET v1.7.0+)
+```
+docker
+  logs:
+    driver: json-file
+    opts:
+      max-file: "1"
+      max-size: 50m
+```
+
+In the plan file the `docker.logs` field allows to set the docker daemon log driver [options](https://docs.docker.com/engine/admin/logging/overview/). The specified options from the plan file get set in `/etc/docker/daemon.json`. 
+
+This is an advanced feature and the values provided will not be validated, please refer to the documentation for your specific driver for the valid options.

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -35,6 +35,9 @@
     * [provider](#clustercloud_providerprovider)
     * [config](#clustercloud_providerconfig)
 * [docker](#docker)
+  * [logs](#dockerlogs)
+    * [driver](#dockerlogsdriver)
+    * [opts](#dockerlogsopts)
   * [storage](#dockerstorage)
     * [direct_lvm](#dockerstoragedirect_lvm)
       * [enabled](#dockerstoragedirect_lvmenabled)
@@ -418,6 +421,30 @@
 ##  docker
 
  Configuration for the docker engine installed by KET 
+
+###  docker.logs
+
+ Log configuration for the docker engine 
+
+###  docker.logs.driver
+
+ Docker logging driver, more details https://docs.docker.com/engine/admin/logging/overview/ 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | `json-file` | 
+
+###  docker.logs.opts
+
+ Driver specific options 
+
+| | |
+|----------|-----------------|
+| **Kind** |  map[string]string |
+| **Required** |  No |
+| **Default** | ` ` | 
 
 ###  docker.storage
 

--- a/integration/plan_patterns.go
+++ b/integration/plan_patterns.go
@@ -80,6 +80,11 @@ docker:
       enabled: true
       block_device: "/dev/xvdb"
       enable_deferred_deletion: false{{end}}
+  logs:
+    driver: "json-file"
+    opts: 
+      "max-size": "50m"
+      "max-file": "1"
 docker_registry:
   server: {{.DockerRegistryServer}}
   CA: {{.DockerRegistryCAPath}}

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -69,9 +69,19 @@ type ClusterCatalog struct {
 	DiagnosticsDirectory string `yaml:"diagnostics_dir"`
 	DiagnosticsDateTime  string `yaml:"diagnostics_date_time"`
 
-	DockerDirectLVMEnabled                 bool   `yaml:"docker_direct_lvm_enabled"`
-	DockerDirectLVMBlockDevicePath         string `yaml:"docker_direct_lvm_block_device_path"`
-	DockerDirectLVMDeferredDeletionEnabled bool   `yaml:"docker_direct_lvm_deferred_deletion_enabled"`
+	Docker struct {
+		Logs struct {
+			Driver string            `yaml:"driver"`
+			Opts   map[string]string `yaml:"opts"`
+		}
+		Storage struct {
+			DirectLVM struct {
+				Enabled                bool   `yaml:"enabled"`
+				BlockDevice            string `yaml:"block_device"`
+				EnableDeferredDeletion bool   `yaml:"enable_deferred_deletion"`
+			}
+		}
+	}
 
 	LocalKubeconfigDirectory string `yaml:"local_kubeconfig_directory"`
 

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -691,10 +691,13 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	}
 
 	// Setup docker options
-	cc.DockerDirectLVMEnabled = p.Docker.Storage.DirectLVM.Enabled
-	if cc.DockerDirectLVMEnabled {
-		cc.DockerDirectLVMBlockDevicePath = p.Docker.Storage.DirectLVM.BlockDevice
-		cc.DockerDirectLVMDeferredDeletionEnabled = p.Docker.Storage.DirectLVM.EnableDeferredDeletion
+	cc.Docker.Logs.Driver = p.Docker.Logs.Driver
+	cc.Docker.Logs.Opts = p.Docker.Logs.Opts
+
+	cc.Docker.Storage.DirectLVM.Enabled = p.Docker.Storage.DirectLVM.Enabled
+	if cc.Docker.Storage.DirectLVM.Enabled {
+		cc.Docker.Storage.DirectLVM.BlockDevice = p.Docker.Storage.DirectLVM.BlockDevice
+		cc.Docker.Storage.DirectLVM.EnableDeferredDeletion = p.Docker.Storage.DirectLVM.EnableDeferredDeletion
 	}
 	if ae.options.RestartServices {
 		cc.EnableRestart()

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -99,6 +99,14 @@ func readDeprecatedFields(p *Plan) {
 }
 
 func setDefaults(p *Plan) {
+	if p.Docker.Logs.Driver == "" {
+		p.Docker.Logs.Driver = "json-file"
+		p.Docker.Logs.Opts = map[string]string{
+			"max-size": "50m",
+			"max-file": "1",
+		}
+	}
+
 	if p.AddOns.CNI == nil {
 		p.AddOns.CNI = &CNI{}
 		p.AddOns.CNI.Provider = cniProviderCalico
@@ -295,6 +303,15 @@ func buildPlanFromTemplateOptions(templateOpts PlanTemplateOptions) Plan {
 	// Set Certificate defaults
 	p.Cluster.Certificates.Expiry = "17520h"
 	p.Cluster.Certificates.CAExpiry = defaultCAExpiry
+
+	// Docker
+	p.Docker.Logs = DockerLogs{
+		Driver: "json-file",
+		Opts: map[string]string{
+			"max-size": "50m",
+			"max-file": "1",
+		},
+	}
 
 	// Add-Ons
 	// CNI

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -212,8 +212,19 @@ type CloudProvider struct {
 
 // Docker includes the configuration for the docker installation owned by KET.
 type Docker struct {
+	// Log configuration for the docker engine
+	Logs DockerLogs
 	// Storage configuration for the docker engine
 	Storage DockerStorage
+}
+
+// DockerLogs includes the log-specific configuration for docker.
+type DockerLogs struct {
+	// Docker logging driver, more details https://docs.docker.com/engine/admin/logging/overview/
+	// +default=json-file
+	Driver string
+	// Driver specific options
+	Opts map[string]string
 }
 
 // DockerStorage includes the storage-specific configuration for docker.

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -83,6 +83,12 @@ cluster:
 
 # Docker daemon configuration of all cluster nodes
 docker:
+  logs:
+    driver: json-file
+    opts:
+      max-file: "1"
+      max-size: 50m
+
   storage:
 
     # Configure devicemapper in direct-lvm mode (RHEL/CentOS only).

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -83,6 +83,12 @@ cluster:
 
 # Docker daemon configuration of all cluster nodes
 docker:
+  logs:
+    driver: json-file
+    opts:
+      max-file: "1"
+      max-size: 50m
+
   storage:
 
     # Configure devicemapper in direct-lvm mode (RHEL/CentOS only).


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/685, fixes https://github.com/apprenda/kismatic/issues/674

Sample plan file:
```
docker:
  logs:
    driver: json-file
    opts:
      max-file: "1"
      max-size: 50m
```

The values above will be used in the docker config json unless the user overwrites these options.

The `opts` is a `map[string]string` so any option can be set.
 