### PR TITLE
Tiller namespace

### DIFF
--- a/ansible/_helm.yaml
+++ b/ansible/_helm.yaml
@@ -8,31 +8,6 @@
       - group_vars/all.yaml
       - group_vars/container_images.yaml
 
-    tasks:
-      - name: "create new serviceaccount for tiller"
-        command: "kubectl -n kube-system create sa tiller"
-        register: out
-        failed_when: 'out.rc != 0 and out.stderr is defined and "Error from server (AlreadyExists)" not in out.stderr'
-      - name: "attach cluster-admin role to the service account tiller"
-        command: "kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller"
-        register: out
-        failed_when: 'out.rc != 0 and out.stderr is defined and "Error from server (AlreadyExists)" not in out.stderr'
-        
-      - name: "run helm init"
-        local_action: command ../../helm init --service-account=tiller -i="{{ images.helm }}" --upgrade {% if disconnected_installation|bool == true %}--skip-refresh{% endif %}
-        become: no
-        environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
-          
-      - block:
-        - name: wait until the tiller pod is ready
-          command: kubectl get deployment tiller-deploy -n kube-system -o jsonpath='{.status.availableReplicas}'
-          register: readyReplicas
-          until: readyReplicas.stdout|int == 1
-          retries: 24
-          delay: 10
-          failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
-        - name: fail if the tiller pod is not ready
-          fail:
-            msg: "Timed out waiting for the tiller pod to be in the ready state."
-          when: readyReplicas.stdout|int != 1
-        when: run_pod_validation|bool == true 
+    roles:
+      - role: helm
+

--- a/ansible/roles/helm/tasks/main.yaml
+++ b/ansible/roles/helm/tasks/main.yaml
@@ -13,7 +13,7 @@
     command: kubectl apply -f {{ kubernetes_spec_dir }}/helm-rbac.yaml
 
   - name: "run helm init"
-    local_action: command ../../helm init --service-account=tiller -i="{{ images.helm }}" --upgrade {% if disconnected_installation|bool == true %}--skip-refresh{% endif %}
+    local_action: command ../../helm init --service-account=tiller -i="{{ images.helm }}" --tiller-namespace="{{ helm.namespace }}" --upgrade {% if disconnected_installation|bool == true %}--skip-refresh{% endif %}
     become: no
     environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
 

--- a/ansible/roles/helm/tasks/main.yaml
+++ b/ansible/roles/helm/tasks/main.yaml
@@ -1,0 +1,23 @@
+---
+  - name: create /etc/kubernetes/specs directory
+    file:
+      path: "{{ kubernetes_spec_dir }}"
+      state: directory
+
+  - name: copy helm-rbac.yaml to remote
+    template:
+      src: helm-rbac.yaml
+      dest: "{{ kubernetes_spec_dir }}/helm-rbac.yaml"
+
+  - name: create helm serviceaccount and rolebinding
+    command: kubectl apply -f {{ kubernetes_spec_dir }}/helm-rbac.yaml
+
+  - name: "run helm init"
+    local_action: command ../../helm init --service-account=tiller -i="{{ images.helm }}" --upgrade {% if disconnected_installation|bool == true %}--skip-refresh{% endif %}
+    become: no
+    environment: "{{ proxy_env|combine({'KUBECONFIG': local_kubeconfig_directory}) }}"
+
+  - block:
+    - name: validate tiller pod
+      include: validate.yaml
+      when: run_pod_validation|bool == true 

--- a/ansible/roles/helm/tasks/validate.yaml
+++ b/ansible/roles/helm/tasks/validate.yaml
@@ -1,0 +1,11 @@
+- name: wait until the tiller pod is ready
+  command: kubectl get deployment tiller-deploy -n kube-system -o jsonpath='{.status.availableReplicas}'
+  register: readyReplicas
+  until: readyReplicas.stdout|int == 1
+  retries: 24
+  delay: 10
+  failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
+- name: fail if the tiller pod is not ready
+  fail:
+     msg: "Timed out waiting for the tiller pod to be in the ready state."
+  when: readyReplicas.stdout|int != 1

--- a/ansible/roles/helm/tasks/validate.yaml
+++ b/ansible/roles/helm/tasks/validate.yaml
@@ -1,5 +1,5 @@
 - name: wait until the tiller pod is ready
-  command: kubectl get deployment tiller-deploy -n kube-system -o jsonpath='{.status.availableReplicas}'
+  command: kubectl get deployment tiller-deploy -n {{ helm.namespace }} -o jsonpath='{.status.availableReplicas}'
   register: readyReplicas
   until: readyReplicas.stdout|int == 1
   retries: 24

