### PR TITLE
Set kubelet-certificate-authority on the API server

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -174,6 +174,7 @@ kubernetes_api_server_option_defaults:
   "etcd-keyfile": "{{ kubernetes_certificates.etcd_client_key }}"
   "etcd-servers": "{{ etcd_k8s_cluster_ip_list }}"
   "insecure-port": "0"
+  "kubelet-certificate-authority": "{{ kubernetes_certificates.ca }}"
   "kubelet-client-certificate": "{{ kubernetes_certificates.kube_apiserver_kubelet_client }}"
   "kubelet-client-key": "{{ kubernetes_certificates.kube_apiserver_kubelet_client_key }}"
   "kubelet-preferred-address-types": "{% if modify_hosts_file is defined and modify_hosts_file|bool == true %}InternalIP,ExternalIP,Hostname{% endif %}"

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -687,7 +687,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	cc.Versions.KubernetesYum = p.Cluster.Version[1:] + "-0"
 	cc.Versions.KubernetesDeb = p.Cluster.Version[1:] + "-00"
 
-	cc.NoProxy = p.AllAddresses()
+	cc.NoProxy = strings.Join(p.AllAddresses(), ",")
 	if p.Cluster.Networking.NoProxy != "" {
 		cc.NoProxy = cc.NoProxy + "," + p.Cluster.Networking.NoProxy
 	}

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -622,6 +622,18 @@ func (node Node) HashCode() string {
 	return fmt.Sprint(node.Host, node.IP, node.InternalIP)
 }
 
+// KubeletAddresses returns the host and the internalIP
+// If no internalIP is provided, IP will be be returned instead
+func (node Node) KubeletAddresses() []string {
+	addr := []string{node.Host}
+	if node.InternalIP != "" {
+		addr = append(addr, node.InternalIP)
+	} else {
+		addr = append(addr, node.IP)
+	}
+	return addr
+}
+
 type NFS struct {
 	// List of NFS volumes that should be attached to the cluster during
 	// the installation.
@@ -706,7 +718,7 @@ func (p *Plan) getNodeWithIP(ip string) (*Node, error) {
 }
 
 // AllAddresses will return the hostnames, IPs and internal IPs for all nodes
-func (p *Plan) AllAddresses() string {
+func (p *Plan) AllAddresses() []string {
 	nodes := p.GetUniqueNodes()
 	var addr []string
 	for _, n := range nodes {
@@ -716,7 +728,7 @@ func (p *Plan) AllAddresses() string {
 			addr = append(addr, n.InternalIP)
 		}
 	}
-	return strings.Join(addr, ",")
+	return addr
 }
 
 func (p *Plan) ValidRole(role string) bool {
@@ -937,11 +949,12 @@ func (node Node) certSpecs(plan Plan, ca *tls.CA) ([]certificateSpec, error) {
 	// Kubelet and etcd client certificate
 	if containsAny([]string{"master", "worker", "ingress", "storage"}, roles) {
 		m = append(m, certificateSpec{
-			description:   fmt.Sprintf("%s kubelet", node.Host),
-			filename:      fmt.Sprintf("%s-kubelet", node.Host),
-			commonName:    fmt.Sprintf("%s:%s", kubeletUserPrefix, strings.ToLower(node.Host)),
-			organizations: []string{kubeletGroup},
-			ca:            ca,
+			description:           fmt.Sprintf("%s kubelet", node.Host),
+			filename:              fmt.Sprintf("%s-kubelet", node.Host),
+			commonName:            fmt.Sprintf("%s:%s", kubeletUserPrefix, strings.ToLower(node.Host)),
+			subjectAlternateNames: node.KubeletAddresses(),
+			organizations:         []string{kubeletGroup},
+			ca:                    ca,
 		})
 
 		// etcd client certificate


### PR DESCRIPTION
Fixes #1178 

This requires the kubelet certs to have valid IP and hostname.
During upgrades the kubelet certs will need to be regenerated, there will be a warning if they are not:
```
Configuring Certificates============================================================
Found valid certificate for etcd001 etcd server                                 [OK]
Found valid certificate for master001 API server                                [OK]
Found valid certificate for kubernetes controller manager                       [OK]
Found valid certificate for kubernetes scheduler                                [OK]
Found valid certificate for service account signing                             [OK]
Found certificate for master001 kubelet, but it is not valid                    [ERROR]
- Certificate "master001-kubelet.pem": SANs validation failed
    expected:
	[192.168.42.3 master001]
    instead got:
	[]
error generating certificates for the cluster: invalid certificate found for "master001 kubelet"
```