### PR TITLE
Removing the prometheus scrape annotations from kube-proxy.

### DIFF
--- a/ansible/roles/kube-proxy/templates/kube-proxy.yaml
+++ b/ansible/roles/kube-proxy/templates/kube-proxy.yaml
@@ -46,8 +46,6 @@ spec:
         kismatic/version: "{{ kismatic_short_version }}"
         k8s-app: kube-proxy
         scheduler.alpha.kubernetes.io/critical-pod: ''
-        prometheus.io/port: "10249"
-        prometheus.io/scrape: "true"
     spec:
       hostNetwork: true
       nodeSelector:


### PR DESCRIPTION
Closes #1068 