### PR TITLE
Properly set hostname-override to the nodeName

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -198,7 +198,7 @@ kube_scheduler_option_defaults:
 
 kube_proxy_option_defaults:
   "cluster-cidr": "{{ kubernetes_pods_cidr }}"
-  "hostname-override": "{{ inventory_hostname }}"
+  "hostname-override": "$(NODE_NAME)"
   "proxy-mode": "iptables"
   "v": "2"
 

--- a/ansible/roles/kube-proxy/templates/kube-proxy.yaml
+++ b/ansible/roles/kube-proxy/templates/kube-proxy.yaml
@@ -77,6 +77,10 @@ spec:
           value: "{{ kubernetes_load_balanced_fqdn }}"
         - name: KUBERNETES_SERVICE_PORT
           value: "{{ kubernetes_master_secure_port }}"
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         securityContext:
           privileged: true
         livenessProbe:


### PR DESCRIPTION
After moving `kube-proxy` to a DS the `hostname-override` option was not being set correctly as all the nodes would have the hostname where the `kubectl apply` command was run from during the installation (master[0])

With this change the override will be set to `spec.nodeName` which gets populated from the kubelet.

Another approach was explored setting the `--config` option however, when that option is set any command line flags are NOT read, this is problematic as we expose `cluster.kube_proxy.option_overrides: {}` and to introduce the config file will require more redesign. 