### PR TITLE
Copy inspector to all nodes before upgrade

### DIFF
--- a/ansible/copy-inspector.yaml
+++ b/ansible/copy-inspector.yaml
@@ -1,0 +1,14 @@
+---
+  - name: "Copy Kismatic Inspector"
+    hosts: all
+    any_errors_fatal: true
+    become: yes
+    vars_files:
+      - group_vars/all.yaml
+
+    tasks:
+      - name: copy Kismatic Inspector to node
+        copy:
+          src: "{{ kismatic_preflight_checker }}"
+          dest: "{{ bin_dir }}/kismatic-inspector"
+          mode: 0744

--- a/pkg/cli/fakes_test.go
+++ b/pkg/cli/fakes_test.go
@@ -48,6 +48,10 @@ func (fe *fakeExecutor) RunPreFlightCheck(p *install.Plan) error {
 	return nil
 }
 
+func (fe *fakeExecutor) CopyInspector(p *install.Plan) error {
+	return nil
+}
+
 func (fe *fakeExecutor) RunNewWorkerPreFlightCheck(install.Plan, install.Node) error {
 	return nil
 }

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -316,6 +316,10 @@ func upgradeNodes(in io.Reader, out io.Writer, plan install.Plan, opts upgradeOp
 	// Run upgrade preflight on the nodes that are to be upgraded
 	unreadyNodes := []install.ListableNode{}
 	if !opts.skipPreflight {
+		util.PrintHeader(out, fmt.Sprintf("Copy Kismatic Inspector to Nodes"), '=')
+		if err := preflightExec.CopyInspector(&plan); err != nil {
+			return errors.New("Error copying kismatic inspector")
+		}
 		for _, node := range nodesNeedUpgrade {
 			util.PrintHeader(out, fmt.Sprintf("Preflight Checks: %s %s", node.Node.Host, node.Roles), '=')
 			if err := preflightExec.RunUpgradePreFlightCheck(&plan, node); err != nil {


### PR DESCRIPTION
The `inspector` service needs to be updated and restarted before upgrading any of the individual nodes.