### PR TITLE
Fix typo of node taint configuration

### DIFF
--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -856,7 +856,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	cc.NodeTaints = make(map[string][]string)
 	for _, n := range p.getAllNodes() {
 		if val, ok := cc.NodeTaints[n.Host]; ok {
-			cc.NodeLabels[n.Host] = append(val, keyValueEffectList(n.Taints)...)
+			cc.NodeTaints[n.Host] = append(val, keyValueEffectList(n.Taints)...)
 		} else {
 			cc.NodeTaints[n.Host] = keyValueEffectList(n.Taints)
 		}


### PR DESCRIPTION
Find this issue by deploy with Taints, but find labels are empty, it should be a typo that must be fixed.