### PR TITLE
Disable Kubelet's read-only-port 10255

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -179,7 +179,7 @@ kubernetes_api_server_option_defaults:
   "kubelet-client-certificate": "{{ kubernetes_certificates.kube_apiserver_kubelet_client }}"
   "kubelet-client-key": "{{ kubernetes_certificates.kube_apiserver_kubelet_client_key }}"
   "kubelet-preferred-address-types": "{% if modify_hosts_file is defined and modify_hosts_file|bool == true %}InternalIP,ExternalIP,Hostname{% endif %}"
-  "runtime-config": "extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true"
+  "runtime-config": "extensions/v1beta1=true,extensions/v1beta1/networkpolicies=true,authentication.k8s.io/v1beta1=true"
   "secure-port": "{{ kubernetes_master_secure_port }}"
   "service-account-key-file": "{{ kubernetes_certificates.service_account_key }}"
   "service-cluster-ip-range": "{{ kubernetes_services_cidr }}"
@@ -217,6 +217,7 @@ kube_proxy_option_defaults:
 
 kubelet_defaults:
   "allow-privileged": "true"
+  "authentication-token-webhook": "true"
   "authorization-mode": "Webhook"
   "event-qps": "0"
   "cadvisor-port" : "0"
@@ -237,6 +238,7 @@ kubelet_defaults:
   "node-ip": "{{ internal_ipv4 }}"
   "pod-infra-container-image": "{{ images.pause }}"
   "pod-manifest-path": "{{ kubelet_pod_manifests_dir }}"
+  "read-only-port": "0"
   "register-schedulable": "{{ kubernetes_schedulable }}"
   "serialize-image-pulls": "false"
   "streaming-connection-idle-timeout": "0"

--- a/ansible/roles/heapster/templates/heapster-rbac.yaml
+++ b/ansible/roles/heapster/templates/heapster-rbac.yaml
@@ -10,3 +10,25 @@ subjects:
 - kind: ServiceAccount
   name: heapster
   namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: heapster-additional
+rules:
+- apiGroups: [""]
+  resources: ["nodes/stats"]
+  verbs: ["create", "get", "watch", "list"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: heapster-additional
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: heapster-additional
+subjects:
+- kind: ServiceAccount
+  name: heapster
+  namespace: kube-system

--- a/ansible/roles/heapster/templates/heapster.yaml
+++ b/ansible/roles/heapster/templates/heapster.yaml
@@ -42,5 +42,5 @@ spec:
         imagePullPolicy: IfNotPresent
         command:
         - /heapster
-        - --source=kubernetes:https://kubernetes.default
+        - --source=kubernetes:https://kubernetes.default?kubeletHttps=true&kubeletPort=10250&useServiceAccount=true
         - --sink={{ heapster.options.heapster.sink }}

--- a/pkg/inspector/rule/rule_set.go
+++ b/pkg/inspector/rule/rule_set.go
@@ -160,12 +160,6 @@ const defaultRuleSet = `---
   - ["master", "worker", "ingress", "storage"]
   port: 10250
   procName: kubelet
-# kubelet no auth
-- kind: TCPPortAvailable
-  when: 
-  - ["master", "worker", "ingress", "storage"]
-  port: 10255
-  procName: kubelet
 
 # Ports used by K8s worker are accessible
 # kube-proxy

--- a/pkg/inspector/rule/rule_test.go
+++ b/pkg/inspector/rule/rule_test.go
@@ -5,8 +5,8 @@ import "testing"
 func TestDefaultRules(t *testing.T) {
 	// This will panic if there are errors in the default rule
 	rules := DefaultRules(map[string]string{"kubernetes_yum_version": "1.10.2-0", "kubernetes_deb_version": "1.10.2-00"})
-	if len(rules) != 76 {
-		t.Errorf("expected to have %d rules, instead got %d", 76, len(rules))
+	if len(rules) != 75 {
+		t.Errorf("expected to have %d rules, instead got %d", 75, len(rules))
 	}
 	for _, r := range rules {
 		if errs := r.Validate(); len(errs) != 0 {


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/1135

This required to modify the Heapster deployment to use the secure port 10250.

A new option authentication-token-webhook=true was used to allow to use the authentication.k8s.io/v1beta1=true API.

The pod was also failing to get some stats:
```
Error in scraping containers from kubelet:10.0.0.81:10250: failed to get all container stats from Kubelet URL "https://10.0.0.81:10250/stats/container/": request failed - "403 Forbidden", response: "Forbidden (user=system:serviceaccount:kube-system:heapster, verb=create, resource=nodes, subresource=stats)"
```
A new ClusterRoleBinding was added with the missing permission.