### PR TITLE
During disconnected installs validate package availability

### DIFF
--- a/pkg/inspector/check/package_manager.go
+++ b/pkg/inspector/check/package_manager.go
@@ -55,7 +55,7 @@ type rpmManager struct {
 }
 
 func (m rpmManager) IsAvailable(p PackageQuery) (bool, error) {
-	out, err := m.run("yum", "list", "available", "-q", p.Name)
+	out, err := m.run("yum", "list", "--showduplicates", "available", "-q", p.Name)
 	if err != nil && strings.Contains(string(out), "No matching Packages to list") {
 		return false, nil
 	}

--- a/pkg/inspector/check/package_test.go
+++ b/pkg/inspector/check/package_test.go
@@ -20,6 +20,7 @@ func TestPackageCheck(t *testing.T) {
 		packageName                string
 		installationDisabled       bool
 		dockerInstallationDisabled bool
+		disconnectedInstallation   bool
 		isInstalled                bool
 		isAvailable                bool
 
@@ -94,6 +95,52 @@ func TestPackageCheck(t *testing.T) {
 			isAvailable:                false,
 			expected:                   true,
 		},
+		{
+			packageName:                "somePkg",
+			installationDisabled:       false,
+			dockerInstallationDisabled: false,
+			disconnectedInstallation:   true,
+			isInstalled:                true,
+			isAvailable:                true,
+			expected:                   true,
+		},
+		{
+			packageName:                "somePkg",
+			installationDisabled:       false,
+			dockerInstallationDisabled: false,
+			disconnectedInstallation:   true,
+			isInstalled:                true,
+			isAvailable:                false,
+			expected:                   true,
+		},
+		{
+			packageName:                "somePkg",
+			installationDisabled:       false,
+			dockerInstallationDisabled: false,
+			disconnectedInstallation:   true,
+			isInstalled:                false,
+			isAvailable:                true,
+			expected:                   true,
+		},
+		{
+			packageName:                "somePkg",
+			installationDisabled:       true,
+			dockerInstallationDisabled: false,
+			disconnectedInstallation:   true,
+			isInstalled:                false,
+			isAvailable:                false,
+			expected:                   false,
+			errExpected:                true,
+		},
+		{
+			packageName:                "docker-ce",
+			installationDisabled:       true,
+			dockerInstallationDisabled: true,
+			disconnectedInstallation:   true,
+			isInstalled:                false,
+			isAvailable:                false,
+			expected:                   true,
+		},
 	}
 
 	for i, test := range tests {
@@ -102,6 +149,7 @@ func TestPackageCheck(t *testing.T) {
 			PackageManager:             stubPkgManager{installed: test.isInstalled, available: test.isAvailable},
 			InstallationDisabled:       test.installationDisabled,
 			DockerInstallationDisabled: test.dockerInstallationDisabled,
+			DisconnectedInstallation:   test.disconnectedInstallation,
 		}
 		ok, err := c.Check()
 		if err != nil && !test.errExpected {

--- a/pkg/inspector/cmd/local.go
+++ b/pkg/inspector/cmd/local.go
@@ -17,6 +17,7 @@ type localOpts struct {
 	rulesFile                   string
 	packageInstallationDisabled bool
 	dockerInstallationDisabled  bool
+	disconnectedInstallation    bool
 	useUpgradeDefaults          bool
 	additionalVariables         map[string]string
 }
@@ -50,6 +51,7 @@ func NewCmdLocal(out io.Writer) *cobra.Command {
 	cmd.Flags().StringVarP(&opts.rulesFile, "file", "f", "", "the path to an inspector rules file. If blank, the inspector uses the default rules")
 	cmd.Flags().BoolVar(&opts.packageInstallationDisabled, "pkg-installation-disabled", false, "when true, the inspector will ensure that the necessary packages are installed on the node")
 	cmd.Flags().BoolVar(&opts.dockerInstallationDisabled, "docker-installation-disabled", false, "when true, the inspector will check for docker packages to be installed")
+	cmd.Flags().BoolVar(&opts.disconnectedInstallation, "disconnected-installation", false, "when true will check for the required packages needed during a disconnected install")
 	cmd.Flags().BoolVarP(&opts.useUpgradeDefaults, "upgrade", "u", false, "use defaults for upgrade, rather than install")
 	cmd.Flags().StringSliceVar(&additionalVars, "additional-vars", []string{}, "provide a key=value list to template ruleset")
 	return cmd
@@ -87,6 +89,7 @@ func runLocal(out io.Writer, opts localOpts) error {
 			PackageManager:              pkgMgr,
 			PackageInstallationDisabled: opts.packageInstallationDisabled,
 			DockerInstallationDisabled:  opts.dockerInstallationDisabled,
+			DisconnectedInstallation:    opts.disconnectedInstallation,
 		},
 	}
 	labels := append(roles, string(distro))

--- a/pkg/inspector/cmd/server.go
+++ b/pkg/inspector/cmd/server.go
@@ -55,7 +55,7 @@ func runServer(out io.Writer, opts serverOpts) error {
 	if opts.disconnectedInstallation {
 		nodeFacts = append(nodeFacts, "disconnected")
 	}
-	s, err := inspector.NewServer(nodeFacts, opts.port, opts.packageInstallationDisabled, opts.dockerInstallationDisabled)
+	s, err := inspector.NewServer(nodeFacts, opts.port, opts.packageInstallationDisabled, opts.dockerInstallationDisabled, opts.disconnectedInstallation)
 	if err != nil {
 		return fmt.Errorf("error starting up inspector server: %v", err)
 	}

--- a/pkg/inspector/rule/check_mapper.go
+++ b/pkg/inspector/rule/check_mapper.go
@@ -21,7 +21,8 @@ type DefaultCheckMapper struct {
 	TargetNodeIP string
 	// PackageInstallationDisabled determines whether Kismatic is allowed to install packages on the node
 	PackageInstallationDisabled bool
-
+	// DisconnectedInstallation determines whether Kismatic can access the internet
+	DisconnectedInstallation bool
 	// DockerInstallationDisabled determines whether Kismatic is expected to install docker
 	// If set to false, Kismatic will validate that a docker executable is present on the machine
 	DockerInstallationDisabled bool
@@ -36,7 +37,7 @@ func (m DefaultCheckMapper) GetCheckForRule(rule Rule) (check.Check, error) {
 		return nil, fmt.Errorf("Rule of type %T is not supported", r)
 	case PackageDependency:
 		pkgQuery := check.PackageQuery{Name: r.PackageName, Version: r.PackageVersion}
-		c = &check.PackageCheck{PackageQuery: pkgQuery, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled, DockerInstallationDisabled: m.DockerInstallationDisabled}
+		c = &check.PackageCheck{PackageQuery: pkgQuery, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled, DockerInstallationDisabled: m.DockerInstallationDisabled, DisconnectedInstallation: m.DisconnectedInstallation}
 	case PackageNotInstalled:
 		pkgQuery := check.PackageQuery{Name: r.PackageName, Version: r.PackageVersion}
 		c = check.PackageNotInstalledCheck{PackageQuery: pkgQuery, AcceptablePackageVersion: r.AcceptablePackageVersion, PackageManager: m.PackageManager, InstallationDisabled: m.PackageInstallationDisabled, DockerInstallationDisabled: m.DockerInstallationDisabled}

--- a/pkg/inspector/server.go
+++ b/pkg/inspector/server.go
@@ -30,7 +30,7 @@ var closeEndpoint = "/close"
 
 // NewServer returns an inspector server that has been initialized
 // with the default rules engine
-func NewServer(nodeFacts []string, port int, packageInstallationDisabled bool, dockerInstallationDisabled bool) (*Server, error) {
+func NewServer(nodeFacts []string, port int, packageInstallationDisabled bool, dockerInstallationDisabled bool, disconnectedInstallation bool) (*Server, error) {
 	s := &Server{
 		Port: port,
 	}
@@ -48,6 +48,7 @@ func NewServer(nodeFacts []string, port int, packageInstallationDisabled bool, d
 			PackageManager:              pkgMgr,
 			PackageInstallationDisabled: packageInstallationDisabled,
 			DockerInstallationDisabled:  dockerInstallationDisabled,
+			DisconnectedInstallation:    disconnectedInstallation,
 		},
 	}
 	s.rulesEngine = engine


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/949

Initial version of KET allowed users to provide package repo details in the plan file and the tool would configure those. That was changed and it would be up to the operator to configure those repos prior to running installation.

This PR modifies the existing `package` check to validate that during `DisconnectedInstalls` the packages are either already installed or available in a configured repo.

Example output of package not being available:
```
=> The following checks failed on "ip-10-0-3-40.ec2.internal":
   - Package "docker-ce 17.999.2.ce-1.el7.centos": package is not installed, and is not available in known package repositories
=> Successful pre-flight checks:
   - Package "kubelet 1.9.6-0"
   - Package "nfs-utils"
   - Package "kubectl 1.9.6-0"
...
```