### PR TITLE
Copy inspector on all nodes prior to running preflight.

### DIFF
--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -343,9 +343,20 @@ func (ae *ansibleExecutor) RunNewNodePreFlightCheck(p Plan, node Node) error {
 	if err != nil {
 		return err
 	}
+	t := task{
+		name:           "copy-inspector",
+		playbook:       "copy-inspector.yaml",
+		inventory:      buildInventoryFromPlan(&p),
+		clusterCatalog: *cc,
+		explainer:      ae.preflightExplainer(),
+		plan:           p,
+	}
+	if err := ae.execute(t); err != nil {
+		return err
+	}
 	p.Worker.ExpectedCount++
 	p.Worker.Nodes = append(p.Worker.Nodes, node)
-	t := task{
+	t = task{
 		name:           "add-node-preflight",
 		playbook:       "preflight.yaml",
 		inventory:      buildInventoryFromPlan(&p),


### PR DESCRIPTION
Actually fixes https://github.com/apprenda/kismatic/issues/918

This was fixed in a previous PR but was unintentionally reverted during a merge.