### PR TITLE
Upgrading Calico node from 2.6.4 and 2.6.5.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ KET operational tools include:
 | Docker | v1.12.6 |
 | Etcd (for Kubernetes) | v3.1.10 |
 | Etcd (for Calico & Contiv) | v3.1.10 |
-| Calico | v2.6.2 |
+| Calico | v2.6.5 |
 | Weave | v2.0.5 |
 | Contiv | v1.1.1 |
 

--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -16,7 +16,7 @@ official_images:
     version: v1.9.0
   calico_node:
     name: calico/node
-    version: v2.6.4
+    version: v2.6.5
   calico_ctl:
     name: calico/ctl
     version: v1.6.3


### PR DESCRIPTION
Closes #1017 

Based off the Calico 2.6.4 release notes (see below)

> Important: Due to a known issue in this release that can cause potential
> brief losses of connectivity while upgrading from v2.6.4, this release is
> deprecated. Use v2.6.5 instead. This issue does not affect those using the
> Kubernetes API datastore or running in policy-only mode.