### PR TITLE
Fix an issue running preflight on add-worker after install with --skip-preflight

### DIFF
--- a/pkg/cli/fakes_test.go
+++ b/pkg/cli/fakes_test.go
@@ -48,10 +48,6 @@ func (fe *fakeExecutor) RunPreFlightCheck(p *install.Plan) error {
 	return nil
 }
 
-func (fe *fakeExecutor) CopyInspector(p *install.Plan) error {
-	return nil
-}
-
 func (fe *fakeExecutor) RunNewWorkerPreFlightCheck(install.Plan, install.Node) error {
 	return nil
 }

--- a/pkg/cli/upgrade.go
+++ b/pkg/cli/upgrade.go
@@ -316,10 +316,6 @@ func upgradeNodes(in io.Reader, out io.Writer, plan install.Plan, opts upgradeOp
 	// Run upgrade preflight on the nodes that are to be upgraded
 	unreadyNodes := []install.ListableNode{}
 	if !opts.skipPreflight {
-		util.PrintHeader(out, fmt.Sprintf("Copy Kismatic Inspector to Nodes"), '=')
-		if err := preflightExec.CopyInspector(&plan); err != nil {
-			return errors.New("Error copying kismatic inspector")
-		}
 		for _, node := range nodesNeedUpgrade {
 			util.PrintHeader(out, fmt.Sprintf("Preflight Checks: %s %s", node.Node.Host, node.Roles), '=')
 			if err := preflightExec.RunUpgradePreFlightCheck(&plan, node); err != nil {


### PR DESCRIPTION
Fixes #918 

The issue was that the inspector binary never gets copied over to the other nodes during install and when `add-worker` runs it tries to `delegate` to one of the masters to startup in server mode, but the binary is missing. 

There was a similar issue for upgrades that was closed in https://github.com/apprenda/kismatic/pull/1019.

The new output would look like:
```
Running Pre-Flight Checks On New Worker=============================================
Copy Kismatic Inspector                                                         [OK]
Configure Cluster Prerequisites                                                 [OK]
Gather Node Facts                                                               [OK]
Update Hosts File                                                               [OK]
Run Cluster Pre-Flight Checks                                                   [OK]
```