### PR TITLE
Add in the plan file the ability to taint nodes

### DIFF
--- a/ansible/_label-nodes.yaml
+++ b/ansible/_label-nodes.yaml
@@ -1,7 +1,7 @@
 ---
   - hosts: master:worker:ingress:storage
     any_errors_fatal: true
-    name: Label Kubernetes Nodes 
+    name: Label and Taint Kubernetes Nodes 
     serial: "{{ serial_count | default('100%') }}"
     become: yes
     vars_files:
@@ -14,3 +14,7 @@
       - name: label nodes with user defined labels
         command: kubectl --kubeconfig {{ kubernetes_kubeconfig.kubectl }} label --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname|lower }} {{ node_labels[inventory_hostname] | join(" ") }}
         when: node_labels[inventory_hostname] is defined and node_labels[inventory_hostname]|length > 0
+
+      - name: taint nodes with user defined taint
+        command: kubectl --kubeconfig {{ kubernetes_kubeconfig.kubectl }} taint --overwrite nodes --selector kubernetes.io/hostname={{ inventory_hostname|lower }} {{ node_taints[inventory_hostname] | join(" ") }}
+        when: node_taints[inventory_hostname] is defined and node_taints[inventory_hostname]|length > 0

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -118,6 +118,10 @@
     * [ip](#etcdnodesip)
     * [internalip](#etcdnodesinternalip)
     * [labels](#etcdnodeslabels)
+    * [taints](#etcdnodestaints)
+      * [key](#etcdnodestaintskey)
+      * [value](#etcdnodestaintsvalue)
+      * [effect](#etcdnodestaintseffect)
     * [kubelet](#etcdnodeskubelet)
       * [option_overrides](#etcdnodeskubeletoption_overrides)
 * [master](#master)
@@ -129,6 +133,10 @@
     * [ip](#masternodesip)
     * [internalip](#masternodesinternalip)
     * [labels](#masternodeslabels)
+    * [taints](#masternodestaints)
+      * [key](#masternodestaintskey)
+      * [value](#masternodestaintsvalue)
+      * [effect](#masternodestaintseffect)
     * [kubelet](#masternodeskubelet)
       * [option_overrides](#masternodeskubeletoption_overrides)
 * [worker](#worker)
@@ -138,6 +146,10 @@
     * [ip](#workernodesip)
     * [internalip](#workernodesinternalip)
     * [labels](#workernodeslabels)
+    * [taints](#workernodestaints)
+      * [key](#workernodestaintskey)
+      * [value](#workernodestaintsvalue)
+      * [effect](#workernodestaintseffect)
     * [kubelet](#workernodeskubelet)
       * [option_overrides](#workernodeskubeletoption_overrides)
 * [ingress](#ingress)
@@ -147,6 +159,10 @@
     * [ip](#ingressnodesip)
     * [internalip](#ingressnodesinternalip)
     * [labels](#ingressnodeslabels)
+    * [taints](#ingressnodestaints)
+      * [key](#ingressnodestaintskey)
+      * [value](#ingressnodestaintsvalue)
+      * [effect](#ingressnodestaintseffect)
     * [kubelet](#ingressnodeskubelet)
       * [option_overrides](#ingressnodeskubeletoption_overrides)
 * [storage](#storage)
@@ -156,6 +172,10 @@
     * [ip](#storagenodesip)
     * [internalip](#storagenodesinternalip)
     * [labels](#storagenodeslabels)
+    * [taints](#storagenodestaints)
+      * [key](#storagenodestaintskey)
+      * [value](#storagenodestaintsvalue)
+      * [effect](#storagenodestaintseffect)
     * [kubelet](#storagenodeskubelet)
       * [option_overrides](#storagenodeskubeletoption_overrides)
 * [nfs](#nfs)
@@ -1110,6 +1130,41 @@
 | **Required** |  No |
 | **Default** | ` ` | 
 
+###  etcd.nodes.taints
+
+ Taints to add when installing the node in the cluster. If a node is defined under multiple roles, the taints for that node will be merged. If a taint is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. 
+
+###  etcd.nodes.taints.key
+
+ Key for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  etcd.nodes.taints.value
+
+ Value for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  etcd.nodes.taints.effect
+
+ Effect for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+| **Options** |  `NoSchedule`, `PreferNoSchedule`, `NoExecute`
+
 ###  etcd.nodes.kubelet
 
  Kubelet configuration applied to this node. If a node is repeated for multiple roles, the overrides cannot be different. 
@@ -1202,6 +1257,41 @@
 | **Required** |  No |
 | **Default** | ` ` | 
 
+###  master.nodes.taints
+
+ Taints to add when installing the node in the cluster. If a node is defined under multiple roles, the taints for that node will be merged. If a taint is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. 
+
+###  master.nodes.taints.key
+
+ Key for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  master.nodes.taints.value
+
+ Value for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  master.nodes.taints.effect
+
+ Effect for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+| **Options** |  `NoSchedule`, `PreferNoSchedule`, `NoExecute`
+
 ###  master.nodes.kubelet
 
  Kubelet configuration applied to this node. If a node is repeated for multiple roles, the overrides cannot be different. 
@@ -1273,6 +1363,41 @@
 | **Kind** |  map[string]string |
 | **Required** |  No |
 | **Default** | ` ` | 
+
+###  worker.nodes.taints
+
+ Taints to add when installing the node in the cluster. If a node is defined under multiple roles, the taints for that node will be merged. If a taint is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. 
+
+###  worker.nodes.taints.key
+
+ Key for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  worker.nodes.taints.value
+
+ Value for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  worker.nodes.taints.effect
+
+ Effect for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+| **Options** |  `NoSchedule`, `PreferNoSchedule`, `NoExecute`
 
 ###  worker.nodes.kubelet
 
@@ -1346,6 +1471,41 @@
 | **Required** |  No |
 | **Default** | ` ` | 
 
+###  ingress.nodes.taints
+
+ Taints to add when installing the node in the cluster. If a node is defined under multiple roles, the taints for that node will be merged. If a taint is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. 
+
+###  ingress.nodes.taints.key
+
+ Key for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  ingress.nodes.taints.value
+
+ Value for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  ingress.nodes.taints.effect
+
+ Effect for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+| **Options** |  `NoSchedule`, `PreferNoSchedule`, `NoExecute`
+
 ###  ingress.nodes.kubelet
 
  Kubelet configuration applied to this node. If a node is repeated for multiple roles, the overrides cannot be different. 
@@ -1417,6 +1577,41 @@
 | **Kind** |  map[string]string |
 | **Required** |  No |
 | **Default** | ` ` | 
+
+###  storage.nodes.taints
+
+ Taints to add when installing the node in the cluster. If a node is defined under multiple roles, the taints for that node will be merged. If a taint is repeated for the same node, only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence. 
+
+###  storage.nodes.taints.key
+
+ Key for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  storage.nodes.taints.value
+
+ Value for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  storage.nodes.taints.effect
+
+ Effect for the taint 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+| **Options** |  `NoSchedule`, `PreferNoSchedule`, `NoExecute`
 
 ###  storage.nodes.kubelet
 

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -161,6 +161,7 @@ type ClusterCatalog struct {
 	NoProxy    string `yaml:"no_proxy"`
 
 	NodeLabels         map[string][]string          `yaml:"node_labels"`
+	NodeTaints         map[string][]string          `yaml:"node_taints"`
 	KubeletNodeOptions map[string]map[string]string `yaml:"kubelet_node_overrides"`
 }
 

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -216,7 +216,7 @@ func setDefaults(p *Plan) {
 	}
 }
 
-var yamlKeyRE = regexp.MustCompile(`[^a-zA-Z]*([a-z_\-A-Z.\d]+)[ ]*:`)
+var yamlKeyRE = regexp.MustCompile(`[^a-zA-Z]*([a-z_\-\/A-Z.\d]+)[ ]*:`)
 
 // Write the plan to the file system
 func (fp *FilePlanner) Write(p *Plan) error {

--- a/pkg/install/plan.go
+++ b/pkg/install/plan.go
@@ -258,7 +258,10 @@ func (fp *FilePlanner) Write(p *Plan) error {
 			if etcdBlock && strings.Contains(text, "labels: {}") {
 				continue
 			}
-
+			// Don't print taints: [] for etcd group
+			if etcdBlock && strings.Contains(text, "taints: []") {
+				continue
+			}
 			// Add a new line if we are leaving a major indentation block
 			// (leaving a struct)..
 			if indent < prevIndent {

--- a/pkg/install/plan_test.go
+++ b/pkg/install/plan_test.go
@@ -24,7 +24,6 @@ func TestWritePlanTemplate(t *testing.T) {
 				IngressNodes:    2,
 				StorageNodes:    0,
 				AdditionalFiles: 1,
-				AdminPassword:   "password",
 			},
 		},
 		{
@@ -36,7 +35,6 @@ func TestWritePlanTemplate(t *testing.T) {
 				IngressNodes:    2,
 				StorageNodes:    2,
 				AdditionalFiles: 1,
-				AdminPassword:   "password",
 			},
 		},
 	}

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -53,6 +53,10 @@ func roles() []string {
 	return []string{"etcd", "master", "worker", "ingress", "storage"}
 }
 
+func taintEffects() []string {
+	return []string{"NoSchedule", "PreferNoSchedule", "NoExecute"}
+}
+
 // Plan is the installation plan that the user intends to execute
 type Plan struct {
 	// Kubernetes cluster configuration
@@ -607,9 +611,25 @@ type Node struct {
 	// only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence.
 	// It is recommended to use reverse-DNS notation to avoid collision with other labels.
 	Labels map[string]string
+	// Taints to add when installing the node in the cluster.
+	// If a node is defined under multiple roles, the taints for that node will be merged.
+	// If a taint is repeated for the same node,
+	// only one will be used in this order: etcd,master,worker,ingress,storage roles where 'storage' has the highest precedence.
+	Taints []Taint
 	// Kubelet configuration applied to this node.
 	// If a node is repeated for multiple roles, the overrides cannot be different.
 	KubeletOptions KubeletOptions `yaml:"kubelet,omitempty"`
+}
+
+// Taint for nodes
+type Taint struct {
+	// Key for the taint
+	Key string
+	// Value for the taint
+	Value string
+	// Effect for the taint
+	// +options=NoSchedule,PreferNoSchedule,NoExecute
+	Effect string
 }
 
 // Equal returns true of 2 nodes have the same host, IP and InternalIP

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -4,10 +4,6 @@ cluster:
   # Kubernetes cluster version (supported minor version "v1.10.x").
   version: v1.10.0
 
-  # This password is used to login to the Kubernetes Dashboard and can also be
-  # used for administration without a security certificate.
-  admin_password: password
-
   # Set to true if the nodes have the required packages installed.
   disable_package_installation: false
 
@@ -256,11 +252,13 @@ master:
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
 # Worker nodes are the ones that will run your workloads on the cluster.
 worker:
@@ -270,16 +268,19 @@ worker:
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
 # Ingress nodes will run the ingress controllers.
 ingress:
@@ -289,11 +290,13 @@ ingress:
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
 # Storage nodes will be used to create a distributed storage cluster that can
 # be consumed by your workloads.
@@ -304,8 +307,10 @@ storage:
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -4,10 +4,6 @@ cluster:
   # Kubernetes cluster version (supported minor version "v1.10.x").
   version: v1.10.0
 
-  # This password is used to login to the Kubernetes Dashboard and can also be
-  # used for administration without a security certificate.
-  admin_password: password
-
   # Set to true if the nodes have the required packages installed.
   disable_package_installation: false
 
@@ -256,11 +252,13 @@ master:
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
 # Worker nodes are the ones that will run your workloads on the cluster.
 worker:
@@ -270,16 +268,19 @@ worker:
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
 # Ingress nodes will run the ingress controllers.
 ingress:
@@ -289,11 +290,13 @@ ingress:
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
   - host: ""
     ip: ""
     internalip: ""
     labels: {}
+    taints: []
 
 # Storage nodes will be used to create a distributed storage cluster that can
 # be consumed by your workloads.

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -1689,6 +1689,225 @@ func TestNodeLabels(t *testing.T) {
 	}
 }
 
+func TestNodeTaints(t *testing.T) {
+	tests := []struct {
+		n     Node
+		valid bool
+	}{
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host:   "foo",
+				IP:     "192.1.1.1",
+				Taints: []Taint{},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "com.foo/bar",
+						Value:  "",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "com.foo/bar",
+						Value:  "foobar",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "com.foo/bar",
+						Value:  "foobar",
+						Effect: "NoSchedule",
+					},
+					Taint{
+						Key:    "com.foo/xyz",
+						Value:  "xyz",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "kismatic/foo",
+						Value:  "bar",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "com.foo/kismatic-version",
+						Value:  "v1.0.0",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: true,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "",
+						Value:  "v1.0.0",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "",
+						Value:  "",
+						Effect: "NoSchedule",
+					},
+				},
+				Labels: map[string]string{"": ""},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "",
+						Value:  "",
+						Effect: "",
+					},
+				},
+				Labels: map[string]string{"": ""},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "node-type:test",
+						Value:  "test",
+						Effect: "NoSchedule",
+					},
+				},
+				Labels: map[string]string{"node-type:test": "test"},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "com.foo/invalid",
+						Value:  ":test",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "node-type:test",
+						Value:  ":test",
+						Effect: "NoSchedule",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "kismatic/foo",
+						Value:  "bar",
+						Effect: "",
+					},
+				},
+			},
+			valid: false,
+		},
+		{
+			n: Node{
+				Host: "foo",
+				IP:   "192.1.1.1",
+				Taints: []Taint{
+					Taint{
+						Key:    "kismatic/foo",
+						Value:  "bar",
+						Effect: "Foo",
+					},
+				},
+			},
+			valid: false,
+		},
+	}
+	for i, test := range tests {
+		ok, _ := test.n.validate()
+		if ok != test.valid {
+			t.Errorf("test %d: expect %t, but got %t", i, test.valid, ok)
+		}
+	}
+}
+
 func TestNodeKubeletOptions(t *testing.T) {
 	tests := []struct {
 		nl    nodeList


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/1057

The taints are a flat list, similar to how it is defined for pods in Kubernetes. This allows the most flexibility when new effects are added. 

Plan file changes:
```
...
worker:
  expected_count: 3
  nodes:
  - host: "worker1"
    ip: "1.2.3.1"
    labels: {}
    taints:
    - key: "foo"
      value: "bar"
      effect: "NoSchedule"

  - host: "worker2"
    ip: "1.2.3.2"
    labels: {}
    taints:
    - key: "xyz"
      value: "zyx"
      effect: "PreferNoSchedule"

  - host: "worker3"
    ip: "1.2.3.3"
    labels: {}
    taints: []
...
```