### PR TITLE
Add option "replicas" to cluster dns

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -118,7 +118,6 @@ kubernetes_master_apiserver_count: "{{ groups['master'] | length }}"
 local_kubernetes_master_ip: https://127.0.0.1:{{ kubernetes_master_secure_port }}
 kubernetes_master_ip: https://{{ kubernetes_load_balanced_fqdn }}:{{ kubernetes_master_secure_port }}
 kubernetes_schedulable: "{% if 'worker' in group_names %}true{% else %}false{% endif %}"
-cluster_dns_replicas: "{{ [2, groups['worker'] | length] | min }}"
 # cloud provider
 cloud_config: "{% if cloud_config_local is defined and cloud_config_local != '' %}{{ kubernetes_install_dir }}/cloud-provider.conf{% else %}{% endif %}"
 

--- a/ansible/roles/coredns/tasks/main.yaml
+++ b/ansible/roles/coredns/tasks/main.yaml
@@ -15,7 +15,7 @@
     - name: wait up to 5 minutes until DNS pods are ready
       command: kubectl --kubeconfig {{ kubernetes_kubeconfig.kubectl }} get deployment coredns -n kube-system -o jsonpath='{.status.availableReplicas}'
       register: readyReplicas
-      until: readyReplicas.stdout|int == cluster_dns_replicas|int
+      until: readyReplicas.stdout|int == dns.options.replicas|int
       retries: 30
       delay: 10
       failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
@@ -27,7 +27,7 @@
         kubectl get pods -n kube-system -l k8s-app=coredns 
         --no-headers -o custom-columns=name:{.metadata.name},status:{.status.phase} | grep -v "Running" | head -n 1 | cut -d " " -f 1
       register: failedDNSPodNames
-      when: readyReplicas.stdout|int != cluster_dns_replicas|int
+      when: readyReplicas.stdout|int != dns.options.replicas|int
 
     - name: get the logs of the first DNS pod that did not start up in time
       command: kubectl --kubeconfig {{ kubernetes_kubeconfig.kubectl }} logs -n kube-system {{ failedDNSPodNames.stdout_lines[0] }} --tail 15
@@ -43,5 +43,5 @@
 
           {{ failedDNSPodLogs.stdout }}
 
-      when: readyReplicas.stdout|int != cluster_dns_replicas|int
+      when: readyReplicas.stdout|int != dns.options.replicas|int
     when: run_pod_validation|bool == true 

--- a/ansible/roles/coredns/templates/coredns.yaml
+++ b/ansible/roles/coredns/templates/coredns.yaml
@@ -69,7 +69,7 @@ metadata:
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
 spec:
