### PR TITLE
Adding CoreDNS as a cluster DNS provider

### DIFF
--- a/ansible/_cluster-dns.yaml
+++ b/ansible/_cluster-dns.yaml
@@ -9,4 +9,7 @@
       - group_vars/container_images.yaml
       
     roles:
-      - kube-dns
+      - role: kube-dns
+        when: dns.provider == "kubedns"
+      - role: coredns
+        when: dns.provider == "coredns"

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -124,7 +124,7 @@ kubernetes_master_apiserver_count: "{{ groups['master'] | length }}"
 local_kubernetes_master_ip: https://127.0.0.1:{{ kubernetes_master_secure_port }}
 kubernetes_master_ip: https://{{ kubernetes_load_balanced_fqdn }}:{{ kubernetes_master_secure_port }}
 kubernetes_schedulable: "{% if 'worker' in group_names %}true{% else %}false{% endif %}"
-kube_dns_replicas: "{{ [2, groups['worker'] | length] | min }}"
+cluster_dns_replicas: "{{ [2, groups['worker'] | length] | min }}"
 # cloud provider
 cloud_config: "{% if cloud_config_local is defined and cloud_config_local != '' %}{{ kubernetes_install_dir }}/cloud-provider.conf{% else %}{% endif %}"
 
@@ -256,6 +256,7 @@ official_versioned_images:
   kubedns: "{{official_images.kubedns.name}}:{{official_images.kubedns.version}}"
   kube_dnsmasq: "{{official_images.kube_dnsmasq.name}}:{{official_images.kube_dnsmasq.version}}"
   kubedns_sidecar: "{{official_images.kubedns_sidecar.name}}:{{official_images.kubedns_sidecar.version}}"
+  coredns: "{{official_images.coredns.name}}:{{official_images.coredns.version}}"
   kubernetes_dashboard: "{{official_images.kubernetes_dashboard.name}}:{{official_images.kubernetes_dashboard.version}}"
   apprenda_tcp_healthz: "{{official_images.apprenda_tcp_healthz.name}}:{{official_images.apprenda_tcp_healthz.version}}"
   helm: "{{official_images.helm.name}}:{{official_images.helm.version}}"
@@ -286,6 +287,7 @@ images:
   kubedns: "{{ official_versioned_images.kubedns | final_image(docker_registry_full_url, load_private_images) }}"
   kube_dnsmasq: "{{ official_versioned_images.kube_dnsmasq | final_image(docker_registry_full_url, load_private_images) }}"
   kubedns_sidecar: "{{ official_versioned_images.kubedns_sidecar | final_image(docker_registry_full_url, load_private_images) }}"
+  coredns: "{{ official_versioned_images.coredns | final_image(docker_registry_full_url, load_private_images) }}"
   kubernetes_dashboard: "{{ official_versioned_images.kubernetes_dashboard | final_image(docker_registry_full_url, load_private_images) }}"
   apprenda_tcp_healthz: "{{ official_versioned_images.apprenda_tcp_healthz | final_image(docker_registry_full_url, load_private_images) }}"
   helm: "{{ official_versioned_images.helm | final_image(docker_registry_full_url, load_private_images) }}"

--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -65,6 +65,9 @@ official_images:
   kubedns_sidecar:
     name: gcr.io/google_containers/k8s-dns-sidecar-amd64
     version: 1.14.7
+  coredns:
+    name: coredns/coredns
+    version: 1.0.2
   kubernetes_dashboard:
     name: gcr.io/google_containers/kubernetes-dashboard-amd64
     version: v1.8.0

--- a/ansible/group_vars/diagnostics.yaml
+++ b/ansible/group_vars/diagnostics.yaml
@@ -29,6 +29,7 @@ diagnostics:
     - {msg: "Dumping kubedns docker logs", command: "docker logs `docker ps -a -f name=k8s_kubedns --format=\\{\\{.ID\\}\\} -l`", file: "logs_kubedns.log"}
     - {msg: "Dumping dnsmasq docker logs", command: "docker logs `docker ps -a -f name=k8s_dnsmasq --format=\\{\\{.ID\\}\\} -l`", file: "logs_dnsmasq.log"}
     - {msg: "Dumping kubedns sidecar docker logs", command: "docker logs `docker ps -a -f name=k8s_sidecar_kube-dns --format=\\{\\{.ID\\}\\} -l`", file: "logs_kubedns_sidecar.log"}
