### PR TITLE
Persist provider-specific options in store

### DIFF
--- a/integration/daemon_test.go
+++ b/integration/daemon_test.go
@@ -81,9 +81,10 @@ The error: %v
 					IngressCount: 1,
 					Provisioner: handler.Provisioner{
 						Provider: "aws",
-						AWSOptions: &handler.AWSProvisionerOptions{
-							AccessKeyID:     accessKeyID,
-							SecretAccessKey: secretAccessKey,
+						Options: map[string]string{
+							"accessKeyId":     accessKeyID,
+							"secretAccessKey": secretAccessKey,
+							"region":          "us-east-1",
 						},
 					},
 				}

--- a/pkg/controller/cluster.go
+++ b/pkg/controller/cluster.go
@@ -342,11 +342,13 @@ func writePlanFile(clusterName string, filePlanner install.FilePlanner, clusterS
 	// Set values in the plan
 	p.Cluster.Name = clusterName
 	p.Provisioner = install.Provisioner{Provider: clusterSpec.Provisioner.Provider}
-	// TODO: Handle provisioner specific options (e.g. AWS Region)
+
+	// Set infrastructure provider specific options
 	switch clusterSpec.Provisioner.Provider {
 	case "aws":
-		p.Provisioner.AWSOptions = &install.AWSProvisionerOptions{}
-		// nothing
+		p.Provisioner.AWSOptions = &install.AWSProvisionerOptions{
+			Region: clusterSpec.Provisioner.Options.AWS.Region,
+		}
 	case "azure":
 		p.AddOns.CNI.Provider = "weave"
 	}

--- a/pkg/server/http/handler/clusters_test.go
+++ b/pkg/server/http/handler/clusters_test.go
@@ -60,9 +60,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -75,9 +75,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "bar",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -90,9 +90,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "foobar",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -105,9 +105,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -120,9 +120,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "",
 				},
 			},
 			EtcdCount:    3,
@@ -135,9 +135,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    0,
@@ -150,9 +150,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -165,9 +165,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -180,9 +180,9 @@ func TestValidationShouldError(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -236,9 +236,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    3,
@@ -266,9 +267,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    3,
@@ -296,9 +298,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID_NEW",
-							SecretAccessKey: "SECRET_NEW",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID_NEW",
+							awsOptionSecretAccessKey: "SECRET_NEW",
 						},
 					},
 					EtcdCount:    3,
