### PR TITLE
mount /lib/modules from hosts in the kube-dns pods so they can detect ip_vs modules

### DIFF
--- a/ansible/roles/kube-proxy/templates/kube-proxy.yaml
+++ b/ansible/roles/kube-proxy/templates/kube-proxy.yaml
@@ -35,6 +35,9 @@ spec:
       - mountPath: /etc/kubernetes
         name: "etc-kube-ssl"
         readOnly: true
+      - mountPath: /lib/modules
+        name: "lib-modules"
+        readOnly: true
     livenessProbe:
       httpGet:
         host: 127.0.0.1
@@ -44,6 +47,9 @@ spec:
       timeoutSeconds: 15
       failureThreshold: 8
   volumes:
+    - name: "lib-modules"
+      hostPath:
+        path: "/lib/modules"
     - name: "ssl-certs"
       hostPath:
         path: "/usr/share/ca-certificates"


### PR DESCRIPTION
This solves an error message from kube-proxy on start up when it is looking for ip_vs modules.
```
kubectl logs kube-proxy-bizhpb0s01k8s -n kube-system 
W1213 20:39:32.056622       1 server.go:191] WARNING: all flags other than --config, --write-config-to, and --cleanup are deprecated. Please begin using a config file ASAP.
I1213 20:39:33.978476       1 iptables.go:192] Could not connect to D-Bus system bus: dial unix /var/run/dbus/system_bus_socket: connect: no such file or directory
time="2017-12-13T20:39:34Z" level=warning msg="Running modprobe ip_vs failed with message: `modprobe: ERROR: ../libkmod/libkmod.c:557 kmod_search_moddep() could not open moddep file '/lib/modules/4.13.0-19-lowlatency/modules.dep.bin'`, error: exit status 1"
time="2017-12-13T20:39:34Z" level=error msg="Could not get ipvs family information from the kernel. It is possible that ipvs is not enabled in your kernel. Native loadbalancing will not work until this is fixed."
```