+    - {msg: "Dumping coredns docker logs", command: "docker logs `docker ps -a -f name=k8s_coredns_coredns --format=\\{\\{.ID\\}\\} -l", file: "logs_coredns.log"}
   calico_diagnostics:
     - {msg: "Dumping calico-node nodes", command: "docker run -i{% if modify_hosts_file is defined and modify_hosts_file|bool == true %} -v /etc/hosts:/etc/hosts{% endif %} -v /etc/kubernetes:/etc/kubernetes -v {{ calicoctl_conf_path }}:{{ calicoctl_conf_path }} {{ images.calico_ctl }} get nodes -o wide", file: "calicoctl_nodes.log"}
     - {msg: "Dumping calico-node docker logs", command: "docker logs `docker ps -a -f name=k8s_calico-node --format=\\{\\{.ID\\}\\} -l`", file: "logs_calico_node.log"}

--- a/ansible/kubernetes.yaml
+++ b/ansible/kubernetes.yaml
@@ -39,7 +39,7 @@
     when: cni.enabled|bool == true and cni.provider == "contiv"
   - include: _rescheduler.yaml
     when: rescheduler.enabled|bool == true
-  - include: _kube-dns.yaml
+  - include: _cluster-dns.yaml
     when: dns.enabled|bool == true
   - include: _heapster.yaml
     when: heapster.enabled|bool == true

--- a/ansible/roles/coredns/tasks/main.yaml
+++ b/ansible/roles/coredns/tasks/main.yaml
@@ -1,0 +1,47 @@
+---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
+  - name: copy coredns.yaml to remote
+    template:
+      src: coredns.yaml
+      dest: "{{ kubernetes_spec_dir }}/coredns.yaml"
+  - name: start coredns service
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/coredns.yaml
+    register: out
+  
+  - block:
+    - name: wait up to 5 minutes until DNS pods are ready
+      command: kubectl get deployment coredns -n kube-system -o jsonpath='{.status.availableReplicas}'
+      register: readyReplicas
+      until: readyReplicas.stdout|int == cluster_dns_replicas|int
+      retries: 30
+      delay: 10
+      failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+    
+    - name: find the DNS pods that failed to start
+      # Get the name and status/phase for all coredns pods, and then filter out the ones that are not running.
+      # Once we have those, grab the first one, and cut the status/phase out of the output.
+      raw: >
+        kubectl get pods -n kube-system -l k8s-app=coredns 
+        --no-headers -o custom-columns=name:{.metadata.name},status:{.status.phase} | grep -v "Running" | head -n 1 | cut -d " " -f 1
+      register: failedDNSPodNames
+      when: readyReplicas.stdout|int != cluster_dns_replicas|int
+
+    - name: get the logs of the first DNS pod that did not start up in time
+      command: kubectl logs -n kube-system {{ failedDNSPodNames.stdout_lines[0] }} --tail 15
+      register: failedDNSPodLogs
+      when: "'stdout_lines' in failedDNSPodNames and failedDNSPodNames.stdout_lines|length > 0"
+      
+    - name: fail if DNS pods are not ready
+      fail:
+        msg: | 
+          Waited for all DNS pods to be ready, but they took longer than 5 minutes to be in the ready state.
+          
+          The pod's latest logs may indicate why it failed to start up:
+
+          {{ failedDNSPodLogs.stdout }}
+
+      when: readyReplicas.stdout|int != cluster_dns_replicas|int
+    when: run_pod_validation|bool == true 