--- a/ansible/roles/helm/templates/helm-rbac.yaml
+++ b/ansible/roles/helm/templates/helm-rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: tiller
+  namespace: kube-system

--- a/ansible/roles/helm/templates/helm-rbac.yaml
+++ b/ansible/roles/helm/templates/helm-rbac.yaml
@@ -1,8 +1,13 @@
 apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ helm.namespace }}
+---
+apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: tiller
-  namespace: kube-system
+  namespace: {{ helm.namespace }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -15,4 +20,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tiller
-  namespace: kube-system
+  namespace: {{ helm.namespace }}

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -82,6 +82,9 @@
   * [package_manager](#add_onspackage_manager)
     * [disable](#add_onspackage_managerdisable)
     * [provider](#add_onspackage_managerprovider)
+    * [options](#add_onspackage_manageroptions)
+      * [helm](#add_onspackage_manageroptionshelm)
+        * [namespace](#add_onspackage_manageroptionshelmnamespace)
   * [rescheduler](#add_onsrescheduler)
     * [disable](#add_onsreschedulerdisable)
 * [features _(deprecated)_](#features-deprecated)
@@ -803,6 +806,24 @@
 | **Required** |  Yes |
 | **Default** | ` ` | 
 | **Options** |  `helm`
+
+###  add_ons.package_manager.options
+
+ The PackageManager options. 
+
+###  add_ons.package_manager.options.helm
+
+ Helm PackageManager options 
+
+###  add_ons.package_manager.options.helm.namespace
+
+ Namespace to deploy tiller 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | `kube-system` | 
 
 ###  add_ons.rescheduler
 

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -128,7 +128,8 @@ type ClusterCatalog struct {
 	}
 
 	Helm struct {
-		Enabled bool
+		Enabled   bool
+		Namespace string
 	}
 
 	Rescheduler struct {

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -788,6 +788,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 		default:
 			cc.Helm.Enabled = true
 		}
+		cc.Helm.Namespace = p.AddOns.PackageManager.Options.Helm.Namespace
 	}
 
 	cc.Rescheduler.Enabled = !p.AddOns.Rescheduler.Disable

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -157,6 +157,10 @@ func setDefaults(p *Plan) {
 	if p.AddOns.Dashboard == nil {
 		p.AddOns.Dashboard = &Dashboard{}
 	}
+
+	if p.AddOns.PackageManager.Options.Helm.Namespace == "" {
+		p.AddOns.PackageManager.Options.Helm.Namespace = "kube-system"
+	}
 }
 
 var yamlKeyRE = regexp.MustCompile(`[^a-zA-Z]*([a-z_\-A-Z]+)[ ]*:`)
@@ -336,6 +340,7 @@ func buildPlanFromTemplateOptions(templateOpts PlanTemplateOptions) Plan {
 
 	// Package Manager
 	p.AddOns.PackageManager.Provider = "helm"
+	p.AddOns.PackageManager.Options.Helm.Namespace = "kube-system"
 
 	p.AddOns.Dashboard = &Dashboard{}
 	p.AddOns.Dashboard.Disable = false

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -437,6 +437,21 @@ type PackageManager struct {
 	// +required
 	// +options=helm
 	Provider string
+	// The PackageManager options.
+	Options PackageManagerOptions `yaml:"options"`
+}
+
+// The PackageManagerOptions for the PackageManager add-on
+type PackageManagerOptions struct {
+	// Helm PackageManager options
+	Helm HelmOptions
+}
+
+// HelmOptions for the helm PackageManager add-on
+type HelmOptions struct {
+	// Namespace to deploy tiller
+	// +default=kube-system
+	Namespace string
 }
 
 // Rescheduler add-on configuration

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -184,6 +184,9 @@ add_ons:
 
     # Options: 'helm'.
     provider: helm
+    options:
+      helm:
+        namespace: kube-system
 
   # The rescheduler ensures that critical add-ons remain running on the cluster.
   rescheduler:

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -184,6 +184,9 @@ add_ons:
 
     # Options: 'helm'.
     provider: helm
+    options:
+      helm:
+        namespace: kube-system
 
   # The rescheduler ensures that critical add-ons remain running on the cluster.
   rescheduler:


### PR DESCRIPTION
Some work on #938

Added `namespace` option to allow setting the `--tiller-namespace` option when running `helm init`