### PR TITLE
Fix seed-registry command to support configurable cluster version

### DIFF
--- a/integration-tests/disconnected_install.go
+++ b/integration-tests/disconnected_install.go
@@ -61,8 +61,9 @@ func seedRegistry(repoNode NodeDeets, registryCAFile string, registryPort int, s
 	start := time.Now()
 	cmds = []string{
 		fmt.Sprintf("sudo docker login -u kismaticuser -p kismaticpassword %s", registry),
-		"sudo tar -xf /tmp/kismatic.tar.gz",
-		fmt.Sprintf("sudo ./kismatic seed-registry --server %s", registry),
+		"sudo mkdir kismatic",
+		"sudo tar -xf /tmp/kismatic.tar.gz -C kismatic",
+		fmt.Sprintf("sudo ./kismatic/kismatic seed-registry --server %s", registry),
 	}
 	err = runViaSSH(cmds, []NodeDeets{repoNode}, sshKey, 60*time.Minute)
 	if err != nil {

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -777,3 +777,17 @@ func (p Plan) NetworkConfigured() bool {
 	// CNI disabled or "custom" return false
 	return p.AddOns.CNI == nil || (!p.AddOns.CNI.Disable && p.AddOns.CNI.Provider != "custom")
 }
+
+func (p Plan) Versions() map[string]string {
+	kubernetesVersion := kubernetesVersionString
+	if p.Cluster.Version != "" {
+		kubernetesVersion = p.Cluster.Version
+	}
+	versions := make(map[string]string)
+	versions["kube_proxy"] = kubernetesVersion
+	versions["kube_controller_manager"] = kubernetesVersion
+	versions["kube_scheduler"] = kubernetesVersion
+	versions["kube_apiserver"] = kubernetesVersion
+
+	return versions
+}

--- a/pkg/install/version.go
+++ b/pkg/install/version.go
@@ -67,3 +67,14 @@ func kubernetesLatestStableVersion() (semver.Version, string, error) {
 func kubernetesVersionValid(version string) bool {
 	return kubeReleaseRegex.MatchString(version)
 }
+
+// VersionOverrides returns a map of all image names and their versions that can be modified by the user
+func VersionOverrides() map[string]string {
+	versions := make(map[string]string, 0)
+	versions["kube_proxy"] = kubernetesVersionString
+	versions["kube_controller_manager"] = kubernetesVersionString
+	versions["kube_scheduler"] = kubernetesVersionString
+	versions["kube_apiserver"] = kubernetesVersionString
+
+	return versions
+}


### PR DESCRIPTION
Integration tests were failing trying to seed-registry.

The `seed-registry` command needs to read the `container_images.yaml`([link](https://github.com/apprenda/kismatic/blob/seed-registry/ansible/group_vars/container_images.yaml#L15)) file that now contains version overrides,  the command needed modification to use default versions or try to read the versions from the plan file.