--- a/ansible/roles/coredns/templates/coredns.yaml
+++ b/ansible/roles/coredns/templates/coredns.yaml
@@ -1,0 +1,163 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    rbac.authorization.kubernetes.io/autoupdate: "true"
+  labels:
+    kubernetes.io/bootstrapping: rbac-defaults
+  name: system:coredns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:coredns
+subjects:
+- kind: ServiceAccount
+  name: coredns
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns
+  namespace: kube-system
+data:
+  Corefile: |
+    .:53 {
+        errors
+        log
+        health
+        kubernetes cluster.local {{ kubernetes_services_cidr }} {{ kubernetes_pods_cidr }} {
+          pods insecure
+          upstream /etc/resolv.conf
+        }
+        prometheus :9153
+        proxy . /etc/resolv.conf
+        cache 30
+    }
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: coredns
+  namespace: kube-system
+  labels:
+    k8s-app: coredns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+spec:
+  replicas: {{ cluster_dns_replicas|int }}  # create 2 replicas or the number of worker nodes
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      k8s-app: coredns
+  template:
+    metadata:
+      labels:
+        k8s-app: coredns
+    spec:
+      serviceAccountName: coredns
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+        - key: "CriticalAddonsOnly"
+          operator: "Exists"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - coredns
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: coredns
+        image: "{{ images.coredns }}"
+        imagePullPolicy: IfNotPresent
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+        ports:
+        - containerPort: 53
+          name: dns
+          protocol: UDP
+        - containerPort: 53
+          name: dns-tcp
+          protocol: TCP
+        - containerPort: 9153
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+      dnsPolicy: Default
+      volumes:
+        - name: config-volume
+          configMap:
+            name: coredns
+            items:
+            - key: Corefile
+              path: Corefile
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-dns
+  namespace: kube-system
+  labels:
+    k8s-app: coredns
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    prometheus.io/port: "9153"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    k8s-app: coredns
+  clusterIP: {{ kubernetes_dns_service_ip }}
+  ports:
+  - name: dns
+    port: 53
+    protocol: UDP
+  - name: dns-tcp
+    port: 53
+    protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP

--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -15,7 +15,7 @@
     - name: wait up to 5 minutes until DNS pods are ready
       command: kubectl get deployment kube-dns -n kube-system -o jsonpath='{.status.availableReplicas}'
       register: readyReplicas
-      until: readyReplicas.stdout|int == kube_dns_replicas|int
+      until: readyReplicas.stdout|int == cluster_dns_replicas|int
       retries: 30
       delay: 10
       failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
@@ -39,7 +39,7 @@
         kubectl get pods -n kube-system -l k8s-app=kube-dns 
         --no-headers -o custom-columns=name:{.metadata.name},status:{.status.phase} | grep -v "Running" | head -n 1 | cut -d " " -f 1
       register: failedDNSPodNames
-      when: readyReplicas.stdout|int != kube_dns_replicas|int
+      when: readyReplicas.stdout|int != cluster_dns_replicas|int
 
     - name: fail if DNS pod validation command could not determine the broken pod
       fail:
@@ -61,6 +61,5 @@
 
           {{ failedDNSPodLogs.stdout }}
 
-      when: "'stdout' in failedDNSPodLogs and readyReplicas.stdout|int != kube_dns_replicas|int"
-
+      when: "'stdout' in failedDNSPodLogs and readyReplicas.stdout|int != cluster_dns_replicas|int"
     when: run_pod_validation|bool == true 

--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -55,7 +55,7 @@ metadata:
   annotations:
     kismatic/version: "{{ kismatic_short_version }}"
 spec:
-  replicas: {{ kube_dns_replicas|int }}  # create 2 replicas or the number of worker nodes
+  replicas: {{ cluster_dns_replicas|int }}  # create 2 replicas or the number of worker nodes
   strategy:
     rollingUpdate:
       maxSurge: 1
@@ -81,6 +81,7 @@ spec:
       containers:
       - name: kubedns
         image: "{{ images.kubedns }}"
+        imagePullPolicy: IfNotPresent
         resources:
           # TODO: Set memory limits when we've profiled the container for large
           # clusters, then set request = limit to keep this container in
@@ -141,6 +142,7 @@ spec:
           mountPath: /kube-dns-config
       - name: dnsmasq
         image: "{{ images.kube_dnsmasq }}"
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthcheck/dnsmasq
@@ -179,6 +181,7 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
       - name: sidecar
         image: "{{ images.kubedns_sidecar }}"
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /metrics

