### PR TITLE
Docker storage drivers

### DIFF
--- a/ansible/_docker.yaml
+++ b/ansible/_docker.yaml
@@ -10,7 +10,6 @@
     roles:
       - role: packages-docker
         when: allow_package_installation|bool == true
-      - role: docker-storage
       - role: docker-registry-cert
         when: configure_docker_with_private_registry is defined and configure_docker_with_private_registry|bool == true
       - role: docker-proxy

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -55,11 +55,6 @@ docker_certificates_cert_path: "{{ docker_install_dir }}/{{ docker_certificates_
 docker_certificates_key_path: "{{ docker_install_dir }}/{{ docker_certificates_key_file_name }}"
 #===============================================================================
 # docker configuration
-# docker.storage.directlvm.enabled: no default
-# docker.storage.directlvm.block_device: no default
-# docker.storage.directlvm.enable_deferred_deletion: no default
-docker_device_mapper_thin_pool_autoextend_threshold: 80
-docker_device_mapper_thin_pool_autoextend_percent: 20
 docker_system_d: /etc/systemd/system/docker.service.d
 #===============================================================================
 # calico

--- a/ansible/roles/docker-storage/tasks/main.yaml
+++ b/ansible/roles/docker-storage/tasks/main.yaml
@@ -1,4 +1,0 @@
----
-  - name: configure devicemapper in direct-lvm mode
-    include: direct_lvm.yaml
-    when: "ansible_os_family == 'RedHat' and docker.storage.directlvm.enabled|bool == true"

--- a/ansible/roles/docker-storage/templates/docker-thinpool.profile
+++ b/ansible/roles/docker-storage/templates/docker-thinpool.profile
@@ -1,4 +1,0 @@
-activation {
-thin_pool_autoextend_threshold={{docker_device_mapper_thin_pool_autoextend_threshold}}
-thin_pool_autoextend_percent={{docker_device_mapper_thin_pool_autoextend_percent}}
-}

--- a/ansible/roles/docker/tasks/direct_lvm.yaml
+++ b/ansible/roles/docker/tasks/direct_lvm.yaml
@@ -5,14 +5,14 @@
       state: present
   - name: create docker volume group
     lvg:
-      pvs: "{{ docker.storage.directlvm.block_device }}"
+      pvs: "{{ docker.storage.direct_lvm_block_device.path }}"
       state: present
       vg: docker
   - name: create thinpool logical volume
     lvol:
       lv: thinpool
       vg: docker
-      size: 95%VG # Use 95% of the volume group for this logical volume
+      size: "{{ docker.storage.direct_lvm_block_device.thinpool_percent }}%VG" # Use 95% of the volume group for this logical volume
       opts: --wipesignatures y
   
   # The following two tasks are used to enable this play to be idempotent. We detect whether
@@ -51,7 +51,7 @@
     lvol:
       lv: thinpoolmeta
       vg: docker
-      size: 1%VG # Use 1% of the volume group for this logical volume
+      size: "{{ docker.storage.direct_lvm_block_device.thinpool_metapercent }}%VG" # Use 1% of the volume group for this logical volume
       opts: --wipesignatures y
     when: requires_thin_pool_conversion is defined and requires_thin_pool_conversion|bool == true
   

--- a/ansible/roles/docker/tasks/main.yaml
+++ b/ansible/roles/docker/tasks/main.yaml
@@ -1,4 +1,8 @@
 ---
+  - name: configure docker storage driver devicemapper in direct-lvm mode
+    include: direct_lvm.yaml
+    when: "ansible_os_family == 'RedHat' and docker.storage.driver == 'devicemapper' and docker.storage.direct_lvm_block_device.path != ''"
+
   - name: create /etc/docker directory
     file:
       path: /etc/docker

--- a/ansible/roles/docker/templates/daemon.json
+++ b/ansible/roles/docker/templates/daemon.json
@@ -1,19 +1,8 @@
 {
-{% if docker.storage.directlvm.enabled %}
-  "storage-driver": "devicemapper",
-   "storage-opts": [
-     "dm.thinpooldev=/dev/mapper/docker-thinpool",
-     "dm.use_deferred_removal=true",
-     "dm.use_deferred_deletion={{docker.storage.directlvm.enable_deferred_deletion}}"
-   ]{% if docker.logs.driver != "" %},{% endif %}
-{% endif %}
-
-{% if docker.logs.driver != "" %}
-  "log-driver": "{{ docker.logs.driver }}"{% if docker.logs.opts | length > 0 %},{% endif %}
-
-{% if docker.logs.opts | length > 0 %}
+  "storage-driver": "{{ docker.storage.driver }}",
+  "storage-opts": 
+{{ docker.storage.opts_list | to_nice_json(indent=4) }},
+  "log-driver": "{{ docker.logs.driver }}",
   "log-opts": 
 {{ docker.logs.opts | to_nice_json(indent=4) }}
-{% endif %}
-{% endif %}
 }

--- a/ansible/roles/docker/templates/docker-thinpool.profile
+++ b/ansible/roles/docker/templates/docker-thinpool.profile
@@ -1,0 +1,4 @@
+activation {
+thin_pool_autoextend_threshold={{docker.storage.direct_lvm_block_device.thinpool_autoextend_threshold}}
+thin_pool_autoextend_percent={{docker.storage.direct_lvm_block_device.thinpool_autoextend_percent}}
+}

--- a/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
+++ b/ansible/roles/preflight/tasks/direct_lvm_preflight.yaml
@@ -1,7 +1,7 @@
 ---
   - name: stat the block device path
     stat:
-      path: "{{ docker.storage.directlvm.block_device }}"
+      path: "{{ docker.storage.direct_lvm_block_device.path }}"
     register: block_device_stat
   - name: fail if the block device does not exists
     fail:
