### PR TITLE
Always lower hostname with kubernetes.io/hostname label

### DIFF
--- a/ansible/_label-nodes.yaml
+++ b/ansible/_label-nodes.yaml
@@ -9,8 +9,8 @@
       
     tasks:
       - name: label nodes with system labels
-        command: kubectl label --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }} kismatic/cni-provider={{ cni.provider| quote }}{% if 'ingress' in group_names%} kismatic/ingress=true{% endif %}{% if 'storage' in group_names%} kismatic/storage=true{% endif %}
+        command: kubectl label --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname|lower }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }} kismatic/cni-provider={{ cni.provider| quote }}{% if 'ingress' in group_names%} kismatic/ingress=true{% endif %}{% if 'storage' in group_names%} kismatic/storage=true{% endif %}
         
       - name: label nodes with user defined labels
-        command: kubectl label --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }} {{ node_labels[inventory_hostname] | join(" ") }}
+        command: kubectl label --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname|lower }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }} {{ node_labels[inventory_hostname] | join(" ") }}
         when: node_labels[inventory_hostname] is defined and node_labels[inventory_hostname]|length > 0

--- a/ansible/roles/kube-proxy/tasks/main.yaml
+++ b/ansible/roles/kube-proxy/tasks/main.yaml
@@ -39,7 +39,7 @@
     when: pod_name is defined and pod_name.stdout is defined and pod_name.stdout != ""
 
   - name: label nodes for kube-proxy
-    command: kubectl label --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }} kismatic/kube-proxy=true
+    command: kubectl label --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname|lower }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }} kismatic/kube-proxy=true
     
   - name: get desired number of kube-proxy pods
     command: kubectl get ds kube-proxy -o=jsonpath='{.status.desiredNumberScheduled}' --namespace=kube-system --kubeconfig {{ kubernetes_kubeconfig.kubectl }}

--- a/ansible/roles/worker-smoke-test/tasks/main.yaml
+++ b/ansible/roles/worker-smoke-test/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
   - name: wait for node '{{ worker_node|lower }}' to register with the API server and become Ready
-    command: kubectl get nodes --selector kubernetes.io/hostname={{ worker_node }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }}
+    command: kubectl get nodes --selector kubernetes.io/hostname={{ worker_node|lower }} --kubeconfig {{ kubernetes_kubeconfig.kubectl }}
     register: nodeStatus
     until: nodeStatus|success and "Ready" in nodeStatus.stdout
     retries: 20


### PR DESCRIPTION
Fixes `hosts file modification feature` test.

Node label `kubernetes.io/hostname` will be the same as `nodeName`, and it's always lower cased. 