### PR TITLE
add Docker & K8s APT keys before updating APT cache

### DIFF
--- a/ansible/roles/packages-repo/tasks/main.yaml
+++ b/ansible/roles/packages-repo/tasks/main.yaml
@@ -41,23 +41,23 @@
     environment: "{{proxy_env}}"
 
   # DEB
-  - name: install apt-transport-https package
-    apt:
-      name: apt-transport-https
-      state: latest
-      update_cache: yes
-    when: ansible_os_family == 'Debian'
-    environment: "{{proxy_env}}"
-
   - name: add Docker deb key
     apt_key:
       url: "{{ docker_deb_gpg_key_url }}"
     when: ansible_os_family == 'Debian' and docker.enabled|bool == true
     environment: "{{proxy_env}}"
-  
+
   - name: add Kubernetes deb key
     apt_key:
       url: "{{ kubernetes_deb_gpg_key_url }}"
+    when: ansible_os_family == 'Debian'
+    environment: "{{proxy_env}}"
+
+  - name: install apt-transport-https package
+    apt:
+      name: apt-transport-https
+      state: latest
+      update_cache: yes
     when: ansible_os_family == 'Debian'
     environment: "{{proxy_env}}"
 


### PR DESCRIPTION
While upgrading a cluster, I ran into an issue where the the pre-flight checks were failing because the K8s PGP key had changed. I was getting stuck at `install apt-transport-https package` task because that also tries to update the APT cache before installing the package.

I was able to resolve the issue by adding the keys before trying to install `apt-transport-https`.