### PR TITLE
Systemd services restart policy change to always

### DIFF
--- a/ansible/roles/etcd/templates/etcd.insecure.service
+++ b/ansible/roles/etcd/templates/etcd.insecure.service
@@ -28,7 +28,7 @@ ExecStart={{ bin_dir }}/docker run \
   --initial-cluster-token={{ etcd_service_cluster_token }} \
   --initial-cluster={{ etcd_service_cluster_string }} \
   --initial-cluster-state=new
-Restart=on-failure
+Restart=always
 RestartSec=3
 
 ExecStop=-{{ bin_dir }}/docker stop {{ etcd_name }}

--- a/ansible/roles/etcd/templates/etcd.service
+++ b/ansible/roles/etcd/templates/etcd.service
@@ -33,7 +33,7 @@ ExecStart={{ bin_dir }}/docker run \
   --initial-cluster-token={{ etcd_service_cluster_token }} \
   --initial-cluster={{ etcd_service_cluster_string }} \
   --initial-cluster-state=new
-Restart=on-failure
+Restart=always
 RestartSec=3
 
 ExecStop=-{{ bin_dir }}/docker stop {{ etcd_name }}

--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
@@ -10,7 +10,7 @@ ExecStart={{ bin_dir }}/kube-apiserver \
   --{{ option[0] }}={{ option[1] }} \
 {% endif %}
 {% endfor %}
-Restart=on-failure
+Restart=always
 RestartSec=3
 
 [Install]

--- a/ansible/roles/kubelet/templates/kubelet.service
+++ b/ansible/roles/kubelet/templates/kubelet.service
@@ -12,7 +12,7 @@ ExecStart=/usr/bin/kubelet \
   --{{ option[0] }}={{ option[1] }} \
 {% endif %}
 {% endfor %}
-Restart=on-failure
+Restart=always
 RestartSec=3
 WorkingDirectory=/root/
 


### PR DESCRIPTION
Changed systemd services so they restart "always" instead of "on-failure"
Fixes #1208 