### PR TITLE
Better Ansible task printouts

### DIFF
--- a/ansible/roles/all/tasks/main.yaml
+++ b/ansible/roles/all/tasks/main.yaml
@@ -5,7 +5,6 @@
 - name: detect SSH pipelining support
   shell: grep --extended-regexp "^\w+\s+requiretty" /etc/sudoers || echo "string not found"
   register: requiretty
-  changed_when: False
 
 - name: enable SSH pipelining
   set_fact:

--- a/ansible/roles/preflight/tasks/main.yaml
+++ b/ansible/roles/preflight/tasks/main.yaml
@@ -1,13 +1,11 @@
 ---
   - name: verify hostname
     fail: msg="provided hostname does not match reported hostname of {{ ansible_nodename }}"
-    when: "ansible_nodename not in [ inventory_hostname, inventory_hostname_short ]"
-    changed_when: false
+    failed_when: "ansible_nodename not in [ inventory_hostname, inventory_hostname_short ]"
 
   - name: verify systemd
     fail: msg="systemd is required"
-    when: ansible_service_mgr != "systemd"
-    changed_when: false
+    failed_when: ansible_service_mgr != "systemd"
 
   # kubernetes checks /proc/swaps lines > 1
   - name: list memory swaps in /proc/swaps


### PR DESCRIPTION
Print `[OK]` instead of `[SKIPPED]`
This PR only impacts the 2 tasks below
```
Run Cluster Pre-Flight Checks
- Running task: verify hostname
  worker001                                                                     [OK]
  master001                                                                     [OK]
  etcd001                                                                       [OK]
- Running task: verify systemd
  worker001                                                                     [OK]
  master001                                                                     [OK]
  etcd001                                                                       [OK]
```