-  replicas: {{ cluster_dns_replicas|int }}  # create 2 replicas or the number of worker nodes
+  replicas: {{ dns.options.replicas|int }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/ansible/roles/kube-dns/tasks/main.yaml
+++ b/ansible/roles/kube-dns/tasks/main.yaml
@@ -15,7 +15,7 @@
     - name: wait up to 5 minutes until DNS pods are ready
       command: kubectl --kubeconfig {{ kubernetes_kubeconfig.kubectl }} get deployment kube-dns -n kube-system -o jsonpath='{.status.availableReplicas}'
       register: readyReplicas
-      until: readyReplicas.stdout|int == cluster_dns_replicas|int
+      until: readyReplicas.stdout|int == dns.options.replicas|int
       retries: 30
       delay: 10
       failed_when: false # We don't want this task to actually fail (We catch the failure with a custom msg in the next task)
@@ -39,7 +39,7 @@
         kubectl get pods -n kube-system -l k8s-app=kube-dns 
         --no-headers -o custom-columns=name:{.metadata.name},status:{.status.phase} | grep -v "Running" | head -n 1 | cut -d " " -f 1
       register: failedDNSPodNames
-      when: readyReplicas.stdout|int != cluster_dns_replicas|int
+      when: readyReplicas.stdout|int != dns.options.replicas|int
 
     - name: fail if DNS pod validation command could not determine the broken pod
       fail:
@@ -61,5 +61,5 @@
 
           {{ failedDNSPodLogs.stdout }}
 
-      when: "'stdout' in failedDNSPodLogs and readyReplicas.stdout|int != cluster_dns_replicas|int"
+      when: "'stdout' in failedDNSPodLogs and readyReplicas.stdout|int != dns.options.replicas|int"
     when: run_pod_validation|bool == true 

--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -55,7 +55,7 @@ metadata:
   annotations:
     kismatic/version: "{{ kismatic_short_version }}"
 spec:
-  replicas: {{ cluster_dns_replicas|int }}  # create 2 replicas or the number of worker nodes
+  replicas: {{ dns.options.replicas|int }}
   strategy:
     rollingUpdate:
       maxSurge: 1

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -79,6 +79,8 @@
   * [dns](#add_onsdns)
     * [disable](#add_onsdnsdisable)
     * [provider](#add_onsdnsprovider)
+    * [options](#add_onsdnsoptions)
+      * [replicas](#add_onsdnsoptionsreplicas)
   * [heapster](#add_onsheapster)
     * [disable](#add_onsheapsterdisable)
     * [options](#add_onsheapsteroptions)
@@ -815,6 +817,20 @@
 | **Required** |  Yes |
 | **Default** | `kubedns` | 
 | **Options** |  `kubedns`, `coredns`
+
+###  add_ons.dns.options
+
+ The options that can be configured for the cluster DNS add-on 
+
+###  add_ons.dns.options.replicas
+
+ Number of cluster DNS replicas that should be scheduled on the cluster. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  int |
+| **Required** |  No |
+| **Default** | `2` | 
 
 ###  add_ons.heapster
 

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -99,6 +99,9 @@ type ClusterCatalog struct {
 	DNS struct {
 		Enabled  bool
 		Provider string
+		Options  struct {
+			Replicas int
+		}
 	}
 
 	RunPodValidation bool `yaml:"run_pod_validation"`

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -781,6 +781,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	// DNS
 	cc.DNS.Enabled = !p.AddOns.DNS.Disable
 	cc.DNS.Provider = p.AddOns.DNS.Provider
+	cc.DNS.Options.Replicas = p.AddOns.DNS.Options.Replicas
 
 	// heapster
 	if p.AddOns.HeapsterMonitoring != nil && !p.AddOns.HeapsterMonitoring.Disable {

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -180,6 +180,9 @@ func setDefaults(p *Plan) {
 	if p.AddOns.DNS.Provider == "" {
 		p.AddOns.DNS.Provider = "kubedns"
 	}
+	if p.AddOns.DNS.Options.Replicas <= 0 {
+		p.AddOns.DNS.Options.Replicas = 2
+	}
 
 	if p.AddOns.HeapsterMonitoring == nil {
 		p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
@@ -389,6 +392,7 @@ func buildPlanFromTemplateOptions(templateOpts PlanTemplateOptions) Plan {
 	p.AddOns.CNI.Options.Calico.IPAutodetectionMethod = "first-found"
 	// DNS
 	p.AddOns.DNS.Provider = "kubedns"
+	p.AddOns.DNS.Options.Replicas = 2
 	// Heapster
 	p.AddOns.HeapsterMonitoring = &HeapsterMonitoring{}
 	p.AddOns.HeapsterMonitoring.Options.Heapster.Replicas = 2

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -434,6 +434,14 @@ type DNS struct {
 	// +options=kubedns,coredns
 	// +default=kubedns
 	Provider string
+	// The options that can be configured for the cluster DNS add-on
+	Options DNSOptions
+}
+
+type DNSOptions struct {
+	// Number of cluster DNS replicas that should be scheduled on the cluster.
+	// +default=2
+	Replicas int
 }
 
 // The HeapsterMonitoring add-on configuration

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -170,6 +170,8 @@ add_ons:
 
     # Options: 'kubedns','coredns'.
     provider: kubedns
+    options:
+      replicas: 2
 
   heapster:
     disable: false

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -170,6 +170,8 @@ add_ons:
 
     # Options: 'kubedns','coredns'.
     provider: kubedns
+    options:
+      replicas: 2
 
   heapster:
     disable: false


### PR DESCRIPTION
Fixes #1160 

New `replicas` option
```
  dns:
    disable: false

    # Options: 'kubedns','coredns'.
    provider: kubedns
    options:
      replicas: 2
```