--- a/ansible/upgrade-cluster-services.yaml
+++ b/ansible/upgrade-cluster-services.yaml
@@ -1,7 +1,7 @@
 ---
   - include: _calico-network-policy.yaml play_name="Upgrade Network Policy Controller" upgrading=true
     when: cni.enabled|bool == true and cni.provider == "calico"
-  - include: _kube-dns.yaml play_name="Upgrade Kubernetes DNS" upgrading=true
+  - include: _cluster-dns.yaml play_name="Upgrade Kubernetes DNS" upgrading=true
     when: dns.enabled|bool == true
   - include: _kube-ingress.yaml play_name="Upgrade Kubernetes Ingress" upgrading=true
     when: configure_ingress|bool == true

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -62,6 +62,7 @@
         * [felix_input_mtu](#add_onscnioptionscalicofelix_input_mtu)
   * [dns](#add_onsdns)
     * [disable](#add_onsdnsdisable)
+    * [provider](#add_onsdnsprovider)
   * [heapster](#add_onsheapster)
     * [disable](#add_onsheapsterdisable)
     * [options](#add_onsheapsteroptions)
@@ -640,6 +641,17 @@
 | **Kind** |  bool |
 | **Required** |  No |
 | **Default** | `false` | 
+
+###  add_ons.dns.provider
+
+ This property indicates the in-cluster DNS provider. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  Yes |
+| **Default** | `kubedns` | 
+| **Options** |  `kubedns`, `coredns`
 
 ###  add_ons.heapster
 

--- a/integration-tests/install.go
+++ b/integration-tests/install.go
@@ -44,6 +44,7 @@ type installOptions struct {
 	serviceCIDR                  string
 	disableCNI                   bool
 	cniProvider                  string
+	dnsProvider                  string
 	heapsterReplicas             int
 	heapsterInfluxdbPVC          string
 	cloudProvider                string
@@ -109,6 +110,7 @@ func buildPlan(nodes provisionedNodes, installOpts installOptions, sshKey string
 		ServiceCIDR:                  installOpts.serviceCIDR,
 		DisableCNI:                   installOpts.disableCNI,
 		CNIProvider:                  installOpts.cniProvider,
+		DNSProvider:                  installOpts.dnsProvider,
 		DisableHelm:                  disableHelm,
 		HeapsterReplicas:             installOpts.heapsterReplicas,
 		HeapsterInfluxdbPVC:          installOpts.heapsterInfluxdbPVC,

--- a/integration-tests/install_test.go
+++ b/integration-tests/install_test.go
@@ -398,6 +398,51 @@ var _ = Describe("kismatic", func() {
 		// 	})
 		// })
 
+		Context("when deploying a skunkworks cluster", func() {
+			Context("with CoreDNS as the DNS provider", func() {
+				ItOnAWS("should install successfully [slow]", func(aws infrastructureProvisioner) {
+					WithInfrastructure(NodeCount{3, 2, 3, 2, 2}, Ubuntu1604LTS, aws, func(nodes provisionedNodes, sshKey string) {
+						// reserve one of the workers for the add-worker test
+						allWorkers := nodes.worker
+						nodes.worker = allWorkers[0 : len(nodes.worker)-1]
+
+						// install cluster
+						installOpts := installOptions{
+							heapsterReplicas:    3,
+							heapsterInfluxdbPVC: "influxdb",
+							dnsProvider:         "coredns",
+						}
+						err := installKismatic(nodes, installOpts, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+
+						sub := SubDescribe("Using a running cluster")
+						defer sub.Check()
+
+						sub.It("should allow adding a worker node", func() error {
+							newWorker := allWorkers[len(allWorkers)-1]
+							return addWorkerToCluster(newWorker, sshKey, []string{"com.integrationtest/worker=true"})
+						})
+
+						sub.It("should be able to deploy a workload with ingress", func() error {
+							return verifyIngressNodes(nodes.master[0], nodes.ingress, sshKey)
+						})
+
+						sub.It("should respect network policies", func() error {
+							return verifyNetworkPolicy(nodes.master[0], sshKey)
+						})
+
+						sub.It("should support heapster with persistent storage", func() error {
+							return verifyHeapster(nodes.master[0], sshKey)
+						})
+
+						sub.It("should have tiller running", func() error {
+							return verifyTiller(nodes.master[0], sshKey)
+						})
+					})
+				})
+			})
+		})
+
 		ItOnPacket("should install successfully [slow]", func(packet infrastructureProvisioner) {
 			WithMiniInfrastructure(Ubuntu1604LTS, packet, func(node NodeDeets, sshKey string) {
 				err := installKismaticMini(node, sshKey, "")

--- a/integration-tests/plan_patterns.go
+++ b/integration-tests/plan_patterns.go
@@ -31,6 +31,7 @@ type PlanAWS struct {
 	ServiceCIDR                  string
 	DisableCNI                   bool
 	CNIProvider                  string
+	DNSProvider                  string
 	DisableHelm                  bool
 	HeapsterReplicas             int
 	HeapsterInfluxdbPVC          string
@@ -99,6 +100,9 @@ add_ons:
       calico:
         mode: overlay
         log_level: info
+  dns:
+    disable: false
+    provider: {{if .DNSProvider}}{{.DNSProvider}}{{else}}kubedns{{end}}
   heapster:
     disable: false
     options:

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -89,7 +89,8 @@ type ClusterCatalog struct {
 	CloudConfig   string `yaml:"cloud_config_local"`
 
 	DNS struct {
-		Enabled bool
+		Enabled  bool
+		Provider string
 	}
 
 	RunPodValidation bool `yaml:"run_pod_validation"`

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -761,6 +761,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 
 	// DNS
 	cc.DNS.Enabled = !p.AddOns.DNS.Disable
+	cc.DNS.Provider = p.AddOns.DNS.Provider
 
 	// heapster
 	if p.AddOns.HeapsterMonitoring != nil && !p.AddOns.HeapsterMonitoring.Disable {

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -126,6 +126,10 @@ func setDefaults(p *Plan) {
 		p.AddOns.CNI.Options.Calico.WorkloadMTU = 1500
 	}
 
+	if p.AddOns.DNS.Provider == "" {
+		p.AddOns.DNS.Provider = "kubedns"
+	}
+
 	if p.AddOns.HeapsterMonitoring == nil {
 		p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
 	}
@@ -312,6 +316,8 @@ func buildPlanFromTemplateOptions(templateOpts PlanTemplateOptions) Plan {
 	p.AddOns.CNI.Options.Calico.LogLevel = "info"
 	p.AddOns.CNI.Options.Calico.WorkloadMTU = 1500
 	p.AddOns.CNI.Options.Calico.FelixInputMTU = 1440
+	// DNS
+	p.AddOns.DNS.Provider = "kubedns"
 	// Heapster
 	p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
 	p.AddOns.HeapsterMonitoring.Options.Heapster.Replicas = 2
@@ -430,6 +436,7 @@ var commentMap = map[string][]string{
 	"add_ons.cni.options.calico.log_level":               []string{"Options: 'warning','info','debug'."},
 	"add_ons.cni.options.calico.workload_mtu":            []string{"MTU for the workload interface, configures the CNI config."},
 	"add_ons.cni.options.calico.felix_input_mtu":         []string{"MTU for the tunnel device used if IPIP is enabled."},
+	"add_ons.dns.provider":                               []string{"Options: 'kubedns','coredns'."},
 	"add_ons.heapster.options.influxdb.pvc_name":         []string{"Provide the name of the persistent volume claim that you will create", "after installation. If not specified, the data will be stored in", "ephemeral storage."},
 	"add_ons.heapster.options.heapster.service_type":     []string{"Specify kubernetes ServiceType. Defaults to 'ClusterIP'.", "Options: 'ClusterIP','NodePort','LoadBalancer','ExternalName'."},
 	"add_ons.heapster.options.heapster.sink":             []string{"Specify the sink to store heapster data. Defaults to an influxdb pod", "running on the cluster."},

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -15,12 +15,21 @@ const (
 	cniProviderCustom = "custom"
 )
 
+const (
+	dnsProviderKubedns = "kubedns"
+	dnsProviderCoredns = "coredns"
+)
+
 func packageManagerProviders() []string {
 	return []string{"helm", ""}
 }
 
 func cniProviders() []string {
 	return []string{cniProviderCalico, cniProviderContiv, cniProviderWeave, cniProviderCustom}
+}
+
+func dnsProviders() []string {
+	return []string{dnsProviderKubedns, dnsProviderCoredns}
 }
 
 func calicoMode() []string {
@@ -351,6 +360,11 @@ type DNS struct {
 	// Whether the DNS add-on should be disabled.
 	// When set to true, no DNS solution will be deployed on the cluster.
 	Disable bool
+	// This property indicates the in-cluster DNS provider.
+	// +required
+	// +options=kubedns,coredns
+	// +default=kubedns
+	Provider string
 }
 
 // The HeapsterMonitoring add-on configuration

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -149,6 +149,9 @@ add_ons:
   dns:
     disable: false
 
+    # Options: 'kubedns','coredns'.
+    provider: kubedns
+
   heapster:
     disable: false
     options:

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -149,6 +149,9 @@ add_ons:
   dns:
     disable: false
 
+    # Options: 'kubedns','coredns'.
+    provider: kubedns
+
   heapster:
     disable: false
     options:

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -241,6 +241,7 @@ func (c *CloudProvider) validate() (bool, []error) {
 func (f *AddOns) validate() (bool, []error) {
 	v := newValidator()
 	v.validate(f.CNI)
+	v.validate(f.DNS)
 	v.validate(f.HeapsterMonitoring)
 	v.validate(&f.PackageManager)
 	return v.valid()
@@ -259,6 +260,16 @@ func (n *CNI) validate() (bool, []error) {
 			if !util.Contains(n.Options.Calico.LogLevel, calicoLogLevel()) {
 				v.addError(fmt.Errorf("%q is not a valid Calico log level. Options are %v", n.Options.Calico.LogLevel, calicoLogLevel()))
 			}
+		}
+	}
+	return v.valid()
+}
+
+func (n DNS) validate() (bool, []error) {
+	v := newValidator()
+	if !n.Disable {
+		if !util.Contains(n.Provider, dnsProviders()) {
+			v.addError(fmt.Errorf("%q is not a valid DNS provider. Optins are %v", n.Provider, dnsProviders()))
 		}
 	}
 	return v.valid()

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -32,6 +32,9 @@ var validPlan = Plan{
 				},
 			},
 		},
+		DNS: DNS{
+			Provider: "kubedns",
+		},
 		HeapsterMonitoring: &HeapsterMonitoring{
 			Options: HeapsterOptions{
 				Heapster: Heapster{
@@ -1115,6 +1118,45 @@ func TestCNIAddOn(t *testing.T) {
 	}
 	for i, test := range tests {
 		ok, _ := test.n.validate()
+		if ok != test.valid {
+			t.Errorf("test %d: expect %t, but got %t", i, test.valid, ok)
+		}
+	}
+}
+
+func TestDNSProvider(t *testing.T) {
+	tests := []struct {
+		d     DNS
+		valid bool
+	}{
+		{
+			d: DNS{
+				Provider: "kubedns",
+			},
+			valid: true,
+		},
+		{
+			d: DNS{
+				Provider: "coredns",
+			},
+			valid: true,
+		},
+		{
+			d: DNS{
+				Disable:  true,
+				Provider: "foo",
+			},
+			valid: true,
+		},
+		{
+			d: DNS{
+				Provider: "foo",
+			},
+			valid: false,
+		},
+	}
+	for i, test := range tests {
+		ok, _ := test.d.validate()
 		if ok != test.valid {
 			t.Errorf("test %d: expect %t, but got %t", i, test.valid, ok)
 		}


### PR DESCRIPTION
Closes #511

Note: KubeDNS is still the default.