### PR TITLE
Upgrading to CoreDNS 1.0.4

### DIFF
--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -67,7 +67,7 @@ official_images:
     version: 1.14.7
   coredns:
     name: coredns/coredns
-    version: 1.0.2
+    version: 1.0.4
   kubernetes_dashboard:
     name: gcr.io/google_containers/kubernetes-dashboard-amd64
     version: v1.8.0

--- a/docs/releases/1.8.0.md
+++ b/docs/releases/1.8.0.md
@@ -6,7 +6,7 @@ Release Team: @dkoshkin @alexbrand @emmetthitz
 
 ## Component version changes
 
-* CoreDNS 1.0.2
+* CoreDNS 1.0.4
 
 ## Changelog since v1.7.0
 


### PR DESCRIPTION
Closes #1060 

Note: Release 1.0.4 is a release that fixes a vulnerability in the underlying DNS library. 
See https://github.com/miekg/dns/issues/627 and the (still embargoed) CVE-2017-15133. 

**IMPORTANT:** This needs to be merged **after** https://github.com/apprenda/kismatic/pull/1055 