### PR TITLE
Mount kubeconfig file into the resheduler pod

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -99,6 +99,7 @@ kubernetes_kubeconfig:
   controller_manager: "{{kubernetes_install_dir}}/controller-manager.conf"
   scheduler: "{{kubernetes_install_dir}}/scheduler.conf"
   kubelet: "{{kubernetes_install_dir}}/kubelet.conf"
+  rescheduler: "{{kubernetes_install_dir}}/rescheduler.conf"
 
 # file modes
 kubernetes_executable_mode: "0775"

--- a/ansible/roles/rescheduler/tasks/main.yaml
+++ b/ansible/roles/rescheduler/tasks/main.yaml
@@ -1,3 +1,11 @@
+  - name: copy rescheduler kubeconfig
+    template:
+      src: kubeconfig.j2
+      dest: "{{ kubernetes_kubeconfig.rescheduler }}"
+      owner: "{{ kubernetes_owner }}"
+      group: "{{ kubernetes_group }}"
+      mode: "{{ kubernetes_service_mode }}"
+
   - name: copy rescheduler.yaml manifest
     template:
       src: rescheduler.yaml

--- a/ansible/roles/rescheduler/templates/kubeconfig.j2
+++ b/ansible/roles/rescheduler/templates/kubeconfig.j2
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Config
+clusters:
+- name: {{ kubernetes_cluster_name }}
+  cluster:
+    certificate-authority: {{ kubernetes_certificates.ca }}
+    server: "{% if 'master' in group_names %}{{ local_kubernetes_master_ip }}{% else %}{{ kubernetes_master_ip }}{% endif %}" 
+users:
+- name: admin
+  user:
+    client-certificate: "{{ kubernetes_certificates.admin }}"
+    client-key: "{{ kubernetes_certificates.admin_key }}"
+contexts:
+- name: kubernetes
+  context:
+    cluster: {{ kubernetes_cluster_name }}
+    user: admin
+current-context: kubernetes

--- a/ansible/roles/rescheduler/templates/rescheduler.yaml
+++ b/ansible/roles/rescheduler/templates/rescheduler.yaml
@@ -22,5 +22,20 @@ spec:
         cpu: 10m
         memory: 100Mi
     command:
+    command:
     - /rescheduler 
     - --running-in-cluster=false
+    volumeMounts:
+      - mountPath: "/root/.kube/config"
+        name: "kubeconfig"
+        readOnly: true
+      - mountPath: /etc/kubernetes
+        name: ssl-certs-kubernetes
+        readOnly: true
+  volumes:
+    - name: "kubeconfig"
+      hostPath:
+        path: "{{ kubernetes_kubeconfig.rescheduler }}"
+    - hostPath:
+        path: /etc/kubernetes
+      name: ssl-certs-kubernetes


### PR DESCRIPTION
Fixes #1167 

Fixes the pod trying to connect to the API via port 8080.
Could not use in-cluster config as when running a static pod the serviceaccount certs were not properly mounted. 