### PR TITLE
Remove kube-apiserver insecure port

### DIFF
--- a/ansible/_kube-control-plane-stop.yaml
+++ b/ansible/_kube-control-plane-stop.yaml
@@ -21,7 +21,7 @@
         when: pod_stat is defined and pod_stat.stat.exists
       - name: wait until kube-apiserver is stopped
         wait_for:
-          port: "{{ kubernetes_master_insecure_port }}"
+          port: "{{ kubernetes_master_secure_port }}"
           state: stopped
           delay: 1
           timeout: 30

--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -17,7 +17,6 @@ bin_dir: /usr/bin
 etcd_k8s_client_port: 2379
 etcd_networking_client_port: 6666
 kubernetes_master_secure_port: 6443
-kubernetes_master_insecure_port: 8080
 kubernetes_proxy_insecure_port: 10256
 kubernetes_scheduler_insecure_port: 10251
 kubernetes_controller_mgr_insecure_port: 10252
@@ -151,7 +150,6 @@ kubernetes_api_server_option_defaults:
   "advertise-address": "{{ internal_ipv4 }}"
   "allow-privileged": "true"
   "apiserver-count": "{{ kubernetes_master_apiserver_count }}"
-  "anonymous-auth": "false"
   "authorization-mode": "Node,RBAC{% if kubernetes_admin_password is defined and kubernetes_admin_password != '' %},ABAC{% endif %}" #TODO remove ABAC
   "authorization-policy-file": "{% if kubernetes_admin_password is defined and kubernetes_admin_password != '' %}{{ kubernetes_authorization_policy_path }}{% endif %}"
   "basic-auth-file": "{% if kubernetes_admin_password is defined and kubernetes_admin_password != '' %}{{ kubernetes_basic_auth_path }}{% endif %}"
@@ -173,8 +171,7 @@ kubernetes_api_server_option_defaults:
   "etcd-certfile": "{{ kubernetes_certificates.etcd_client }}"
   "etcd-keyfile": "{{ kubernetes_certificates.etcd_client_key }}"
   "etcd-servers": "{{ etcd_k8s_cluster_ip_list }}"
-  "insecure-bind-address": "127.0.0.1"
-  "insecure-port": "{{ kubernetes_master_insecure_port }}"
+  "insecure-port": "0"
   "kubelet-preferred-address-types": "{% if modify_hosts_file is defined and modify_hosts_file|bool == true %}InternalIP,ExternalIP,Hostname{% endif %}"
   "runtime-config": "extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true"
   "secure-port": "{{ kubernetes_master_secure_port }}"
@@ -325,9 +322,6 @@ kubernetes_deb_repository_url: "https://packages.cloud.google.com/apt/"
 kubernetes_deb_gpg_key_url: "https://packages.cloud.google.com/apt/doc/apt-key.gpg"
 
 #===============================================================================
-
-# Preflight check variables
-preflight_check_tcp_ports: "{{etcd_k8s_client_port}},{{etcd_networking_client_port}},{{kubernetes_master_secure_port}},{{kubernetes_master_insecure_port}}"
 
 # Gluster
 volume_mount: /

--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.yaml
@@ -28,9 +28,6 @@ spec:
     - containerPort: {{ kubernetes_master_secure_port }}
       hostPort: {{ kubernetes_master_secure_port }}
       name: https
-    - containerPort: {{ kubernetes_master_insecure_port }}
-      hostPort: {{ kubernetes_master_insecure_port }}
-      name: local
     volumeMounts:
     - mountPath: /etc/kubernetes
       name: ssl-certs-kubernetes
@@ -50,7 +47,8 @@ spec:
       httpGet:
         host: 127.0.0.1
         path: /healthz
-        port: {{ kubernetes_master_insecure_port }}
+        port: {{ kubernetes_master_secure_port }}
+        scheme: HTTPS
       initialDelaySeconds: 15
       timeoutSeconds: 15
       failureThreshold: 8

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -103,11 +103,6 @@ const defaultRuleSet = `---
   - ["master"]
   port: 6443
   procName: kube-apiserver
-- kind: TCPPortAvailable
-  when: 
-  - ["master"]
-  port: 8080
-  procName: kube-apiserver
 # kube-scheduler
 - kind: TCPPortAvailable
   when: 
@@ -122,7 +117,6 @@ const defaultRuleSet = `---
   procName: kube-controller
 
 # Ports used by K8s master are accessible
-# Port 8080 is not accessible from outside
 - kind: TCPPortAccessible
   when: 
   - ["master"]

--- a/pkg/inspector/rule/rule_test.go
+++ b/pkg/inspector/rule/rule_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestDefaultRules(t *testing.T) {
 	// This will panic if there are errors in the default rule
 	rules := DefaultRules(map[string]string{"kubernetes_yum_version": "1.9.3-0", "kubernetes_deb_version": "1.9.3-00"})
-	if len(rules) != 77 {
-		t.Errorf("expected to have %d rules, instead got %d", 77, len(rules))
+	if len(rules) != 76 {
+		t.Errorf("expected to have %d rules, instead got %d", 76, len(rules))
 	}
 	for _, r := range rules {
 		if errs := r.Validate(); len(errs) != 0 {

--- a/pkg/install/kube_api_server_options.go
+++ b/pkg/install/kube_api_server_options.go
@@ -15,7 +15,6 @@ var kubeAPIServerProtectedOptions = []string{
 	"etcd-certfile",
 	"etcd-keyfile",
 	"etcd-servers",
-	"insecure-port",
 	"secure-port",
 	"service-account-key-file",
 	"service-cluster-ip-range",


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/1134

**Note** `"anonymous-auth": "false"` was removed from the `kube-apiserver`, this is safe as in Kubernetes 1.6+ the behavior was changed for each Auth method to explicitly grant access to the `system:unauthenticated` group.

This changed was required for apiserver liveliness probes to function correctly, this is also how `kubeadm` and `kops` do their deployment.

With RBAC this group will only have `get` access to some `nonResourceURLs`.

```
- apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRole
  metadata:
    annotations:
      rbac.authorization.kubernetes.io/autoupdate: "true"
    creationTimestamp: 2018-02-27T13:46:56Z
    labels:
      kubernetes.io/bootstrapping: rbac-defaults
    name: system:discovery
    namespace: ""
    resourceVersion: "37"
    selfLink: /apis/rbac.authorization.k8s.io/v1/clusterroles/system%3Adiscovery
    uid: acda7bce-1bc4-11e8-ba35-080027c30a85
  rules:
  - nonResourceURLs:
    - /api
    - /api/*
    - /apis
    - /apis/*
    - /healthz
    - /swagger-2.0.0.pb-v1
    - /swagger.json
    - /swaggerapi
    - /swaggerapi/*
    - /version
    verbs:
    - get
---
- apiVersion: rbac.authorization.k8s.io/v1
  kind: ClusterRoleBinding
  metadata:
    annotations:
      rbac.authorization.kubernetes.io/autoupdate: "true"
    creationTimestamp: 2018-02-27T13:46:56Z
    labels:
      kubernetes.io/bootstrapping: rbac-defaults
    name: system:discovery
    namespace: ""
    resourceVersion: "83"
    selfLink: /apis/rbac.authorization.k8s.io/v1/clusterrolebindings/system%3Adiscovery
    uid: ad03e232-1bc4-11e8-ba35-080027c30a85
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
    name: system:discovery
  subjects:
  - apiGroup: rbac.authorization.k8s.io
    kind: Group
    name: system:authenticated
  - apiGroup: rbac.authorization.k8s.io
    kind: Group
    name: system:unauthenticated
``` 