### PR TITLE
Support the overlay2 docker storage driver

### DIFF
--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -11,23 +11,26 @@
 
   # The overlay2 docker storage driver will be used for the following operating systems:
   # - RHEL 7.4
-  # - Ubuntu 16 and higher.
+  # - Centos 7.4.1708
+  # - Ubuntu 16 and higher
   - name: write overlay2 docker config file
     template:
       src: overlay2-daemon.json
       dest: /etc/docker/daemon.json
-    when: (ansible_os_family == "RedHat" and ansible_distribution_version == '7.4') or
+    when: (ansible_distribution == "Red Hat Enterprise Linux" and ansible_lsb.release == '7.4') or
+          (ansible_distribution == "CentOS" and ansible_distribution_version == '7.4.1708') or
           (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= '16')
 
   # The devicemapper docker storage driver will be used for the following operating systems:
-  # - All RHEL versions other than 7.4,
-  # - All CentOS versions
-  # - All Ubuntu versions lower than 16.
+  # - All RHEL versions other than 7.4
+  # - All CentOS versions which aren't 7.4.1708
+  # - All Ubuntu versions lower than 16
   - name: write devicemapper docker config file
     template:
       src: devicemapper-daemon.json
       dest: /etc/docker/daemon.json
-    when: (ansible_os_family == "RedHat" and ansible_distribution_version != '7.4') or
+    when: (ansible_distribution == "Red Hat Enterprise Linux" and ansible_lsb.release != '7.4') or
+          (ansible_distribution == "CentOS" and ansible_distribution_version != '7.4.1708') or
           (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < '16')
 
   # start and verify that Docker installed successfully and is running

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,12 +1,35 @@
+# ######################################################################################################################
+# For more information on Docker storage drivers see:
+# https://docs.docker.com/engine/userguide/storagedriver/selectadriver/#supported-storage-drivers-per-linux-distribution
+# ######################################################################################################################
+
 ---
   - name: create /etc/docker directory
     file:
       path: /etc/docker
       state: directory
-  - name: write docker config file
+
+  # The overlay2 docker storage driver will be used for the following operating systems:
+  # - RHEL 7.4
+  # - Ubuntu 16 and higher.
+  - name: write overlay2 docker config file
     template:
-      src: daemon.json
+      src: overlay2-daemon.json
       dest: /etc/docker/daemon.json
+    when: (ansible_os_family == "RedHat" and ansible_distribution_version == '7.4') or
+          (ansible_distribution == "Ubuntu" and ansible_distribution_major_version >= '16')
+
+  # The devicemapper docker storage driver will be used for the following operating systems:
+  # - All RHEL versions other than 7.4,
+  # - All CentOS versions
+  # - All Ubuntu versions lower than 16.
+  - name: write devicemapper docker config file
+    template:
+      src: devicemapper-daemon.json
+      dest: /etc/docker/daemon.json
+    when: (ansible_os_family == "RedHat" and ansible_distribution_version != '7.4') or
+          (ansible_distribution == "Ubuntu" and ansible_distribution_major_version < '16')
+
   # start and verify that Docker installed successfully and is running
   - name: start docker service
     service:

--- a/ansible/roles/docker/templates/devicemapper-daemon.json
+++ b/ansible/roles/docker/templates/devicemapper-daemon.json
@@ -13,7 +13,7 @@
 
 {% if docker.logs.opts | length > 0 %}
   "log-opts": 
-{{ docker.logs.opts | to_nice_json(indent=4) }}
+    {{ docker.logs.opts | to_nice_json(indent=4) }}
 {% endif %}
 {% endif %}
 }

--- a/ansible/roles/docker/templates/overlay2-daemon.json
+++ b/ansible/roles/docker/templates/overlay2-daemon.json
@@ -1,15 +1,17 @@
 {
   "storage-driver": "overlay2",
+{% if ansible_distribution == 'CentOS' %}
+  "storage-opts": [
+  "overlay2.override_kernel_check=true"
+  ],
+{% endif %}
   "icc": false,
   "disable-legacy-registry": true,
-  "live-restore": true{% if docker.logs.opts | length > 0 %},{% endif %}
-
-{% if docker.logs.driver != "" %}
+  "live-restore": true,
   "log-driver": "{{ docker.logs.driver }}"{% if docker.logs.opts | length > 0 %},{% endif %}
 
 {% if docker.logs.opts | length > 0 %}
   "log-opts":
-    {{ docker.logs.opts | to_nice_json(indent=4) }}
-{% endif %}
+  {{ docker.logs.opts | to_nice_json(indent=4) }}
 {% endif %}
 }

--- a/ansible/roles/docker/templates/overlay2-daemon.json
+++ b/ansible/roles/docker/templates/overlay2-daemon.json
@@ -1,0 +1,15 @@
+{
+  "storage-driver": "overlay2",
+  "icc": false,
+  "disable-legacy-registry": true,
+  "live-restore": true{% if docker.logs.opts | length > 0 %},{% endif %}
+
+{% if docker.logs.driver != "" %}
+  "log-driver": "{{ docker.logs.driver }}"{% if docker.logs.opts | length > 0 %},{% endif %}
+
+{% if docker.logs.opts | length > 0 %}
+  "log-opts":
+    {{ docker.logs.opts | to_nice_json(indent=4) }}
+{% endif %}
+{% endif %}
+}


### PR DESCRIPTION
Implements: #770 

**Note: This is currently a work-in-progress.**

The story thus far:

- I have tested overlay2 for Ubuntu 16.04 and CentOS 7.4.1708

Things to complete:

- Comments in the plan file that overlay2 will be the default storage driver
- Comments in the plan file that directlvm only needs to be enabled for RHEL 7.3 and below
- Comments in the plan file that directlvm only needs to be enabled for CentOS 7.3 and below
- Add integration tests for the implementation on RHEL, CentOS and Ubuntu versions
- Add integration tests for upgrading from devicemapper (with directlvm) to overlay2

cc @aquasheep20