### PR TITLE
Adding a releases template

### DIFF
--- a/releases/template.md
+++ b/releases/template.md
@@ -1,0 +1,36 @@
+# Version X.Y.Z
+
+Release Date: DD-MM-YYYY
+
+Release Team: @dkoshkin @alexbrand @emmetthitz
+
+## Component version changes
+
+* Lorem ipsum dolor sit amet
+* Lorem ipsum dolor sit amet
+* Lorem ipsum dolor sit amet
+
+## Notable Changes
+
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed volutpat. (#1234, @swade1987)
+
+
+## Plan file changes
+
+### New fields
+
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed volutpat.
+
+### Deprecated fields
+
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed volutpat.
+
+## CLI changes
+
+### New commands
+
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed volutpat.
+
+### Deprecated commands
+
+* Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed volutpat.


### PR DESCRIPTION
My plan here is for each release to have a dedicated file underneath `releases`.

Each release will have a filename of `v1.7.0-release.md`

Then in the releases tab on GitHub, we can simply link to the necessary set of release notes.