### PR TITLE
No longer deploy nginx-ingress controller with hostNetwork

### DIFF
--- a/ansible/roles/nginx-ingress/templates/nginx-ingress-controller.yaml
+++ b/ansible/roles/nginx-ingress/templates/nginx-ingress-controller.yaml
@@ -14,7 +14,6 @@ spec:
         prometheus.io/scrape: "true"
     spec:
       terminationGracePeriodSeconds: 60
-      hostNetwork: true # required in a CNI networkd
       nodeSelector:
         kismatic/ingress: "true"
       containers:


### PR DESCRIPTION
This was unblocked with the fix for https://github.com/apprenda/kismatic/issues/1207

No longer requires to deploy the Ingress Controller with `hostNetwork: true`, this has the benefits of being able to specify `networkPolicies` for the ingress pods.