### PR TITLE
Upgrading to CoreDNS v1.0.3 

### DIFF
--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -67,7 +67,7 @@ official_images:
     version: 1.14.7
   coredns:
     name: coredns/coredns
-    version: 1.0.2
+    version: 1.0.3
   kubernetes_dashboard:
     name: gcr.io/google_containers/kubernetes-dashboard-amd64
     version: v1.8.0

--- a/ansible/roles/coredns/templates/coredns.yaml
+++ b/ansible/roles/coredns/templates/coredns.yaml
@@ -79,6 +79,9 @@ spec:
       k8s-app: coredns
   template:
     metadata:
+      annotations:
+        prometheus.io/port: "9153"
+        prometheus.io/scrape: "true"
       labels:
         k8s-app: coredns
     spec:
@@ -115,9 +118,6 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
-        - containerPort: 9153
-          name: metrics
-          protocol: TCP
         livenessProbe:
           httpGet:
             path: /health
@@ -145,8 +145,6 @@ metadata:
     k8s-app: coredns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
-    prometheus.io/port: "9153"
-    prometheus.io/scrape: "true"
 spec:
   selector:
     k8s-app: coredns
@@ -157,7 +155,4 @@ spec:
     protocol: UDP
   - name: dns-tcp
     port: 53
-    protocol: TCP
-  - name: metrics
-    port: 9153
     protocol: TCP

--- a/ansible/roles/coredns/templates/coredns.yaml
+++ b/ansible/roles/coredns/templates/coredns.yaml
@@ -137,7 +137,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: coredns
+  name: kube-dns
   namespace: kube-system
   labels:
     k8s-app: coredns

--- a/ansible/roles/coredns/templates/coredns.yaml
+++ b/ansible/roles/coredns/templates/coredns.yaml
@@ -137,7 +137,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-dns
+  name: coredns
   namespace: kube-system
   labels:
     k8s-app: coredns

--- a/ansible/roles/coredns/templates/coredns.yaml
+++ b/ansible/roles/coredns/templates/coredns.yaml
@@ -87,8 +87,6 @@ spec:
     spec:
       serviceAccountName: coredns
       tolerations:
-        - key: node-role.kubernetes.io/master
-          effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
       affinity:

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -6,7 +6,7 @@ Release Team: @dkoshkin @alexbrand @emmetthitz
 
 ## Component version changes
 
-* CoreDNS 1.0.2
+* CoreDNS 1.0.3
 
 ## Changelog since v1.7.0
 


### PR DESCRIPTION
Closes #1053 

I also removed the master toleration, for more info see https://github.com/coredns/deployment/issues/50

We are now also scraping via the pods directly rather than the service.