### PR TITLE
Upgrading to CoreDNS 1.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ KET operational tools include:
 | Weave | v2.1.3 |
 | Contiv | v1.1.1 |
 |NGINX Ingress Controller|v0.9.0|
+|CoreDNS|v1.0.5|
 
 
 [Download KET here](https://github.com/apprenda/kismatic/releases)

--- a/ansible/group_vars/container_images.yaml
+++ b/ansible/group_vars/container_images.yaml
@@ -67,7 +67,7 @@ official_images:
     version: 1.14.8
   coredns:
     name: coredns/coredns
-    version: 1.0.4
+    version: 1.0.5
   kubernetes_dashboard:
     name: gcr.io/google_containers/kubernetes-dashboard-amd64
     version: v1.8.2


### PR DESCRIPTION
Closes #1092  

For more information see https://coredns.io/2018/01/25/coredns-1.0.5-release/ 