### PR TITLE
Expose portmap CNI plugin as an option in the planfile

### DIFF
--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -42,12 +42,12 @@ data:
             "kubernetes": {
                 "kubeconfig": "__KUBECONFIG_FILEPATH__"
             }
-        },
+        }{% if cni.options.portmap.enabled == true %},
         {
           "type": "portmap",
           "snat": true,
           "capabilities": {"portMappings": true}
-        }
+        }{% endif %}
       ]
     }
   # If you're using TLS enabled etcd uncomment the following.

--- a/ansible/roles/weave/templates/weavenet.conflist
+++ b/ansible/roles/weave/templates/weavenet.conflist
@@ -6,11 +6,11 @@
             "name": "weave",
             "type": "weave-net",
             "hairpinMode": true
-        },
+        }{% if cni.options.portmap.enabled == true %},
         {
             "type": "portmap",
             "capabilities": {"portMappings": true},
             "snat": true
-        }
+        }{% endif %}
     ]
 }

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -70,6 +70,8 @@
     * [disable](#add_onscnidisable)
     * [provider](#add_onscniprovider)
     * [options](#add_onscnioptions)
+      * [portmap](#add_onscnioptionsportmap)
+        * [disable](#add_onscnioptionsportmapdisable)
       * [calico](#add_onscnioptionscalico)
         * [mode](#add_onscnioptionscalicomode)
         * [log_level](#add_onscnioptionscalicolog_level)
@@ -762,6 +764,20 @@
 ###  add_ons.cni.options
 
  The CNI options that can be configured for each CNI provider. 
+
+###  add_ons.cni.options.portmap
+
+ The options that can be configured for the Portmap CNI provider. 
+
+###  add_ons.cni.options.portmap.disable
+
+ Disable the portmap CNI plugin 
+
+| | |
+|----------|-----------------|
+| **Kind** |  bool |
+| **Required** |  No |
+| **Default** | `false` | 
 
 ###  add_ons.cni.options.calico
 

--- a/integration-tests/plan_patterns.go
+++ b/integration-tests/plan_patterns.go
@@ -101,6 +101,8 @@ add_ons:
     disable: {{.DisableCNI}}
     provider: {{if .CNIProvider}}{{.CNIProvider}}{{else}}calico{{end}}
     options:
+      portmap:
+        disable: false
       calico:
         mode: overlay
         log_level: info

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -110,6 +110,9 @@ type ClusterCatalog struct {
 		Enabled  bool
 		Provider string
 		Options  struct {
+			Portmap struct {
+				Enabled bool
+			}
 			Calico struct {
 				Mode                  string
 				LogLevel              string `yaml:"log_level"`

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -788,6 +788,7 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	if p.AddOns.CNI != nil && !p.AddOns.CNI.Disable {
 		cc.CNI.Enabled = true
 		cc.CNI.Provider = p.AddOns.CNI.Provider
+		cc.CNI.Options.Portmap.Enabled = !p.AddOns.CNI.Options.Portmap.Disable
 		// Calico
 		cc.CNI.Options.Calico.Mode = p.AddOns.CNI.Options.Calico.Mode
 		cc.CNI.Options.Calico.LogLevel = p.AddOns.CNI.Options.Calico.LogLevel

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -402,10 +402,19 @@ type CNI struct {
 
 // CNIOptions that can be configured for each CNI provider.
 type CNIOptions struct {
+	// The options that can be configured for the Portmap CNI provider.
+	Portmap PortmapOptions
 	// The options that can be configured for the Calico CNI provider.
 	Calico CalicoOptions
 	// The options that can be configured for the Weave CNI provider.
 	Weave WeaveOptions
+}
+
+// The PortmapOptions that can be configured for the Portmap CNI plugin.
+type PortmapOptions struct {
+	// Disable the portmap CNI plugin
+	// +default=false
+	Disable bool
 }
 
 // The CalicoOptions that can be configured for the Calico CNI provider.

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -144,6 +144,9 @@ add_ons:
     # Options: 'calico','weave','contiv','custom'.
     provider: calico
     options:
+      portmap:
+        disable: false
+
       calico:
 
         # Options: 'overlay','routed'.

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -144,6 +144,9 @@ add_ons:
     # Options: 'calico','weave','contiv','custom'.
     provider: calico
     options:
+      portmap:
+        disable: false
+
       calico:
 
         # Options: 'overlay','routed'.


### PR DESCRIPTION
Fixes https://github.com/apprenda/kismatic/issues/1235

New section for the `portmap` CNI plugin.
```
add_ons:
  cni:
    options:
      portmap:
        disable: false
```