### PR TITLE
Remove defaults from AWS terraform vars

### DIFF
--- a/pkg/provision/aws.go
+++ b/pkg/provision/aws.go
@@ -68,7 +68,7 @@ func (aws AWS) Provision(plan install.Plan) (*install.Plan, error) {
 
 	// Write out the terraform variables
 	data := AWSTerraformData{
-		Version:           aws.Terraform.KismaticVersion.String(),
+		KismaticVersion:   aws.Terraform.KismaticVersion.String(),
 		Region:            plan.Provisioner.AWSOptions.Region,
 		ClusterName:       plan.Cluster.Name,
 		ClusterOwner:      aws.Terraform.ClusterOwner,

--- a/pkg/provision/aws_types.go
+++ b/pkg/provision/aws_types.go
@@ -9,9 +9,9 @@ type AWS struct {
 
 // AWSTerraformData provider for creating and destroying infrastructure on AWS
 type AWSTerraformData struct {
-	Version           string `json:"version"`
+	KismaticVersion   string `json:"kismatic_version"`
 	Region            string `json:"region,omitempty"`
-	AvailabilityZone  string `json:"AZ,omitempty"`
+	AvailabilityZone  string `json:"availability_zone,omitempty"`
 	PrivateSSHKeyPath string `json:"private_ssh_key_path"`
 	PublicSSHKeyPath  string `json:"public_ssh_key_path"`
 	SSHUser           string `json:"ssh_user"`

--- a/terraform/providers/aws/elb.tf
+++ b/terraform/providers/aws/elb.tf
@@ -8,7 +8,7 @@ resource "aws_s3_bucket" "lb_logs" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/bucket"       = "lb"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -49,7 +49,7 @@ resource "aws_elb" "kismatic_master" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/loadBalancer" = "master"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -99,7 +99,7 @@ resource "aws_elb" "kismatic_ingress" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/loadBalancer" = "ingress"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }

--- a/terraform/providers/aws/instances.tf
+++ b/terraform/providers/aws/instances.tf
@@ -6,13 +6,13 @@ resource "aws_instance" "bastion" {
   // TODO: setup a bastion node for added security
   ami             = "${data.aws_ami.ubuntu.id}"
   instance_type   = "${var.instance_size}"
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-bastion-${count.index}"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/nodeRoles"    = "bastion"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -40,13 +40,13 @@ resource "aws_instance" "master" {
   count                  = "${var.master_count}"
   ami                    = "${data.aws_ami.ubuntu.id}"
   instance_type          = "${var.instance_size}"
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-master-${count.index}"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/nodeRoles"    = "master"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -74,13 +74,13 @@ resource "aws_instance" "etcd" {
   count                   = "${var.etcd_count}"
   ami                     = "${data.aws_ami.ubuntu.id}"
   instance_type           = "${var.instance_size}"
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-etcd-${count.index}"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/nodeRoles"    = "etcd"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -108,13 +108,13 @@ resource "aws_instance" "worker" {
   count                   = "${var.worker_count}"
   ami                     = "${data.aws_ami.ubuntu.id}"
   instance_type           = "${var.instance_size}"
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-worker-${count.index}"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/nodeRoles"    = "worker"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -142,13 +142,13 @@ resource "aws_instance" "ingress" {
   count                   = "${var.ingress_count}"
   ami                     = "${data.aws_ami.ubuntu.id}"
   instance_type           = "${var.instance_size}"
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-ingress-${count.index}"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/nodeRoles"    = "ingress"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -176,13 +176,13 @@ resource "aws_instance" "storage" {
   count                   = "${var.storage_count}"
   ami                     = "${data.aws_ami.ubuntu.id}"
   instance_type           = "${var.instance_size}"
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-storage-${count.index}"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/nodeRoles"    = "storage"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }

--- a/terraform/providers/aws/main.tf
+++ b/terraform/providers/aws/main.tf
@@ -4,6 +4,7 @@ provider "aws" {
   $ export AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY
   $ export AWS_DEFAULT_REGION=us-east-1
   */
+  region = "${var.region}"
 }
 
 resource "aws_key_pair" "kismatic" {

--- a/terraform/providers/aws/main.tf
+++ b/terraform/providers/aws/main.tf
@@ -4,9 +4,6 @@ provider "aws" {
   $ export AWS_SECRET_ACCESS_KEY=YOUR_AWS_SECRET_ACCESS_KEY
   $ export AWS_DEFAULT_REGION=us-east-1
   */
-  region      = "${var.region}"
-  access_key  = "${var.access_key}"
-  secret_key  = "${var.secret_key}"
 }
 
 resource "aws_key_pair" "kismatic" {

--- a/terraform/providers/aws/securitygroups.tf
+++ b/terraform/providers/aws/securitygroups.tf
@@ -15,7 +15,7 @@ resource "aws_security_group" "kismatic_ssh" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/securityGroup"= "ssh"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -48,7 +48,7 @@ resource "aws_security_group" "kismatic_private" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/securityGroup"= "private"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -75,7 +75,7 @@ resource "aws_security_group" "kismatic_lb_master" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/securityGroup"= "lb-master"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -108,7 +108,7 @@ resource "aws_security_group" "kismatic_lb_ingress" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/securityGroup"= "lb-ingress"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }

--- a/terraform/providers/aws/subnets.tf
+++ b/terraform/providers/aws/subnets.tf
@@ -2,13 +2,13 @@ resource "aws_subnet" "kismatic_public" {
   vpc_id      = "${aws_vpc.kismatic.id}"
   cidr_block  = "10.0.1.0/24"
   map_public_ip_on_launch = "True"
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-subnet-public"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/subnet"       = "public"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -22,13 +22,13 @@ resource "aws_subnet" "kismatic_private" {
   cidr_block  = "10.0.2.0/24"
   map_public_ip_on_launch = "True"
   //TODO: disable when we add bastion support
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-subnet-private"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/subnet"       = "private"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -42,13 +42,13 @@ resource "aws_subnet" "kismatic_master" {
   cidr_block  = "10.0.3.0/24"
   map_public_ip_on_launch = "True"
   //TODO: disable when we add bastion support
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-subnet-master"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/subnet"       = "master"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
@@ -62,13 +62,13 @@ resource "aws_subnet" "kismatic_ingress" {
   cidr_block  = "10.0.4.0/24"
   map_public_ip_on_launch = "True"
   //TODO: disable when we add bastion support
-  availability_zone = "${var.AZ}"
+  availability_zone = "${var.availability_zone}"
   tags {
     "Name"                  = "${var.cluster_name}-subnet-ingress"
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kismatic/subnet"       = "ingress"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }

--- a/terraform/providers/aws/variables.tf
+++ b/terraform/providers/aws/variables.tf
@@ -2,46 +2,32 @@ variable "region" {
   default = "us-east-1"
 }
 
-variable "AZ" {
+variable "availability_zone" {
   default = "us-east-1c"
 }
 
-variable "access_key" {
-  default = ""
-}
-
-variable "secret_key" {
-  default = ""
-}
-
 variable "private_ssh_key_path" {
-  default = ""
+  description = "Path to the SSH private key"
 }
 
 variable "public_ssh_key_path" {
-  description = "SSH Public Key"
-  default = ""
+  description = "Path to the SSH public key"
 }
 
 variable "ssh_user" {
-  default = ""
+  description = "The SSH user that should be used for accessing the nodes over SSH"
 }
 
-variable "version" {
-  default = ""
-}
+variable "kismatic_version" {}
 
-variable "cluster_name" {
-  default = "kismatic-cluster"
-}
+variable "cluster_name" {}
 
-variable "cluster_owner" {
-  default = ""
+variable "cluster_owner" {}
 }
 
 variable "ami" {
-  default = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
   //These will have to change when we want to also support RHEL/CentOS
+  default = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
 }
 
 variable "instance_size" {
@@ -50,25 +36,20 @@ variable "instance_size" {
 
 variable master_count {
   description = "Number of k8s master nodes"
-  default     = 1
 }
 
 variable etcd_count {
   description = "Number of etcd nodes"
-  default     = 1
 }
 
 variable worker_count {
   description = "Number of k8s worker nodes"
-  default     = 1
 }
 
 variable ingress_count {
   description = "Number of k8s ingress nodes"
-  default     = 1
 }
 
 variable storage_count {
   description = "Number of k8s storage nodes"
-  default     = 1
 }

--- a/terraform/providers/aws/variables.tf
+++ b/terraform/providers/aws/variables.tf
@@ -23,10 +23,9 @@ variable "kismatic_version" {}
 variable "cluster_name" {}
 
 variable "cluster_owner" {}
-}
 
 variable "ami" {
-  //These will have to change when we want to also support RHEL/CentOS
+  // These will have to change when we want to also support RHEL/CentOS
   default = "ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"
 }
 

--- a/terraform/providers/aws/vpc.tf
+++ b/terraform/providers/aws/vpc.tf
@@ -7,7 +7,7 @@ resource "aws_vpc" "kismatic" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
   lifecycle {
@@ -22,7 +22,7 @@ resource "aws_internet_gateway" "kismatic_gateway" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
   lifecycle {
@@ -43,7 +43,7 @@ resource "aws_default_route_table" "kismatic_router" {
     "kismatic/clusterName"  = "${var.cluster_name}"
     "kismatic/clusterOwner" = "${var.cluster_owner}"
     "kismatic/dateCreated"  = "${timestamp()}"
-    "kismatic/version"      = "${var.version}"
+    "kismatic/version"      = "${var.kismatic_version}"
     "kubernetes.io/cluster" = "${var.cluster_name}"
   }
   lifecycle {


### PR DESCRIPTION
Removed defaults from AWS terraform vars that we expect KET to set.

Also removed the secrets from the vars definition, so that they are never stored in the binary plan.