@@ -9,10 +9,10 @@
     when: block_device_stat.stat.exists == False
   - name: fail if the provided path is not a block device
     fail:
-      msg: "{{ docker.storage.directlvm.block_device }} is not a block device."
+      msg: "{{ docker.storage.direct_lvm_block_device.path }} is not a block device."
     when: block_device_stat.stat.isblk == False
   - name: fail if the block device is already mounted
     fail:
       msg: "Block deviced specified for docker storage is currently mounted. This should be an unmounted, unused device"
     with_items: "{{ ansible_mounts }}"
-    when: item.device == "{{ docker.storage.directlvm.block_device }}"
+    when: item.device == "{{ docker.storage.direct_lvm_block_device.path }}"

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -23,7 +23,7 @@
 
   - name: validate devicemapper direct-lvm block device
     include: direct_lvm_preflight.yaml
-    when: "ansible_os_family == 'RedHat' and docker.storage.directlvm.enabled|bool == true"
+    when: "ansible_os_family == 'RedHat' and docker.storage.driver == 'devicemapper' and docker.storage.direct_lvm_block_device.path != ''"
 
   # Every etcd node should be able to reach all etcd nodes. This is quadratic,
   # but we can live with it because etcd count is usually <= 5

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -40,7 +40,15 @@
     * [driver](#dockerlogsdriver)
     * [opts](#dockerlogsopts)
   * [storage](#dockerstorage)
-    * [direct_lvm](#dockerstoragedirect_lvm)
+    * [driver](#dockerstoragedriver)
+    * [opts](#dockerstorageopts)
+    * [direct_lvm_block_device](#dockerstoragedirect_lvm_block_device)
+      * [path](#dockerstoragedirect_lvm_block_devicepath)
+      * [thinpool_percent](#dockerstoragedirect_lvm_block_devicethinpool_percent)
+      * [thinpool_metapercent](#dockerstoragedirect_lvm_block_devicethinpool_metapercent)
+      * [thinpool_autoextend_threshold](#dockerstoragedirect_lvm_block_devicethinpool_autoextend_threshold)
+      * [thinpool_autoextend_percent](#dockerstoragedirect_lvm_block_devicethinpool_autoextend_percent)
+    * [direct_lvm _(deprecated)_](#dockerstoragedirect_lvm-deprecated)
       * [enabled](#dockerstoragedirect_lvmenabled)
       * [block_device](#dockerstoragedirect_lvmblock_device)
       * [enable_deferred_deletion](#dockerstoragedirect_lvmenable_deferred_deletion)
@@ -436,11 +444,11 @@
 
 ###  docker.logs
 
- Log configuration for the docker engine 
+ Log configuration for the docker engine. 
 
 ###  docker.logs.driver
 
- Docker logging driver, more details https://docs.docker.com/engine/admin/logging/overview/ 
+ Docker logging driver, more details https://docs.docker.com/engine/admin/logging/overview/. 
 
 | | |
 |----------|-----------------|
@@ -450,7 +458,7 @@
 
 ###  docker.logs.opts
 
- Driver specific options 
+ Driver specific options. 
 
 | | |
 |----------|-----------------|
@@ -460,11 +468,85 @@
 
 ###  docker.storage
 
- Storage configuration for the docker engine 
+ Storage configuration for the docker engine. 
 
-###  docker.storage.direct_lvm
+###  docker.storage.driver
 
- DirectLVM is the configuration required for setting up device mapper in direct-lvm mode 
+ Docker storage driver, more details https://docs.docker.com/engine/userguide/storagedriver/. Leave empty to have docker automatically select the driver. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | `'empty'` | 
+
+###  docker.storage.opts
+
+ Driver specific options 
+
+| | |
+|----------|-----------------|
+| **Kind** |  map[string]string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  docker.storage.direct_lvm_block_device
+
+ DirectLVMBlockDevice is the configuration required for setting up Device Mapper storage driver in direct-lvm mode. Refer to https://docs.docker.com/v17.03/engine/userguide/storagedriver/device-mapper-driver/#manage-devicemapper docs. 
+
+###  docker.storage.direct_lvm_block_device.path
+
+ The path to the block device. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  docker.storage.direct_lvm_block_device.thinpool_percent
+
+ The percentage of space to use for storage from the passed in block device. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | `95` | 
+
+###  docker.storage.direct_lvm_block_device.thinpool_metapercent
+
+ The percentage of space to for metadata storage from the passed in block device. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | `1` | 
+
+###  docker.storage.direct_lvm_block_device.thinpool_autoextend_threshold
+
+ The threshold for when lvm should automatically extend the thin pool as a percentage of the total storage space. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | `80` | 
+
+###  docker.storage.direct_lvm_block_device.thinpool_autoextend_percent
+
+ The percentage to increase the thin pool by when an autoextend is triggered. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | `20` | 
+
+###  docker.storage.direct_lvm _(deprecated)_
+
+ DirectLVM is the configuration required for setting up device mapper in direct-lvm mode. 
 
 ###  docker.storage.direct_lvm.enabled
 

--- a/integration-tests/install.go
+++ b/integration-tests/install.go
@@ -41,7 +41,7 @@ type installOptions struct {
 	httpProxy                    string
 	httpsProxy                   string
 	noProxy                      string
-	useDirectLVM                 bool
+	dockerStorageDriver          string
 	serviceCIDR                  string
 	disableCNI                   bool
 	cniProvider                  string
@@ -112,7 +112,7 @@ func buildPlan(nodes provisionedNodes, installOpts installOptions, sshKey string
 		HTTPProxy:                    installOpts.httpProxy,
 		HTTPSProxy:                   installOpts.httpsProxy,
 		NoProxy:                      installOpts.noProxy,
-		UseDirectLVM:                 installOpts.useDirectLVM,
+		DockerStorageDriver:          installOpts.dockerStorageDriver,
 		ServiceCIDR:                  installOpts.serviceCIDR,
 		DisableCNI:                   installOpts.disableCNI,
 		CNIProvider:                  installOpts.cniProvider,

--- a/integration-tests/install_test.go
+++ b/integration-tests/install_test.go
@@ -178,7 +178,7 @@ var _ = Describe("kismatic", func() {
 
 		Context("when using direct-lvm docker storage", func() {
 			installOpts := installOptions{
-				useDirectLVM: true,
+				dockerStorageDriver: "devicemapper",
 			}
 			Context("when targeting CentOS", func() {
 				ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
@@ -199,6 +199,27 @@ var _ = Describe("kismatic", func() {
 			Context("when targeting RHEL", func() {
 				ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
 					WithMiniInfrastructureAndBlockDevice(RedHat7, aws, func(node NodeDeets, sshKey string) {
+						theNode := []NodeDeets{node}
+						nodes := provisionedNodes{
+							etcd:    theNode,
+							master:  theNode,
+							worker:  theNode,
+							ingress: theNode,
+						}
+						err := installKismatic(nodes, installOpts, sshKey)
+						Expect(err).ToNot(HaveOccurred())
+					})
+				})
+			})
+		})
+
+		Context("when using overlay2 docker storage", func() {
+			installOpts := installOptions{
+				dockerStorageDriver: "overlay2",
+			}
+			Context("when targeting Ubuntu", func() {
+				ItOnAWS("should install successfully", func(aws infrastructureProvisioner) {
+					WithMiniInfrastructureAndBlockDevice(Ubuntu1604LTS, aws, func(node NodeDeets, sshKey string) {
 						theNode := []NodeDeets{node}
 						nodes := provisionedNodes{
 							etcd:    theNode,

--- a/integration-tests/plan_patterns.go
+++ b/integration-tests/plan_patterns.go
@@ -28,7 +28,7 @@ type PlanAWS struct {
 	HTTPProxy                    string
 	HTTPSProxy                   string
 	NoProxy                      string
-	UseDirectLVM                 bool
+	DockerStorageDriver          string
 	ServiceCIDR                  string
 	DisableCNI                   bool
 	CNIProvider                  string
@@ -78,12 +78,16 @@ const planAWSOverlay = `cluster:
   cloud_provider:
     provider: {{.CloudProvider}}
 docker:
-  disable: {{.DisableDockerInstallation}}{{if .UseDirectLVM}}
+  disable: {{.DisableDockerInstallation}}
   storage:
-    direct_lvm:
-      enabled: true
-      block_device: "/dev/xvdb"
-      enable_deferred_deletion: false{{end}}
+    driver: "{{.DockerStorageDriver}}"
+    opts: {}
+    direct_lvm_block_device:
+      path: {{if eq .DockerStorageDriver "devicemapper"}}"/dev/xvdb"{{end}}
+      thinpool_percent: "95"
+      thinpool_metapercent: "1"
+      thinpool_autoextend_threshold: "80"
+      thinpool_autoextend_percent: "20"
   logs:
     driver: "json-file"
     opts: 

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -76,11 +76,10 @@ type ClusterCatalog struct {
 			Opts   map[string]string `yaml:"opts"`
 		}
 		Storage struct {
-			DirectLVM struct {
-				Enabled                bool   `yaml:"enabled"`
-				BlockDevice            string `yaml:"block_device"`
-				EnableDeferredDeletion bool   `yaml:"enable_deferred_deletion"`
-			}
+			Driver               string               `yaml:"driver"`
+			Opts                 map[string]string    `yaml:"opts"`
+			OptsList             []string             `yaml:"opts_list"`
+			DirectLVMBlockDevice DirectLVMBlockDevice `yaml:"direct_lvm_block_device"`
 		}
 	}
 
@@ -145,6 +144,13 @@ type ClusterCatalog struct {
 	KubeletNodeOptions map[string]map[string]string `yaml:"kubelet_node_overrides"`
 }
 
+type DirectLVMBlockDevice struct {
+	Path                        string
+	ThinpoolPercent             string `yaml:"thinpool_percent"`
+	ThinpoolMetaPercent         string `yaml:"thinpool_metapercent"`
+	ThinpoolAutoextendThreshold string `yaml:"thinpool_autoextend_threshold"`
+	ThinpoolAutoextendPercent   string `yaml:"thinpool_autoextend_percent"`
+}
 type NFSVolume struct {
 	Host string
 	Path string

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -716,12 +716,21 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	cc.Docker.Enabled = !p.Docker.Disable
 	cc.Docker.Logs.Driver = p.Docker.Logs.Driver
 	cc.Docker.Logs.Opts = p.Docker.Logs.Opts
-
-	cc.Docker.Storage.DirectLVM.Enabled = p.Docker.Storage.DirectLVM.Enabled
-	if cc.Docker.Storage.DirectLVM.Enabled {
-		cc.Docker.Storage.DirectLVM.BlockDevice = p.Docker.Storage.DirectLVM.BlockDevice
-		cc.Docker.Storage.DirectLVM.EnableDeferredDeletion = p.Docker.Storage.DirectLVM.EnableDeferredDeletion
+	cc.Docker.Storage.Driver = p.Docker.Storage.Driver
+	cc.Docker.Storage.Opts = p.Docker.Storage.Opts
+	cc.Docker.Storage.OptsList = []string{}
+	// A formatted list to set in docker daemon.json
+	for k, v := range p.Docker.Storage.Opts {
+		cc.Docker.Storage.OptsList = append(cc.Docker.Storage.OptsList, fmt.Sprintf("%s=%s", k, v))
 	}
+	cc.Docker.Storage.DirectLVMBlockDevice = ansible.DirectLVMBlockDevice{
+		Path:                        p.Docker.Storage.DirectLVMBlockDevice.Path,
+		ThinpoolPercent:             p.Docker.Storage.DirectLVMBlockDevice.ThinpoolPercent,
+		ThinpoolMetaPercent:         p.Docker.Storage.DirectLVMBlockDevice.ThinpoolMetaPercent,
+		ThinpoolAutoextendThreshold: p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendThreshold,
+		ThinpoolAutoextendPercent:   p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendPercent,
+	}
+
 	if ae.options.RestartServices {
 		cc.EnableRestart()
 	}

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -94,6 +94,21 @@ func readDeprecatedFields(p *Plan) {
 	if p.DockerRegistry.Server == "" && p.DockerRegistry.Address != "" && p.DockerRegistry.Port != 0 {
 		p.DockerRegistry.Server = fmt.Sprintf("%s:%d", p.DockerRegistry.Address, p.DockerRegistry.Port)
 	}
+
+	if p.Docker.Storage.DirectLVM != nil && p.Docker.Storage.DirectLVM.Enabled && (p.Docker.Storage.Opts == nil || len(p.Docker.Storage.Opts) == 0) {
+		p.Docker.Storage.Driver = "devicemapper"
+		p.Docker.Storage.Opts = map[string]string{
+			"dm.thinpooldev":           "/dev/mapper/docker-thinpool",
+			"dm.use_deferred_removal":  "true",
+			"dm.use_deferred_deletion": fmt.Sprintf("%t", p.Docker.Storage.DirectLVM.EnableDeferredDeletion),
+		}
+		p.Docker.Storage.DirectLVMBlockDevice.Path = p.Docker.Storage.DirectLVM.BlockDevice
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolPercent = "95"
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolMetaPercent = "1"
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendThreshold = "80"
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendPercent = "20"
+		p.Docker.Storage.DirectLVM = nil
+	}
 }
 
 func setDefaults(p *Plan) {
@@ -103,6 +118,32 @@ func setDefaults(p *Plan) {
 			"max-size": "50m",
 			"max-file": "1",
 		}
+	}
+
+	// set options that were previously set in Ansible
+	// only set them when creating a block device
+	if p.Docker.Storage.Driver == "devicemapper" && p.Docker.Storage.DirectLVMBlockDevice.Path != "" {
+		if _, ok := p.Docker.Storage.Opts["dm.thinpooldev"]; !ok {
+			p.Docker.Storage.Opts["dm.thinpooldev"] = "/dev/mapper/docker-thinpool"
+		}
+		if _, ok := p.Docker.Storage.Opts["dm.use_deferred_removal"]; !ok {
+			p.Docker.Storage.Opts["dm.use_deferred_removal"] = "true"
+		}
+		if _, ok := p.Docker.Storage.Opts["dm.use_deferred_deletion"]; !ok {
+			p.Docker.Storage.Opts["dm.use_deferred_deletion"] = "false"
+		}
+	}
+	if p.Docker.Storage.DirectLVMBlockDevice.ThinpoolPercent == "" {
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolPercent = "95"
+	}
+	if p.Docker.Storage.DirectLVMBlockDevice.ThinpoolMetaPercent == "" {
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolMetaPercent = "1"
+	}
+	if p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendThreshold == "" {
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendThreshold = "80"
+	}
+	if p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendPercent == "" {
+		p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendPercent = "20"
 	}
 
 	if p.AddOns.CNI == nil {
@@ -159,7 +200,7 @@ func setDefaults(p *Plan) {
 	}
 }
 
-var yamlKeyRE = regexp.MustCompile(`[^a-zA-Z]*([a-z_\-A-Z]+)[ ]*:`)
+var yamlKeyRE = regexp.MustCompile(`[^a-zA-Z]*([a-z_\-A-Z.]+)[ ]*:`)
 
 // Write the plan to the file system
 func (fp *FilePlanner) Write(p *Plan) error {
@@ -317,6 +358,10 @@ func buildPlanFromTemplateOptions(templateOpts PlanTemplateOptions) Plan {
 			"max-file": "1",
 		},
 	}
+	p.Docker.Storage.DirectLVMBlockDevice.ThinpoolPercent = "95"
+	p.Docker.Storage.DirectLVMBlockDevice.ThinpoolMetaPercent = "1"
+	p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendThreshold = "80"
+	p.Docker.Storage.DirectLVMBlockDevice.ThinpoolAutoextendPercent = "20"
 
 	// Add-Ons
 	// CNI
@@ -400,59 +445,59 @@ func getDNSServiceIP(p *Plan) (string, error) {
 // in the plan file. The value of the map contains the comment, split into
 // separate lines.
 var commentMap = map[string][]string{
-	"cluster.admin_password":                             []string{"This password is used to login to the Kubernetes Dashboard and can also be", "used for administration without a security certificate."},
-	"cluster.disable_package_installation":               []string{"Set to true if the nodes have the required packages installed."},
-	"cluster.disconnected_installation":                  []string{"Set to true if you are performing a disconnected installation."},
-	"cluster.networking":                                 []string{"Networking configuration of your cluster."},
-	"cluster.networking.pod_cidr_block":                  []string{"Kubernetes will assign pods IPs in this range. Do not use a range that is", "already in use on your local network!"},
-	"cluster.networking.service_cidr_block":              []string{"Kubernetes will assign services IPs in this range. Do not use a range", "that is already in use by your local network or pod network!"},
-	"cluster.networking.update_hosts_files":              []string{"Set to true if your nodes cannot resolve each others' names using DNS."},
-	"cluster.networking.http_proxy":                      []string{"Set the proxy server to use for HTTP connections."},
-	"cluster.networking.https_proxy":                     []string{"Set the proxy server to use for HTTPs connections."},
-	"cluster.networking.no_proxy":                        []string{"List of host names and/or IPs that shouldn't go through any proxy.", "All nodes' 'host' and 'IPs' are always set."},
-	"cluster.certificates":                               []string{"Generated certs configuration."},
-	"cluster.certificates.expiry":                        []string{"Self-signed certificate expiration period in hours; default is 2 years."},
-	"cluster.certificates.ca_expiry":                     []string{"CA certificate expiration period in hours; default is 2 years."},
-	"cluster.ssh":                                        []string{"SSH configuration for cluster nodes."},
-	"cluster.ssh.user":                                   []string{"This user must be able to sudo without password."},
-	"cluster.ssh.ssh_key":                                []string{"Absolute path to the ssh private key we should use to manage nodes."},
-	"cluster.kube_apiserver":                             []string{"Override configuration of Kubernetes components."},
-	"cluster.cloud_provider":                             []string{"Kubernetes cloud provider integration."},
-	"cluster.cloud_provider.provider":                    []string{"Options: 'aws','azure','cloudstack','fake','gce','mesos','openstack',", "'ovirt','photon','rackspace','vsphere'.", "Leave empty for bare metal setups or other unsupported providers."},
-	"cluster.cloud_provider.config":                      []string{"Path to the config file, leave empty if provider does not require it."},
-	"docker":                                             []string{"Docker daemon configuration of all cluster nodes."},
-	"docker.disable":                                     []string{"Set to true if docker is already installed and configured."},
-	"etcd":                                               []string{"Etcd nodes are the ones that run the etcd distributed key-value database."},
-	"etcd.nodes":                                         []string{"Provide the hostname and IP of each node. If the node has an IP for internal", "traffic, provide it in the internalip field. Otherwise, that field can be", "left blank."},
-	"master":                                             []string{"Master nodes are the ones that run the Kubernetes control plane components."},
-	"worker":                                             []string{"Worker nodes are the ones that will run your workloads on the cluster."},
-	"ingress":                                            []string{"Ingress nodes will run the ingress controllers."},
-	"storage":                                            []string{"Storage nodes will be used to create a distributed storage cluster that can", "be consumed by your workloads."},
-	"master.load_balanced_fqdn":                          []string{"If you have set up load balancing for master nodes, enter the FQDN name here.", "Otherwise, use the IP address of a single master node."},
-	"master.load_balanced_short_name":                    []string{"If you have set up load balancing for master nodes, enter the short name here.", "Otherwise, use the IP address of a single master node."},
-	"docker.storage.direct_lvm":                          []string{"Configure devicemapper in direct-lvm mode (RHEL/CentOS only)."},
-	"docker.storage.direct_lvm.block_device":             []string{"Path to the block device that will be used for direct-lvm mode. This", "device will be wiped and used exclusively by docker."},
-	"docker.storage.direct_lvm.enable_deferred_deletion": []string{"Set to true if you want to enable deferred deletion when using", "direct-lvm mode."},
-	"docker_registry":                                    []string{"If you want to use an internal registry for the installation or upgrade, you", "must provide its information here. You must seed this registry before the", "installation or upgrade of your cluster. This registry must be accessible from", "all nodes on the cluster."},
-	"docker_registry.server":                             []string{"IP or hostname and port for your registry."},
-	"docker_registry.CA":                                 []string{"Absolute path to the certificate authority that should be trusted when", "connecting to your registry."},
-	"docker_registry.username":                           []string{"Leave blank for unauthenticated access."},
-	"docker_registry.password":                           []string{"Leave blank for unauthenticated access."},
-	"add_ons":                                            []string{"Add-ons are additional components that KET installs on the cluster."},
-	"nfs":                                                []string{"A set of NFS volumes for use by on-cluster persistent workloads."},
-	"nfs.nfs_host":                                       []string{"The host name or ip address of an NFS server."},
-	"nfs.mount_path":                                     []string{"The mount path of an NFS share. Must start with '/'."},
-	"add_ons.cni.provider":                               []string{"Selecting 'custom' will result in a CNI ready cluster, however it is up to", "you to configure a plugin after the install.", "Options: 'calico','weave','contiv','custom'."},
-	"add_ons.cni.options.calico.mode":                    []string{"Options: 'overlay','routed'."},
-	"add_ons.cni.options.calico.log_level":               []string{"Options: 'warning','info','debug'."},
-	"add_ons.cni.options.calico.workload_mtu":            []string{"MTU for the workload interface, configures the CNI config."},
-	"add_ons.cni.options.calico.felix_input_mtu":         []string{"MTU for the tunnel device used if IPIP is enabled."},
-	"add_ons.dns.provider":                               []string{"Options: 'kubedns','coredns'."},
-	"add_ons.heapster.options.influxdb.pvc_name":         []string{"Provide the name of the persistent volume claim that you will create", "after installation. If not specified, the data will be stored in", "ephemeral storage."},
-	"add_ons.heapster.options.heapster.service_type":     []string{"Specify kubernetes ServiceType. Defaults to 'ClusterIP'.", "Options: 'ClusterIP','NodePort','LoadBalancer','ExternalName'."},
-	"add_ons.heapster.options.heapster.sink":             []string{"Specify the sink to store heapster data. Defaults to an influxdb pod", "running on the cluster."},
-	"add_ons.package_manager.provider":                   []string{"Options: 'helm'."},
-	"add_ons.rescheduler":                                []string{"The rescheduler ensures that critical add-ons remain running on the cluster."},
+	"cluster.admin_password":                         []string{"This password is used to login to the Kubernetes Dashboard and can also be", "used for administration without a security certificate."},
+	"cluster.disable_package_installation":           []string{"Set to true if the nodes have the required packages installed."},
+	"cluster.disconnected_installation":              []string{"Set to true if you are performing a disconnected installation."},
+	"cluster.networking":                             []string{"Networking configuration of your cluster."},
+	"cluster.networking.pod_cidr_block":              []string{"Kubernetes will assign pods IPs in this range. Do not use a range that is", "already in use on your local network!"},
+	"cluster.networking.service_cidr_block":          []string{"Kubernetes will assign services IPs in this range. Do not use a range", "that is already in use by your local network or pod network!"},
+	"cluster.networking.update_hosts_files":          []string{"Set to true if your nodes cannot resolve each others' names using DNS."},
+	"cluster.networking.http_proxy":                  []string{"Set the proxy server to use for HTTP connections."},
+	"cluster.networking.https_proxy":                 []string{"Set the proxy server to use for HTTPs connections."},
+	"cluster.networking.no_proxy":                    []string{"List of host names and/or IPs that shouldn't go through any proxy.", "All nodes' 'host' and 'IPs' are always set."},
+	"cluster.certificates":                           []string{"Generated certs configuration."},
+	"cluster.certificates.expiry":                    []string{"Self-signed certificate expiration period in hours; default is 2 years."},
+	"cluster.certificates.ca_expiry":                 []string{"CA certificate expiration period in hours; default is 2 years."},
+	"cluster.ssh":                                    []string{"SSH configuration for cluster nodes."},
+	"cluster.ssh.user":                               []string{"This user must be able to sudo without password."},
+	"cluster.ssh.ssh_key":                            []string{"Absolute path to the ssh private key we should use to manage nodes."},
+	"cluster.kube_apiserver":                         []string{"Override configuration of Kubernetes components."},
+	"cluster.cloud_provider":                         []string{"Kubernetes cloud provider integration."},
+	"cluster.cloud_provider.provider":                []string{"Options: 'aws','azure','cloudstack','fake','gce','mesos','openstack',", "'ovirt','photon','rackspace','vsphere'.", "Leave empty for bare metal setups or other unsupported providers."},
+	"cluster.cloud_provider.config":                  []string{"Path to the config file, leave empty if provider does not require it."},
+	"docker":                                         []string{"Docker daemon configuration of all cluster nodes."},
+	"docker.disable":                                 []string{"Set to true if docker is already installed and configured."},
+	"docker.storage.driver":                          []string{"Leave empty to have docker automatically select the driver."},
+	"docker.storage.direct_lvm_block_device":         []string{"Used for setting up Device Mapper storage driver in direct-lvm mode."},
+	"docker.storage.direct_lvm_block_device.path":    []string{"Absolute path to the block device that will be used for direct-lvm mode.", "This device will be wiped and used exclusively by docker."},
+	"docker_registry":                                []string{"If you want to use an internal registry for the installation or upgrade, you", "must provide its information here. You must seed this registry before the", "installation or upgrade of your cluster. This registry must be accessible from", "all nodes on the cluster."},
+	"docker_registry.server":                         []string{"IP or hostname and port for your registry."},
+	"docker_registry.CA":                             []string{"Absolute path to the certificate authority that should be trusted when", "connecting to your registry."},
+	"docker_registry.username":                       []string{"Leave blank for unauthenticated access."},
+	"docker_registry.password":                       []string{"Leave blank for unauthenticated access."},
+	"add_ons":                                        []string{"Add-ons are additional components that KET installs on the cluster."},
+	"add_ons.cni.provider":                           []string{"Selecting 'custom' will result in a CNI ready cluster, however it is up to", "you to configure a plugin after the install.", "Options: 'calico','weave','contiv','custom'."},
+	"add_ons.cni.options.calico.mode":                []string{"Options: 'overlay','routed'."},
+	"add_ons.cni.options.calico.log_level":           []string{"Options: 'warning','info','debug'."},
+	"add_ons.cni.options.calico.workload_mtu":        []string{"MTU for the workload interface, configures the CNI config."},
+	"add_ons.cni.options.calico.felix_input_mtu":     []string{"MTU for the tunnel device used if IPIP is enabled."},
+	"add_ons.dns.provider":                           []string{"Options: 'kubedns','coredns'."},
+	"add_ons.heapster.options.influxdb.pvc_name":     []string{"Provide the name of the persistent volume claim that you will create", "after installation. If not specified, the data will be stored in", "ephemeral storage."},
+	"add_ons.heapster.options.heapster.service_type": []string{"Specify kubernetes ServiceType. Defaults to 'ClusterIP'.", "Options: 'ClusterIP','NodePort','LoadBalancer','ExternalName'."},
+	"add_ons.heapster.options.heapster.sink":         []string{"Specify the sink to store heapster data. Defaults to an influxdb pod", "running on the cluster."},
+	"add_ons.package_manager.provider":               []string{"Options: 'helm'."},
+	"add_ons.rescheduler":                            []string{"The rescheduler ensures that critical add-ons remain running on the cluster."},
+	"etcd":                                           []string{"Etcd nodes are the ones that run the etcd distributed key-value database."},
+	"etcd.nodes":                                     []string{"Provide the hostname and IP of each node. If the node has an IP for internal", "traffic, provide it in the internalip field. Otherwise, that field can be", "left blank."},
+	"master":                                         []string{"Master nodes are the ones that run the Kubernetes control plane components."},
+	"worker":                                         []string{"Worker nodes are the ones that will run your workloads on the cluster."},
+	"ingress":                                        []string{"Ingress nodes will run the ingress controllers."},
+	"storage":                                        []string{"Storage nodes will be used to create a distributed storage cluster that can", "be consumed by your workloads."},
+	"master.load_balanced_fqdn":                      []string{"If you have set up load balancing for master nodes, enter the FQDN name here.", "Otherwise, use the IP address of a single master node."},
+	"master.load_balanced_short_name":                []string{"If you have set up load balancing for master nodes, enter the short name here.", "Otherwise, use the IP address of a single master node."},
+	"nfs":            []string{"A set of NFS volumes for use by on-cluster persistent workloads."},
+	"nfs.nfs_host":   []string{"The host name or ip address of an NFS server."},
+	"nfs.mount_path": []string{"The mount path of an NFS share. Must start with '/'."},
 }
 
 type stack struct {

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -227,30 +227,57 @@ type Docker struct {
 	// The installer will validate that docker is installed and running prior to proceeding.
 	// Use this option if a different version of docker from the included one is required.
 	Disable bool
-	// Log configuration for the docker engine
+	// Log configuration for the docker engine.
 	Logs DockerLogs
-	// Storage configuration for the docker engine
+	// Storage configuration for the docker engine.
 	Storage DockerStorage
 }
 
 // DockerLogs includes the log-specific configuration for docker.
 type DockerLogs struct {
-	// Docker logging driver, more details https://docs.docker.com/engine/admin/logging/overview/
+	// Docker logging driver, more details https://docs.docker.com/engine/admin/logging/overview/.
 	// +default=json-file
 	Driver string
-	// Driver specific options
+	// Driver specific options.
 	Opts map[string]string
 }
 
 // DockerStorage includes the storage-specific configuration for docker.
 type DockerStorage struct {
-	// DirectLVM is the configuration required for setting up device mapper in direct-lvm mode
-	DirectLVM DockerStorageDirectLVM `yaml:"direct_lvm"`
+	// Docker storage driver, more details https://docs.docker.com/engine/userguide/storagedriver/.
+	// Leave empty to have docker automatically select the driver.
+	// +default='empty'
+	Driver string
+	// Driver specific options
+	Opts map[string]string
+	// DirectLVMBlockDevice is the configuration required for setting up Device Mapper storage driver in direct-lvm mode.
+	// Refer to https://docs.docker.com/v17.03/engine/userguide/storagedriver/device-mapper-driver/#manage-devicemapper docs.
+	DirectLVMBlockDevice DirectLVMBlockDevice `yaml:"direct_lvm_block_device"`
+	// DirectLVM is the configuration required for setting up device mapper in direct-lvm mode.
+	// +deprecated
+	DirectLVM *DockerStorageDirectLVMDeprecated `yaml:"direct_lvm,omitempty"`
 }
 
-// DockerStorageDirectLVM includes the configuration required for setting up
-// device mapper in direct-lvm mode
-type DockerStorageDirectLVM struct {
+type DirectLVMBlockDevice struct {
+	// The path to the block device.
+	Path string
+	// The percentage of space to use for storage from the passed in block device.
+	// +default=95
+	ThinpoolPercent string `yaml:"thinpool_percent"`
+	// The percentage of space to for metadata storage from the passed in block device.
+	// +default=1
+	ThinpoolMetaPercent string `yaml:"thinpool_metapercent"`
+	// The threshold for when lvm should automatically extend the thin pool as a percentage of the total storage space.
+	// +default=80
+	ThinpoolAutoextendThreshold string `yaml:"thinpool_autoextend_threshold"`
+	// The percentage to increase the thin pool by when an autoextend is triggered.
+	// +default=20
+	ThinpoolAutoextendPercent string `yaml:"thinpool_autoextend_percent"`
+}
+
+// DockerStorageDirectLVMDeprecated includes the configuration required for setting up
+// device mapper in direct-lvm mode.
+type DockerStorageDirectLVMDeprecated struct {
 	// Whether the direct_lvm mode of the devicemapper storage driver should be enabled.
 	// When set to true, a dedicated block storage device must be available on each cluster node.
 	// +default=false

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -94,17 +94,20 @@ docker:
 
   storage:
 
-    # Configure devicemapper in direct-lvm mode (RHEL/CentOS only).
-    direct_lvm:
-      enabled: false
+    # Leave empty to have docker automatically select the driver.
+    driver: ""
+    opts: {}
 
-      # Path to the block device that will be used for direct-lvm mode. This
-      # device will be wiped and used exclusively by docker.
-      block_device: ""
+    # Used for setting up Device Mapper storage driver in direct-lvm mode.
+    direct_lvm_block_device:
 
-      # Set to true if you want to enable deferred deletion when using
-      # direct-lvm mode.
-      enable_deferred_deletion: false
+      # Absolute path to the block device that will be used for direct-lvm mode.
+      # This device will be wiped and used exclusively by docker.
+      path: ""
+      thinpool_percent: "95"
+      thinpool_metapercent: "1"
+      thinpool_autoextend_threshold: "80"
+      thinpool_autoextend_percent: "20"
 
 # If you want to use an internal registry for the installation or upgrade, you
 # must provide its information here. You must seed this registry before the

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -94,17 +94,20 @@ docker:
 
   storage:
 
-    # Configure devicemapper in direct-lvm mode (RHEL/CentOS only).
-    direct_lvm:
-      enabled: false
+    # Leave empty to have docker automatically select the driver.
+    driver: ""
+    opts: {}
 
-      # Path to the block device that will be used for direct-lvm mode. This
-      # device will be wiped and used exclusively by docker.
-      block_device: ""
+    # Used for setting up Device Mapper storage driver in direct-lvm mode.
+    direct_lvm_block_device:
 
-      # Set to true if you want to enable deferred deletion when using
-      # direct-lvm mode.
-      enable_deferred_deletion: false
+      # Absolute path to the block device that will be used for direct-lvm mode.
+      # This device will be wiped and used exclusively by docker.
+      path: ""
+      thinpool_percent: "95"
+      thinpool_metapercent: "1"
+      thinpool_autoextend_threshold: "80"
+      thinpool_autoextend_percent: "20"
 
 # If you want to use an internal registry for the installation or upgrade, you
 # must provide its information here. You must seed this registry before the

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -516,12 +516,18 @@ func (d Docker) validate() (bool, []error) {
 func (ds DockerStorage) validate() (bool, []error) {
 	v := newValidator()
 	v.validateWithErrPrefix("Direct LVM", ds.DirectLVM)
+	if ds.DirectLVMBlockDevice.Path != "" && ds.Driver != "devicemapper" {
+		v.addError(errors.New("DirectLVMBlockDevice Path can only be used with 'devicemapper' storage driver"))
+	}
+	if ds.DirectLVMBlockDevice.Path != "" && !filepath.IsAbs(ds.DirectLVMBlockDevice.Path) {
+		v.addError(errors.New("DirectLVMBlockDevice Path must be absolute"))
+	}
 	return v.valid()
 }
 
-func (dlvm DockerStorageDirectLVM) validate() (bool, []error) {
+func (dlvm *DockerStorageDirectLVMDeprecated) validate() (bool, []error) {
 	v := newValidator()
-	if dlvm.Enabled {
+	if dlvm != nil && dlvm.Enabled {
 		if dlvm.BlockDevice == "" {
 			v.addError(errors.New("DirectLVM is enabled, but no block device was specified"))
 		}

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -918,32 +918,100 @@ func TestDockerRegistry(t *testing.T) {
 	}
 }
 
+func TestValidateDockerStorage(t *testing.T) {
+	tests := []struct {
+		storage DockerStorage
+		valid   bool
+	}{
+		{
+			storage: DockerStorage{
+				Driver: "devicemapper",
+			},
+			valid: true,
+		},
+		{
+			storage: DockerStorage{
+				Driver: "overlay2",
+			},
+			valid: true,
+		},
+		{
+			storage: DockerStorage{
+				Driver: "foo",
+			},
+			valid: true,
+		},
+		{
+			storage: DockerStorage{
+				Driver: "devicemapper",
+				DirectLVMBlockDevice: DirectLVMBlockDevice{
+					Path: "",
+				},
+			},
+			valid: true,
+		},
+		{
+			storage: DockerStorage{
+				Driver: "devicemapper",
+				DirectLVMBlockDevice: DirectLVMBlockDevice{
+					Path: "foo",
+				},
+			},
+			valid: false,
+		},
+		{
+			storage: DockerStorage{
+				Driver: "devicemapper",
+				DirectLVMBlockDevice: DirectLVMBlockDevice{
+					Path: "/foo/bar",
+				},
+			},
+			valid: true,
+		},
+		{
+			storage: DockerStorage{
+				Driver: "foo",
+				DirectLVMBlockDevice: DirectLVMBlockDevice{
+					Path: "/foo/bar",
+				},
+			},
+			valid: false,
+		},
+	}
+	for i, test := range tests {
+		ok, _ := test.storage.validate()
+		if ok != test.valid {
+			t.Errorf("test %d: expect valid, but got invalid", i)
+		}
+	}
+}
+
 func TestValidateDockerStorageDirectLVM(t *testing.T) {
 	tests := []struct {
-		config DockerStorageDirectLVM
+		config DockerStorageDirectLVMDeprecated
 		valid  bool
 	}{
 		{
-			config: DockerStorageDirectLVM{
+			config: DockerStorageDirectLVMDeprecated{
 				Enabled: false,
 			},
 			valid: true,
 		},
 		{
-			config: DockerStorageDirectLVM{
+			config: DockerStorageDirectLVMDeprecated{
 				Enabled: true,
 			},
 			valid: false,
 		},
 		{
-			config: DockerStorageDirectLVM{
+			config: DockerStorageDirectLVMDeprecated{
 				Enabled:     true,
 				BlockDevice: "foo",
 			},
 			valid: false,
 		},
 		{
-			config: DockerStorageDirectLVM{
+			config: DockerStorageDirectLVMDeprecated{
 				Enabled:     true,
 				BlockDevice: "/dev/sdb",
 			},


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/770

Add support to allow users to configure [docker storage drivers](https://docs.docker.com/engine/userguide/storagedriver/)

The values from the  `opts{}` field will be set in docker `daemon.json` `"storage-opts"` 
```
# Docker daemon configuration of all cluster nodes.
docker:

  # Set to true if docker is already installed and configured.
  disable: false
  logs:
    driver: json-file
    opts:
      max-file: "1"
      max-size: 50m

  storage:

    # Leave empty to have docker automatically select the driver.
    driver: ""
    opts: {}

    # Used for setting up Device Mapper storage driver in direct-lvm mode.
    direct_lvm_block_device:

      # Absolute path to the block device that will be used for direct-lvm mode.
      # This device will be wiped and used exclusively by docker.
      path: ""
      thinpool_percent: "95"
      thinpool_metapercent: "1"
      thinpool_autoextend_threshold: "80"
      thinpool_autoextend_percent: "20"
```

**NOTE IT IS NOT RECOMMENDED CHANGING THE STORAGE DRIVER OF A RUNNING CLUSTER**

---
To maintain backwards `docker.storage.direct_lvm` providing the `docker.storage.direct_lvm` field will still work as it previously has (it is deprecated and will be removed in a future version), during execution it will be updated to the latest schema.

The new schema allows the user to override any of the previously hardcoded options.
Old config:
```
docker:
  disable: false
  storage:
    direct_lvm:
      enabled: true
      block_device: "/dev/xvdb"
      enable_deferred_deletion: false
```
New Equivalent Config
```
  storage:
    driver: devicemapper
    opts:
      dm.thinpooldev: /dev/mapper/docker-thinpool
      dm.use_deferred_deletion: "false"
      dm.use_deferred_removal: "true"
    direct_lvm_block_device:
      path: /dev/xvdb
      thinpool_percent: "95"
      thinpool_metapercent: "1"
      thinpool_autoextend_threshold: "80"
      thinpool_autoextend_percent: "20"
```