### PR TITLE
Upgrade Calico to v2.6.4

### DIFF
--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -16,16 +16,16 @@ official_images:
     version: v1.9.0
   calico_node:
     name: calico/node
-    version: v2.6.3
+    version: v2.6.4
   calico_ctl:
     name: calico/ctl
-    version: v1.6.2
+    version: v1.6.3
   calico_cni:
     name: calico/cni
-    version: v1.11.1
+    version: v1.11.2
   calico_kube_controller:
     name: calico/kube-controllers
-    version: v1.0.1
+    version: v1.0.2
   cni_bin:
     name: apprenda/cni-bin
     version: v0.6.0

--- a/ansible/roles/calico-network-policy/templates/policy-controller.yaml
+++ b/ansible/roles/calico-network-policy/templates/policy-controller.yaml
@@ -84,6 +84,9 @@ spec:
               value: "{{ kubernetes_master_ip }}"
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
+            # Choose which controllers to run.
+            - name: ENABLED_CONTROLLERS
+              value: policy,profile,workloadendpoint,node
 
 ---
 

--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -1,9 +1,9 @@
-# Calico Version v2.6.3
-# https://docs.projectcalico.org/v2.6/releases#v2.6.3
+# Calico Version v2.6.4
+# https://docs.projectcalico.org/v2.6/releases#v2.6.4
 # This manifest includes the following component versions:
-#   calico/node:v2.6.3
-#   calico/cni:v1.11.1
-#   calico/kube-controllers:v1.0.1
+#   calico/node:v2.6.4
+#   calico/cni:v1.11.2
+#   calico/kube-controllers:v1.0.2
 
 # This ConfigMap is used to configure a self-hosted Calico installation.
 kind: ConfigMap

--- a/ansible/roles/calico/templates/rbac.yaml
+++ b/ansible/roles/calico/templates/rbac.yaml
@@ -1,12 +1,12 @@
-# Calico Version v2.6.0
-# https://docs.projectcalico.org/v2.6/releases#v2.6.0
+# Calico Version v2.6.4
+# https://docs.projectcalico.org/v2.6/releases#v2.6.4
 
 ---
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-kube-controllers
-  namespace: kube-system
 rules:
   - apiGroups:
     - ""
@@ -15,6 +15,7 @@ rules:
       - pods
       - namespaces
       - networkpolicies
+      - nodes
     verbs:
       - watch
       - list
@@ -31,12 +32,13 @@ subjects:
 - kind: ServiceAccount
   name: calico-kube-controllers
   namespace: kube-system
+
 ---
+
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: calico-node
-  namespace: kube-system
 rules:
   - apiGroups: [""]
     resources:
@@ -44,7 +46,9 @@ rules:
       - nodes
     verbs:
       - get
+
 ---
+
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
[New Release Notes](https://docs.projectcalico.org/v2.6/releases/)  