### PR TITLE
Send terraform logs to cluster log file, instead of stdout

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -12,10 +12,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/apprenda/kismatic/pkg/install"
-
 	"github.com/apprenda/kismatic/pkg/controller"
-	"github.com/apprenda/kismatic/pkg/provision"
+	"github.com/apprenda/kismatic/pkg/install"
 	"github.com/apprenda/kismatic/pkg/server/http"
 	"github.com/apprenda/kismatic/pkg/server/http/handler"
 	"github.com/apprenda/kismatic/pkg/store"
@@ -127,19 +125,18 @@ func doServer(stdout io.Writer, options serverOptions) error {
 	}()
 
 	// Setup provisioner
-	terraform := provision.Terraform{
-		Output:          os.Stdout,
-		BinaryPath:      filepath.Join(pwd, "terraform/bin/terraform"),
-		KismaticVersion: install.KismaticVersion,
-	}
+	tfCreater := controller.TerraformProvisionerCreator(
+		filepath.Join(pwd, "terraform/bin/terraform"),
+		install.KismaticVersion,
+	)
 
 	ctrl := controller.New(
 		logger,
 		controller.DefaultExecutorCreator(),
-		controller.DefaultProvisionerCreator(terraform),
+		tfCreater,
 		clusterStore,
 		10*time.Minute,
-		assetsDir,
+		controller.AssetsDir(assetsDir),
 	)
 	ctx, cancel := context.WithCancel(context.Background())
 	go ctrl.Run(ctx)

--- a/pkg/controller/cluster.go
+++ b/pkg/controller/cluster.go
@@ -2,12 +2,12 @@ package controller
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/apprenda/kismatic/pkg/install"
-	"github.com/apprenda/kismatic/pkg/provision"
 	"github.com/apprenda/kismatic/pkg/store"
 	"github.com/google/go-cmp/cmp"
 )
@@ -31,12 +31,13 @@ const (
 
 // The clusterController manages the lifecycle of a single cluster.
 type clusterController struct {
+	log              *log.Logger
 	clusterName      string
 	clusterSpec      store.ClusterSpec
 	clusterAssetsDir string
-	log              *log.Logger
+	logFile          io.Writer
 	executor         install.Executor
-	newProvisioner   func(store.Cluster) provision.Provisioner
+	newProvisioner   ProvisionerCreator
 	clusterStore     store.ClusterStore
 }
 
@@ -221,7 +222,7 @@ func (c *clusterController) planFilePath() string {
 
 func (c *clusterController) provision(cluster store.Cluster) store.Cluster {
 	c.log.Printf("provisioning infrastructure for cluster %q", c.clusterName)
-	provisioner := c.newProvisioner(cluster)
+	provisioner := c.newProvisioner(cluster, c.logFile)
 	fp := install.FilePlanner{File: c.planFilePath()}
 	plan, err := fp.Read()
 	if err != nil {
@@ -250,7 +251,7 @@ func (c *clusterController) provision(cluster store.Cluster) store.Cluster {
 
 func (c *clusterController) destroy(cluster store.Cluster) store.Cluster {
 	c.log.Printf("destroying cluster %q", c.clusterName)
-	provisioner := c.newProvisioner(cluster)
+	provisioner := c.newProvisioner(cluster, c.logFile)
 	err := provisioner.Destroy(c.clusterName)
 	if err != nil {
 		c.log.Printf("error destroying cluster %q: %v", c.clusterName, err)

--- a/pkg/provision/aws.go
+++ b/pkg/provision/aws.go
@@ -94,19 +94,21 @@ func (aws AWS) Provision(plan install.Plan) (*install.Plan, error) {
 	initCmd := exec.Command(aws.BinaryPath, "init", providerDir)
 	initCmd.Env = cmdEnv
 	initCmd.Dir = cmdDir
-	if out, err := initCmd.CombinedOutput(); err != nil {
-		fmt.Fprintln(aws.Output, string(out))
+	initCmd.Stdout = aws.Terraform.Output
+	initCmd.Stderr = aws.Terraform.Output
+	if err := initCmd.Run(); err != nil {
 		return nil, fmt.Errorf("Error initializing terraform: %s", err)
 	}
 
 	// Terraform plan
 	planCmd := exec.Command(aws.BinaryPath, "plan", fmt.Sprintf("-out=%s", plan.Cluster.Name), providerDir)
+	planCmd.Stdout = aws.Terraform.Output
+	planCmd.Stderr = aws.Terraform.Output
 	planCmd.Env = cmdEnv
 	planCmd.Dir = cmdDir
 
-	if out, err := planCmd.CombinedOutput(); err != nil {
-		fmt.Fprintln(aws.Output, string(out))
-		return nil, fmt.Errorf("Error running terraform plan: %s", out)
+	if err := planCmd.Run(); err != nil {
+		return nil, fmt.Errorf("Error running terraform plan: %s", err)
 	}
 
 	// Terraform apply


### PR DESCRIPTION
Both the provisioner and the installer (aka. executor) need to be able to write logs to the log file that the API server returns for the logs endpoint. For this reason, something other than the executor needs to create the cluster assets dir and the log file. 

Given that the multi-cluster controller is responsible for setting up the individual cluster controllers, it seems like it should also be responsible for setting up the cluster-specific assets directory and log file. Failure to create these results in the cluster controller not being created. Once created, the provisioner and installer both have access to these.

The overall outcome of this change is that the terraform logs are now visible through the API, so any provisioning errors are observable by the user.