### PR TITLE
Upgrade validation

### DIFF
--- a/pkg/data/kubernetes_type.go
+++ b/pkg/data/kubernetes_type.go
@@ -10,11 +10,22 @@ type Pod struct {
 }
 
 type ObjectMeta struct {
-	Annotations map[string]string `json:"annotations,omitempty"`
-	Name        string            `json:"name,omitempty"`
-	Namespace   string            `json:"namespace,omitempty"`
-	Labels      map[string]string `json:"labels,omitempty"`
+	Annotations     map[string]string `json:"annotations,omitempty"`
+	Name            string            `json:"name,omitempty"`
+	Namespace       string            `json:"namespace,omitempty"`
+	Labels          map[string]string `json:"labels,omitempty"`
+	OwnerReferences []OwnerReference  `json:"ownerReferences,omitempty"`
 }
+
+type OwnerReference struct {
+	APIVersion string `json:"apiVersion"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	UID        UID    `json:"uid"`
+	Controller bool   `json:"controller"`
+}
+
+type UID string
 
 // ObjectReference contains enough information to let you inspect or modify the referred object.
 type ObjectReference struct {

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -41,13 +41,13 @@ func (e masterNodeLoadBalancingErr) Error() string {
 type ingressNotSupportedErr struct{}
 
 func (e ingressNotSupportedErr) Error() string {
-	return "Upgrading this node may result in storage volumes becoming temporarily unavailable."
+	return "Upgrading this node may result in service unavailability if clients are accessing services directly through this ingress point."
 }
 
 type storageNotSupportedErr struct{}
 
 func (e storageNotSupportedErr) Error() string {
-	return "Upgrading this node may result in service unavailability if clients are accessing services directly through this ingress point."
+	return "Upgrading this node may result in storage volumes becoming temporarily unavailable."
 }
 
 type workerNodeCountErr struct{}

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -179,7 +179,8 @@ func detectWorkerNodeUpgradeSafety(node Node, kubeClient upgradeKubeInfoClient) 
 	}
 	nodePods := []data.Pod{}
 	for _, p := range podList.Items {
-		if p.Spec.NodeName == node.Host {
+		// Don't check pods that are running in "kube-system" namespace
+		if p.Spec.NodeName == node.Host && p.Namespace != "kube-system" {
 			nodePods = append(nodePods, p)
 		}
 	}

--- a/pkg/install/upgrade.go
+++ b/pkg/install/upgrade.go
@@ -1,14 +1,11 @@
 package install
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 
 	"github.com/apprenda/kismatic/pkg/data"
 )
-
-const kubeCreatedBy = "kubernetes.io/created-by"
 
 type upgradeKubeInfoClient interface {
 	data.PodLister
@@ -229,66 +226,64 @@ func detectWorkerNodeUpgradeSafety(node Node, kubeClient upgradeKubeInfoClient) 
 	//    verify that it is not the only one
 	// 4. Are there any pods that belong to a job running on this node?
 	for _, p := range nodePods {
-		creator, ok := p.Annotations[kubeCreatedBy]
-		if !ok {
+		if len(p.ObjectMeta.OwnerReferences) == 0 {
 			errs = append(errs, unmanagedPodErr{namespace: p.Namespace, name: p.Name})
 			continue
 		}
-		var r data.SerializedReference
-		err := json.Unmarshal([]byte(creator), &r)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("Unable to determine the creator of pod %s/%s", p.Namespace, p.Name))
+		owner := p.ObjectMeta.OwnerReferences[0]
+		if owner.Kind == "" || owner.Name == "" {
+			errs = append(errs, fmt.Errorf("Unable to determine the owner of pod %s/%s", p.Namespace, p.Name))
 			continue
 		}
-		switch strings.ToLower(r.Reference.Kind) {
+		switch strings.ToLower(owner.Kind) {
 		default:
-			errs = append(errs, fmt.Errorf("Unable to determine upgrade safety for a pod managed by a controller of type %q", r.Reference.Kind))
+			errs = append(errs, fmt.Errorf("Unable to determine upgrade safety for a pod managed by a controller of type %q", owner.Kind))
 		case "daemonset":
-			ds, err := kubeClient.GetDaemonSet(r.Reference.Namespace, r.Reference.Name)
+			ds, err := kubeClient.GetDaemonSet(p.Namespace, owner.Name)
 			if err != nil || ds == nil {
-				errs = append(errs, fmt.Errorf("Failed to get information about DaemonSet %s/%s", r.Reference.Namespace, r.Reference.Name))
+				errs = append(errs, fmt.Errorf("Failed to get information about DaemonSet %s/%s", p.Namespace, owner.Name))
 				continue
 			}
 			// Check if other nodes should be running this DS
 			if ds.Status.DesiredNumberScheduled < 2 {
-				errs = append(errs, podUnsafeDaemonErr{dsNamespace: r.Reference.Namespace, dsName: r.Reference.Name})
+				errs = append(errs, podUnsafeDaemonErr{dsNamespace: p.Namespace, dsName: owner.Name})
 			}
 		case "job":
-			errs = append(errs, podRunningJobErr{namespace: r.Reference.Namespace, name: r.Reference.Name})
+			errs = append(errs, podRunningJobErr{namespace: p.Namespace, name: owner.Name})
 		case "replicationcontroller":
-			rc, err := kubeClient.GetReplicationController(r.Reference.Namespace, r.Reference.Name)
+			rc, err := kubeClient.GetReplicationController(p.Namespace, owner.Name)
 			if err != nil || rc == nil {
-				errs = append(errs, fmt.Errorf(`Failed to get information about ReplicationController "%s/%s"`, r.Reference.Namespace, r.Reference.Name))
+				errs = append(errs, fmt.Errorf(`Failed to get information about ReplicationController "%s/%s"`, p.Namespace, owner.Name))
 				continue
 			}
 			if rc.Status.Replicas < 2 {
-				errs = append(errs, unsafeReplicaCountErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+				errs = append(errs, unsafeReplicaCountErr{kind: owner.Kind, namespace: p.Namespace, name: owner.Name})
 			}
-			rcPods[r.Reference.Namespace+r.Reference.Name]++
-			if rcPods[r.Reference.Namespace+r.Reference.Name] == rc.Status.Replicas {
-				errs = append(errs, replicasOnSingleNodeErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+			rcPods[p.Namespace+owner.Name]++
+			if rcPods[p.Namespace+owner.Name] == rc.Status.Replicas {
+				errs = append(errs, replicasOnSingleNodeErr{kind: owner.Kind, namespace: p.Namespace, name: owner.Name})
 			}
 		case "replicaset":
-			rs, err := kubeClient.GetReplicaSet(r.Reference.Namespace, r.Reference.Name)
+			rs, err := kubeClient.GetReplicaSet(p.Namespace, owner.Name)
 			if err != nil || rs == nil {
-				errs = append(errs, fmt.Errorf(`Failed to get information about ReplicaSet "%s/%s"`, r.Reference.Namespace, r.Reference.Name))
+				errs = append(errs, fmt.Errorf(`Failed to get information about ReplicaSet "%s/%s"`, p.Namespace, owner.Name))
 				continue
 			}
 			if rs.Status.Replicas < 2 {
-				errs = append(errs, unsafeReplicaCountErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+				errs = append(errs, unsafeReplicaCountErr{kind: owner.Kind, namespace: p.Namespace, name: owner.Name})
 			}
-			rsPods[r.Reference.Namespace+r.Reference.Name]++
-			if rsPods[r.Reference.Namespace+r.Reference.Name] == rs.Status.Replicas {
-				errs = append(errs, replicasOnSingleNodeErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+			rsPods[p.Namespace+owner.Name]++
+			if rsPods[p.Namespace+owner.Name] == rs.Status.Replicas {
+				errs = append(errs, replicasOnSingleNodeErr{kind: owner.Kind, namespace: p.Namespace, name: owner.Name})
 			}
 		case "statefulset":
-			sts, err := kubeClient.GetStatefulSet(r.Reference.Namespace, r.Reference.Name)
+			sts, err := kubeClient.GetStatefulSet(p.Namespace, owner.Name)
 			if err != nil || sts == nil {
-				errs = append(errs, fmt.Errorf(`Failed to get information about StatefulSet "%s/%s"`, r.Reference.Namespace, r.Reference.Name))
+				errs = append(errs, fmt.Errorf(`Failed to get information about StatefulSet "%s/%s"`, p.Namespace, owner.Name))
 				continue
 			}
 			if sts.Status.Replicas < 2 {
-				errs = append(errs, unsafeReplicaCountErr{kind: r.Reference.Kind, namespace: r.Reference.Namespace, name: r.Reference.Name})
+				errs = append(errs, unsafeReplicaCountErr{kind: owner.Kind, namespace: p.Namespace, name: owner.Name})
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #1104 

* Fixes an issue where the owner of a pod was not being properly retrieved:
```
The pod "kube-system/default-http-backend-d2g5x" is not being managed by a controller
```
* Fixes an issue where resources deployed by the tool were reporting errors, to fix this any pod in `kube-system` namespace will be removed:
```
Validate Online Upgrade=============================================================
etcd001 [etcd]                                                                  [ERROR]
- This node is part of an etcd cluster that has less than 3 members. Upgrading it may make the cluster unavailable.
master001 [master]                                                              [ERROR]
- This is the only master node in the cluster. Upgrading it may make the cluster unavailable.
- This node is acting as the load balanced endpoint for the master nodes. Upgrading it may make the cluster unavailable
worker001 [worker ingress]                                                      [ERROR]
- This is the only worker node in the cluster. Upgrading it may make cluster features unavailable.
- Pod "kube-system/calico-kube-controllers-cc54bd575-kk6c2" is using HostPath volume "ca", which is unsafe for upgrades.
- Pod "kube-system/calico-kube-controllers-cc54bd575-kk6c2" is using HostPath volume "cert", which is unsafe for upgrades.
- Pod "kube-system/calico-kube-controllers-cc54bd575-kk6c2" is using HostPath volume "key", which is unsafe for upgrades.
- Pod "kube-system/calico-node-jsvxq" is using HostPath volume "lib-modules", which is unsafe for upgrades.
- Pod "kube-system/calico-node-jsvxq" is using HostPath volume "var-run-calico", which is unsafe for upgrades.
- Pod "kube-system/calico-node-jsvxq" is using HostPath volume "cni-bin-dir", which is unsafe for upgrades.
- Pod "kube-system/calico-node-jsvxq" is using HostPath volume "cni-net-dir", which is unsafe for upgrades.
- Pod "kube-system/calico-node-jsvxq" is using HostPath volume "etcd-certs", which is unsafe for upgrades.
- Pod "kube-system/heapster-influxdb-6c4b84d695-2jn88" is using EmptyDir volume "influxdb-storage", which is unsafe for upgrades.
- Pod "kube-system/kube-proxy-ntqxh" is using HostPath volume "varlog", which is unsafe for upgrades.
- Pod "kube-system/kube-proxy-ntqxh" is using HostPath volume "xtables-lock", which is unsafe for upgrades.
- Pod "kube-system/kube-proxy-ntqxh" is using HostPath volume "lib-modules", which is unsafe for upgrades.
- Pod "kube-system/kubernetes-dashboard-599948858f-qzk84" is using EmptyDir volume "tmp-volume", which is unsafe for upgrades.
- The pod "default/nginx" is not being managed by a controller. Upgrading this node might result in data or availability loss.
- Pod managed by ReplicaSet "kube-system/calico-kube-controllers-cc54bd575" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/calico-kube-controllers-cc54bd575" are running on this node.
- Pod managed by DaemonSet "kube-system/default-http-backend" is running on this node, and no other nodes are capable of hosting this daemon. Upgrading it may make the daemon unavailable.
- All the replicas that belong to the ReplicaSet "kube-system/heapster-9695fd7f4" are running on this node.
- Pod managed by ReplicaSet "kube-system/heapster-influxdb-6c4b84d695" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/heapster-influxdb-6c4b84d695" are running on this node.
- Pod managed by DaemonSet "kube-system/ingress" is running on this node, and no other nodes are capable of hosting this daemon. Upgrading it may make the daemon unavailable.
- All the replicas that belong to the ReplicaSet "kube-system/kube-dns-7b6d44794f" are running on this node.
- Pod managed by ReplicaSet "kube-system/kubernetes-dashboard-599948858f" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/kubernetes-dashboard-599948858f" are running on this node.
- Pod managed by ReplicaSet "kube-system/metrics-server-59794fdbc5" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/metrics-server-59794fdbc5" are running on this node.
- Pod managed by ReplicaSet "kube-system/tiller-deploy-7bf964fff8" is running on this node, and the ReplicaSet does not have a replica count greater than 1.
- All the replicas that belong to the ReplicaSet "kube-system/tiller-deploy-7bf964fff8" are running on this node.
- Upgrading this node may result in storage volumes becoming temporarily unavailable.
```

New output:
```
Validate Online Upgrade=============================================================
etcd001 [etcd]                                                                  [ERROR]
- This node is part of an etcd cluster that has less than 3 members. Upgrading it may make the cluster unavailable.
master001 [master]                                                              [ERROR]
- This is the only master node in the cluster. Upgrading it may make the cluster unavailable.
- This node is acting as the load balanced endpoint for the master nodes. Upgrading it may make the cluster unavailable
worker001 [worker ingress]                                                      [ERROR]
- This is the only worker node in the cluster. Upgrading it may make cluster features unavailable.
- The pod "default/nginx" is not being managed by a controller. Upgrading this node might result in data or availability loss.
- Upgrading this node may result in storage volumes becoming temporarily unavailable.
```