### PR TITLE
Explicitly enable SIGPIPE as a status for restarting services

### DIFF
--- a/ansible/roles/etcd/templates/etcd.insecure.service
+++ b/ansible/roles/etcd/templates/etcd.insecure.service
@@ -30,6 +30,7 @@ ExecStart={{ bin_dir }}/docker run \
   --initial-cluster-state=new
 Restart=on-failure
 RestartSec=3
+RestartForceExitStatus=SIGPIPE
 
 ExecStop=-{{ bin_dir }}/docker stop {{ etcd_name }}
 

--- a/ansible/roles/etcd/templates/etcd.service
+++ b/ansible/roles/etcd/templates/etcd.service
@@ -35,6 +35,7 @@ ExecStart={{ bin_dir }}/docker run \
   --initial-cluster-state=new
 Restart=on-failure
 RestartSec=3
+RestartForceExitStatus=SIGPIPE
 
 ExecStop=-{{ bin_dir }}/docker stop {{ etcd_name }}
 

--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
@@ -12,6 +12,7 @@ ExecStart={{ bin_dir }}/kube-apiserver \
 {% endfor %}
 Restart=on-failure
 RestartSec=3
+RestartForceExitStatus=SIGPIPE
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/kubelet/templates/kubelet.service
+++ b/ansible/roles/kubelet/templates/kubelet.service
@@ -14,6 +14,7 @@ ExecStart=/usr/bin/kubelet \
 {% endfor %}
 Restart=on-failure
 RestartSec=3
+RestartForceExitStatus=SIGPIPE
 WorkingDirectory=/root/
 
 [Install]


### PR DESCRIPTION
Explicitly enable SIGPIPE as a status for restarting services.  Tested this by restarting systemd-journald and the kubelet restarted as expected.  Also set the same option for etcd services too.

Fixes #1208