@@ -326,9 +329,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    3,
@@ -356,9 +360,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    3,
@@ -386,9 +391,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    5,
@@ -416,9 +422,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    3,
@@ -446,9 +453,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    3,
@@ -476,9 +484,10 @@ func TestUpdateValidationShouldError(t *testing.T) {
 					DesiredState: "installed",
 					Provisioner: Provisioner{
 						Provider: "aws",
-						AWSOptions: &AWSProvisionerOptions{
-							AccessKeyID:     "ACCESS_ID",
-							SecretAccessKey: "SECRET",
+						Options: map[string]string{
+							awsOptionRegion:          "us-east-1",
+							awsOptionAccessKeyID:     "ACCESS_ID",
+							awsOptionSecretAccessKey: "SECRET",
 						},
 					},
 					EtcdCount:    3,
@@ -518,9 +527,10 @@ func TestValidation(t *testing.T) {
 			DesiredState: "installed",
 			Provisioner: Provisioner{
 				Provider: "aws",
-				AWSOptions: &AWSProvisionerOptions{
-					AccessKeyID:     "ACCESS_ID",
-					SecretAccessKey: "SECRET",
+				Options: map[string]string{
+					awsOptionRegion:          "us-east-1",
+					awsOptionAccessKeyID:     "ACCESS_ID",
+					awsOptionSecretAccessKey: "SECRET",
 				},
 			},
 			EtcdCount:    3,
@@ -567,9 +577,10 @@ func TestCreateUpdateGetGetAllandDelete(t *testing.T) {
 		DesiredState: "installed",
 		Provisioner: Provisioner{
 			Provider: "aws",
-			AWSOptions: &AWSProvisionerOptions{
-				AccessKeyID:     "ACCESS_ID",
-				SecretAccessKey: "SECRET",
+			Options: map[string]string{
+				awsOptionRegion:          "us-east-1",
+				awsOptionAccessKeyID:     "ACCESS_ID",
+				awsOptionSecretAccessKey: "SECRET",
 			},
 		},
 		EtcdCount:    3,
@@ -616,9 +627,10 @@ func TestCreateUpdateGetGetAllandDelete(t *testing.T) {
 		DesiredState: "installed",
 		Provisioner: Provisioner{
 			Provider: "aws",
-			AWSOptions: &AWSProvisionerOptions{
-				AccessKeyID:     "ACCESS_ID",
-				SecretAccessKey: "SECRET",
+			Options: map[string]string{
+				awsOptionRegion:          "us-east-1",
+				awsOptionAccessKeyID:     "ACCESS_ID",
+				awsOptionSecretAccessKey: "SECRET",
 			},
 		},
 		EtcdCount:    3,
@@ -746,6 +758,61 @@ func TestCreateUpdateGetGetAllandDelete(t *testing.T) {
 	if len(respAll) != 1 && respAll[0].DesiredState != "destroyed" {
 		t.Errorf("handler returned unexpected body: got %v want %v",
 			rr.Body.String(), respAll)
+	}
+}
+
+func TestProviderOptions(t *testing.T) {
+	cs := &mockClustersStore{}
+	handler := Clusters{Store: cs, Logger: log.New(os.Stdout, "test", 0)}
+	clusterRequest := &ClusterRequest{
+		Name:         "foo",
+		DesiredState: "installed",
+		Provisioner: Provisioner{
+			Provider: "aws",
+			Options: map[string]string{
+				awsOptionAccessKeyID:     "ACCESS_ID",
+				awsOptionSecretAccessKey: "SECRET",
+				awsOptionRegion:          "us-east-2",
+			},
+		},
+		EtcdCount:    3,
+		MasterCount:  2,
+		WorkerCount:  5,
+		IngressCount: 2,
+	}
+	encoded, err := json.Marshal(clusterRequest)
+	if err != nil {
+		t.Fatalf("could not encode body to json %v", err)
+	}
+	req, err := http.NewRequest("POST", "/clusters", bytes.NewBuffer(encoded))
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler.Create(httptest.NewRecorder(), req, httprouter.Params{})
+	cluster, err := cs.Get(clusterRequest.Name)
+	if err != nil {
+		t.Fatalf("cluster was not persisted in the store")
+	}
+	if cluster.Spec.Provisioner.Options.AWS.Region != clusterRequest.Provisioner.Options[awsOptionRegion] {
+		t.Errorf("AWS region was not persisted. Expected %s, but got %s", clusterRequest.Provisioner.Options[awsOptionRegion], cluster.Spec.Provisioner.Options.AWS.Region)
+	}
+
+	recorder := httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "/clusters/"+clusterRequest.Name, nil)
+	if err != nil {
+		t.Fatalf("error building request: %v", err)
+	}
+	handler.Get(recorder, req, httprouter.Params{httprouter.Param{Key: "name", Value: clusterRequest.Name}})
+	clusterResponse := ClusterResponse{}
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("unexpected response from the server: %d", recorder.Code)
+	}
+	err = json.NewDecoder(recorder.Body).Decode(&clusterResponse)
+	if err != nil {
+		t.Fatalf("error decoding response from server: %v", err)
+	}
+	if clusterResponse.Provisioner.Options[awsOptionRegion] != clusterRequest.Provisioner.Options[awsOptionRegion] {
+		t.Errorf("cluster response has region %q, but request had region %q", clusterResponse.Provisioner.Options[awsOptionRegion], clusterRequest.Provisioner.Options[awsOptionRegion])
 	}
 }
 

--- a/pkg/server/http/handler/validation.go
+++ b/pkg/server/http/handler/validation.go
@@ -76,11 +76,14 @@ func (p *Provisioner) validate() (bool, []error) {
 		}
 		switch p.Provider {
 		case "aws":
-			if p.AWSOptions == nil || p.AWSOptions.AccessKeyID == "" {
-				v.addError(fmt.Errorf("provisioner.options.accessKeyID cannot be empty"))
+			if p.Options[awsOptionAccessKeyID] == "" {
+				v.addError(fmt.Errorf("provisioner.options.accessKeyId cannot be empty"))
 			}
-			if p.AWSOptions == nil || p.AWSOptions.SecretAccessKey == "" {
+			if p.Options[awsOptionSecretAccessKey] == "" {
 				v.addError(fmt.Errorf("provisioner.options.secretAccessKey cannot be empty"))
+			}
+			if p.Options[awsOptionRegion] == "" {
+				v.addError(fmt.Errorf("provisioner.options.region cannot be empty"))
 			}
 		}
 	}

--- a/pkg/store/cluster.go
+++ b/pkg/store/cluster.go
@@ -34,12 +34,21 @@ type ClusterStatus struct {
 type Provisioner struct {
 	Provider    string
 	Credentials ProvisionerCredentials
+	Options     ProvisionerOptions
 }
 
 // ProvisionerCredentials are the credentials necessary for connecting to the
 // infrastructure provisioner.
 type ProvisionerCredentials struct {
 	AWS AWSCredentials
+}
+
+type ProvisionerOptions struct {
+	AWS AWSProvisionerOptions
+}
+
+type AWSProvisionerOptions struct {
+	Region string
 }
 
 // AWSCredentials are the credentials for interacting with the AWS API.


### PR DESCRIPTION
Fixes #984 

In order to not get into deserialization and type assertion hell, I made the options field of the ClusterRequest a `map[string]string`. This is the initial step towards the long term plan of supporting providers without having to recompile KET.

With that said, we still have provider specific code as we do not have the required framework built yet. The structs are basically replaced by provider-specific constants that define the keys we expect in the options map. These constants are used in validation and when transforming the request into a cluster spec. More importantly, the cluster spec's provider field is still cloud-provider specific. This is to avoid unnecessary instability until we fully figure out our approach for "any-provider" provisioning.