### PR TITLE
APIServer Load Balancer Port

### DIFF
--- a/ansible/group_vars/all.yaml
+++ b/ansible/group_vars/all.yaml
@@ -118,7 +118,7 @@ docker_certificates_group: root
 # kubernetes cluster config
 kubernetes_master_apiserver_count: "{{ groups['master'] | length }}"
 local_kubernetes_master_ip: https://127.0.0.1:{{ kubernetes_master_secure_port }}
-kubernetes_master_ip: https://{{ kubernetes_load_balanced_fqdn }}:{{ kubernetes_master_secure_port }}
+kubernetes_master_ip: https://{{ kubernetes_load_balancer }}:{{ kubernetes_load_balancer_port }}
 kubernetes_schedulable: "{% if 'worker' in group_names %}true{% else %}false{% endif %}"
 # cloud provider
 cloud_config: "{% if cloud_config_local is defined and cloud_config_local != '' %}{{ kubernetes_install_dir }}/cloud-provider.conf{% else %}{% endif %}"

--- a/ansible/roles/calico-network-policy/templates/network-policy-controller.yaml
+++ b/ansible/roles/calico-network-policy/templates/network-policy-controller.yaml
@@ -122,7 +122,7 @@ spec:
             # The location of the Kubernetes API.  Use the default Kubernetes
             # service for API access.
             - name: K8S_API
-              value: "{{ kubernetes_master_ip }}"
+              value: "https://kubernetes.default:443"
             - name: CONFIGURE_ETC_HOSTS
               value: "true"
             # Choose which controllers to run.

--- a/ansible/roles/calico/templates/calico.yaml
+++ b/ansible/roles/calico/templates/calico.yaml
@@ -29,7 +29,7 @@ data:
             },
             "policy": {
                 "type": "k8s",
-                "k8s_api_root": "{{ kubernetes_master_ip }}",
+                "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
                 "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
             },
             "kubernetes": {

--- a/ansible/roles/contiv/templates/configmap.yaml
+++ b/ansible/roles/contiv/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
     }
   config: |-
     {
-       "K8S_API_SERVER": "https://{{ kubernetes_load_balanced_fqdn }}:6443",
+       "K8S_API_SERVER": "https://{{ kubernetes_load_balancer }}:{{ kubernetes_load_balancer_port }}",
        "K8S_CA": "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt",
        "K8S_KEY": "",
        "K8S_CERT": "",

--- a/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
+++ b/ansible/roles/kube-dns/templates/kubernetes-dns.yaml
@@ -126,7 +126,6 @@ spec:
         - --domain=cluster.local
         - --dns-port=10053
         - --config-dir=/kube-dns-config
-        #- --kube-master-url={{ kubernetes_master_ip }}
         - --v=2
         ports:
         - containerPort: 10053
@@ -138,15 +137,7 @@ spec:
         - containerPort: 10055
           name: metrics
           protocol: TCP
-        # setting these vars to use with serviceaccount
-        # --kube-master-url does not work with error:
-        #  x509: failed to load system roots and no roots provided
-        # CA does not get mounted correctly with that flag
         env:
-        - name: KUBERNETES_SERVICE_HOST
-          value: "{{ kubernetes_load_balanced_fqdn }}"
-        - name: KUBERNETES_SERVICE_PORT
-          value: "{{ kubernetes_master_secure_port }}"
         - name: PROMETHEUS_PORT
           value: "10055"
         volumeMounts:

--- a/ansible/roles/kube-proxy/templates/kube-proxy.yaml
+++ b/ansible/roles/kube-proxy/templates/kube-proxy.yaml
@@ -72,9 +72,9 @@ spec:
 {% endfor %}
         env:
         - name: KUBERNETES_SERVICE_HOST
-          value: "{{ kubernetes_load_balanced_fqdn }}"
+          value: "{{ kubernetes_load_balancer }}"
         - name: KUBERNETES_SERVICE_PORT
-          value: "{{ kubernetes_master_secure_port }}"
+          value: "{{ kubernetes_load_balancer_port }}"
         - name: NODE_NAME
           valueFrom:
             fieldRef:

--- a/docs/plan-file-reference.md
+++ b/docs/plan-file-reference.md
@@ -18,6 +18,7 @@
   * [certificates](#clustercertificates)
     * [expiry](#clustercertificatesexpiry)
     * [ca_expiry](#clustercertificatesca_expiry)
+    * [apiserver_cert_extra_sans](#clustercertificatesapiserver_cert_extra_sans)
   * [ssh](#clusterssh)
     * [user](#clustersshuser)
     * [ssh_key](#clustersshssh_key)
@@ -129,8 +130,9 @@
       * [option_overrides](#etcdnodeskubeletoption_overrides)
 * [master](#master)
   * [expected_count](#masterexpected_count)
-  * [load_balanced_fqdn](#masterload_balanced_fqdn)
-  * [load_balanced_short_name](#masterload_balanced_short_name)
+  * [load_balancer](#masterload_balancer)
+  * [load_balanced_fqdn _(deprecated)_](#masterload_balanced_fqdn-deprecated)
+  * [load_balanced_short_name _(deprecated)_](#masterload_balanced_short_name-deprecated)
   * [nodes](#masternodes)
     * [host](#masternodeshost)
     * [ip](#masternodesip)
@@ -346,6 +348,16 @@
 |----------|-----------------|
 | **Kind** |  string |
 | **Required** |  Yes |
+| **Default** | ` ` | 
+
+###  cluster.certificates.apiserver_cert_extra_sans
+
+ Comma-separated list of Subject Alternative Names (SANs) to use for the API Server serving certificate. Can be both IP addresses and DNS names. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
 | **Default** | ` ` | 
 
 ###  cluster.ssh
@@ -1221,24 +1233,34 @@
 | **Required** |  Yes |
 | **Default** | ` ` | 
 
-###  master.load_balanced_fqdn
+###  master.load_balancer
+
+ The IP or DNS and Port of the load balancer that is fronting multiple master nodes. In the case where there no load balancer this can be set to the IP address of the master node with port '6443'. 
+
+| | |
+|----------|-----------------|
+| **Kind** |  string |
+| **Required** |  No |
+| **Default** | ` ` | 
+
+###  master.load_balanced_fqdn _(deprecated)_
 
  The FQDN of the load balancer that is fronting multiple master nodes. In the case where there is only one master node, this can be set to the IP address of the master node. 
 
 | | |
 |----------|-----------------|
 | **Kind** |  string |
-| **Required** |  Yes |
+| **Required** |  No |
 | **Default** | ` ` | 
 
-###  master.load_balanced_short_name
+###  master.load_balanced_short_name _(deprecated)_
 
  The short name of the load balancer that is fronting multiple master nodes. In the case where there is only one master node, this can be set to the IP address of the master nodes. 
 
 | | |
 |----------|-----------------|
 | **Kind** |  string |
-| **Required** |  Yes |
+| **Required** |  No |
 | **Default** | ` ` | 
 
 ###  master.nodes

--- a/integration-tests/planfile.go
+++ b/integration-tests/planfile.go
@@ -26,10 +26,9 @@ type ClusterPlan struct {
 		Nodes         []NodePlan
 	}
 	Master struct {
-		ExpectedCount         int `yaml:"expected_count"`
-		Nodes                 []NodePlan
-		LoadBalancedFQDN      string `yaml:"load_balanced_fqdn"`
-		LoadBalancedShortName string `yaml:"load_balanced_short_name"`
+		ExpectedCount int `yaml:"expected_count"`
+		Nodes         []NodePlan
+		LoadBalancer  string `yaml:"load_balancer"`
 	}
 	Worker struct {
 		ExpectedCount int `yaml:"expected_count"`

--- a/pkg/ansible/clustercatalog.go
+++ b/pkg/ansible/clustercatalog.go
@@ -23,7 +23,8 @@ type ClusterCatalog struct {
 	EnablePackageInstallation bool   `yaml:"allow_package_installation"`
 	DisconnectedInstallation  bool   `yaml:"disconnected_installation"`
 	KuberangPath              string `yaml:"kuberang_path"`
-	LoadBalancedFQDN          string `yaml:"kubernetes_load_balanced_fqdn"`
+	LoadBalancer              string `yaml:"kubernetes_load_balancer"`
+	LoadBalancerPort          string `yaml:"kubernetes_load_balancer_port"`
 
 	APIServerOptions             map[string]string `yaml:"kubernetes_api_server_option_overrides"`
 	KubeControllerManagerOptions map[string]string `yaml:"kube_controller_manager_option_overrides"`

--- a/pkg/cli/ip.go
+++ b/pkg/cli/ip.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"io"
 
@@ -44,17 +43,9 @@ func doIP(out io.Writer, planner install.Planner, opts *ipOpts) error {
 	if err != nil {
 		return fmt.Errorf("error reading plan file: %v", err)
 	}
-	address, err := getClusterAddress(*plan)
-	if err != nil {
-		return err
+	if plan.Master.LoadBalancer == "" {
+		return fmt.Errorf("master load balancer is not set in the plan file")
 	}
-	fmt.Fprintln(out, address)
+	fmt.Fprintln(out, plan.Master.LoadBalancer)
 	return nil
-}
-
-func getClusterAddress(plan install.Plan) (string, error) {
-	if plan.Master.LoadBalancedFQDN == "" {
-		return "", errors.New("Master load balanced FQDN is not set in the plan file")
-	}
-	return plan.Master.LoadBalancedFQDN, nil
 }

--- a/pkg/cli/ip_test.go
+++ b/pkg/cli/ip_test.go
@@ -30,7 +30,7 @@ func TestIPCmdEmptyAddress(t *testing.T) {
 		planFilename: "planFile",
 	}
 	if err := doIP(out, fp, opts); err == nil {
-		t.Errorf("ip did not return an error when LoadBalancedFQDN is empty")
+		t.Errorf("ip did not return an error when LoadBalancer is empty")
 	}
 }
 
@@ -39,7 +39,7 @@ func TestIPCmdValidAddress(t *testing.T) {
 	fp := &fakePlanner{
 		plan: &install.Plan{
 			Master: install.MasterNodeGroup{
-				LoadBalancedFQDN: "10.0.0.10",
+				LoadBalancer: "10.0.0.10:6443",
 			},
 		},
 		exists: true,
@@ -51,7 +51,7 @@ func TestIPCmdValidAddress(t *testing.T) {
 	if err != nil {
 		t.Errorf("ip returned an error %v", err)
 	}
-	if out.String() != fp.plan.Master.LoadBalancedFQDN+"\n" {
-		t.Errorf("ip returned %s, but expectetd %s", out.String(), fp.plan.Master.LoadBalancedFQDN)
+	if out.String() != fp.plan.Master.LoadBalancer+"\n" {
+		t.Errorf("ip returned %s, but expectetd %s", out.String(), fp.plan.Master.LoadBalancer)
 	}
 }

--- a/pkg/install/execute.go
+++ b/pkg/install/execute.go
@@ -719,11 +719,16 @@ func (ae *ansibleExecutor) buildClusterCatalog(p *Plan) (*ansible.ClusterCatalog
 	}
 	cc.LocalKubeconfigDirectory = generatedDir
 
-	// Setup FQDN or default to first master
-	if p.Master.LoadBalancedFQDN != "" {
-		cc.LoadBalancedFQDN = p.Master.LoadBalancedFQDN
-	} else {
-		cc.LoadBalancedFQDN = p.Master.Nodes[0].InternalIP
+	// Setup LB or default to first master
+	cc.LoadBalancer = p.Master.Nodes[0].InternalIP
+	cc.LoadBalancerPort = "6443"
+	if p.Master.LoadBalancer != "" {
+		host, port, err := p.ClusterAddress()
+		if err != nil {
+			return nil, err
+		}
+		cc.LoadBalancer = host
+		cc.LoadBalancerPort = port
 	}
 
 	if p.PrivateRegistryProvided() {

--- a/pkg/install/kubeconfig.go
+++ b/pkg/install/kubeconfig.go
@@ -52,7 +52,11 @@ users:
 // GenerateKubeconfig generate a kubeconfig file for a specific user
 func GenerateKubeconfig(p *Plan, generatedAssetsDir string) error {
 	user := "admin"
-	server := "https://" + p.Master.LoadBalancedFQDN + ":6443"
+	host, port, err := p.ClusterAddress()
+	if err != nil {
+		return err
+	}
+	server := "https://" + host + ":" + port
 	cluster := p.Cluster.Name
 	context := p.Cluster.Name + "-" + user
 
@@ -81,7 +85,11 @@ func GenerateKubeconfig(p *Plan, generatedAssetsDir string) error {
 
 func GenerateDashboardAdminKubeconfig(base64token string, p *Plan, generatedAssetsDir string) error {
 	user := "admin"
-	server := "https://" + p.Master.LoadBalancedFQDN + ":6443"
+	host, port, err := p.ClusterAddress()
+	if err != nil {
+		return err
+	}
+	server := "https://" + host + ":" + port
 	cluster := p.Cluster.Name
 	context := p.Cluster.Name + "-" + "dashboard-admin"
 

--- a/pkg/install/kubeconfig_test.go
+++ b/pkg/install/kubeconfig_test.go
@@ -29,7 +29,7 @@ func TestRegenerateKubeconfigPreviousDoesNotExist(t *testing.T) {
 
 	p := &Plan{}
 	p.Cluster.Name = "test"
-	p.Master.LoadBalancedFQDN = "test"
+	p.Master.LoadBalancer = "test:6443"
 
 	backup, err := RegenerateKubeconfig(p, tempDir)
 	if err != nil {
@@ -53,14 +53,14 @@ func TestRegenerateKubeconfigDifferentIsBackedUp(t *testing.T) {
 
 	p := &Plan{}
 	p.Cluster.Name = "old"
-	p.Master.LoadBalancedFQDN = "old"
+	p.Master.LoadBalancer = "old:6443"
 
 	if err := GenerateKubeconfig(p, path); err != nil {
 		t.Fatalf("error creating pre-existing kubeconfig file: %v", err)
 	}
 
 	p.Cluster.Name = "new"
-	p.Master.LoadBalancedFQDN = "new"
+	p.Master.LoadBalancer = "new:6443"
 	backup, err := RegenerateKubeconfig(p, path)
 	if err != nil {
 		t.Fatalf("unexected error: %v", err)
@@ -83,7 +83,7 @@ func TestRegenerateKubeconfigSameIsNotBackedUp(t *testing.T) {
 
 	p := &Plan{}
 	p.Cluster.Name = "old"
-	p.Master.LoadBalancedFQDN = "old"
+	p.Master.LoadBalancer = "old:6443"
 
 	if err := GenerateKubeconfig(p, path); err != nil {
 		t.Fatalf("error creating pre-existing kubeconfig file: %v", err)

--- a/pkg/install/plan_types.go
+++ b/pkg/install/plan_types.go
@@ -963,7 +963,7 @@ func (node Node) certSpecs(plan Plan, ca *tls.CA) ([]certificateSpec, error) {
 		if err != nil {
 			return nil, err
 		}
-		san = append(san, node.Host, node.IP, "127.0.0.1")
+		san = append(san, node.Host, node.IP)
 		if node.InternalIP != "" {
 			san = append(san, node.InternalIP)
 		}

--- a/pkg/install/plan_types_test.go
+++ b/pkg/install/plan_types_test.go
@@ -1,9 +1,10 @@
 package install
 
 import (
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"testing"
+
+	"gopkg.in/yaml.v2"
 )
 
 func TestCanReadAPIServerOverrides(t *testing.T) {
@@ -12,4 +13,63 @@ func TestCanReadAPIServerOverrides(t *testing.T) {
 	yaml.Unmarshal(d, p)
 
 	assertEqual(t, p.Cluster.APIServerOptions.Overrides["runtime-config"], "beta/v2api=true,alpha/v1api=true")
+}
+
+func TestClusterAddress(t *testing.T) {
+	tests := []struct {
+		plan  Plan
+		valid bool
+		host  string
+		port  string
+	}{
+		{
+			plan: Plan{
+				Master: MasterNodeGroup{
+					LoadBalancer: "lb:6443",
+				},
+			},
+			valid: true,
+			host:  "lb",
+			port:  "6443",
+		},
+		{
+			plan: Plan{
+				Master: MasterNodeGroup{
+					LoadBalancer: "lb:443",
+				},
+			},
+			valid: true,
+			host:  "lb",
+			port:  "443",
+		},
+		{
+			plan: Plan{
+				Master: MasterNodeGroup{
+					LoadBalancer: "lb",
+				},
+			},
+			valid: false,
+		},
+		{
+			plan: Plan{
+				Master: MasterNodeGroup{
+					LoadBalancer: "",
+				},
+			},
+			valid: false,
+		},
+	}
+	for _, test := range tests {
+		host, port, err := test.plan.ClusterAddress()
+		if test.valid != (err == nil) {
+			t.Fatalf("expected err to be %q, instead got %q", test.valid, err)
+		}
+		if test.host != host {
+			t.Errorf("expected host to be %q, instead got %q", test.host, host)
+		}
+		if test.port != port {
+			t.Errorf("expected host to be %q, instead got %q", test.port, port)
+		}
+	}
+
 }

--- a/pkg/install/test/plan-template-with-storage.golden.yaml
+++ b/pkg/install/test/plan-template-with-storage.golden.yaml
@@ -43,6 +43,10 @@ cluster:
     # CA certificate expiration period in hours; default is 2 years.
     ca_expiry: 17520h
 
+    # Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate.
+    # Can be both IP addresses and DNS names.
+    apiserver_cert_extra_sans: ""
+
   # SSH configuration for cluster nodes.
   ssh:
 
@@ -246,13 +250,9 @@ etcd:
 master:
   expected_count: 2
 
-  # If you have set up load balancing for master nodes, enter the FQDN name here.
-  # Otherwise, use the IP address of a single master node.
-  load_balanced_fqdn: ""
-
-  # If you have set up load balancing for master nodes, enter the short name here.
-  # Otherwise, use the IP address of a single master node.
-  load_balanced_short_name: ""
+  # If you have set up load balancing for master nodes, enter the IP or DNS and Port.
+  # Otherwise, use the IP address of a single master node and port '6443'.
+  load_balancer: ""
   nodes:
   - host: ""
     ip: ""

--- a/pkg/install/test/plan-template.golden.yaml
+++ b/pkg/install/test/plan-template.golden.yaml
@@ -43,6 +43,10 @@ cluster:
     # CA certificate expiration period in hours; default is 2 years.
     ca_expiry: 17520h
 
+    # Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate.
+    # Can be both IP addresses and DNS names.
+    apiserver_cert_extra_sans: ""
+
   # SSH configuration for cluster nodes.
   ssh:
 
@@ -246,13 +250,9 @@ etcd:
 master:
   expected_count: 2
 
-  # If you have set up load balancing for master nodes, enter the FQDN name here.
-  # Otherwise, use the IP address of a single master node.
-  load_balanced_fqdn: ""
-
-  # If you have set up load balancing for master nodes, enter the short name here.
-  # Otherwise, use the IP address of a single master node.
-  load_balanced_short_name: ""
+  # If you have set up load balancing for master nodes, enter the IP or DNS and Port.
+  # Otherwise, use the IP address of a single master node and port '6443'.
+  load_balancer: ""
   nodes:
   - host: ""
     ip: ""

--- a/pkg/install/upgrade_test.go
+++ b/pkg/install/upgrade_test.go
@@ -109,6 +109,7 @@ func TestDetectNodeUpgradeSafetyEtcdCountUnsafe(t *testing.T) {
 func TestDetectNodeUpgradeSafetyMasterCountUnsafe(t *testing.T) {
 	plan := Plan{
 		Master: MasterNodeGroup{
+			LoadBalancer:  "lb:6443",
 			ExpectedCount: 1,
 			Nodes: []Node{
 				{
@@ -131,8 +132,8 @@ func TestDetectNodeUpgradeSafetyMasterCountUnsafe(t *testing.T) {
 func TestDetectNodeUpgradeSafetyMasterLoadBalancingUnsafe(t *testing.T) {
 	plan := Plan{
 		Master: MasterNodeGroup{
-			ExpectedCount:    2,
-			LoadBalancedFQDN: "foo",
+			ExpectedCount: 2,
+			LoadBalancer:  "foo:6443",
 			Nodes: []Node{
 				{
 					Host: "foo",
@@ -158,8 +159,8 @@ func TestDetectNodeUpgradeSafetyMasterLoadBalancingUnsafe(t *testing.T) {
 func TestDetectNodeUpgradeSafetyMasterLoadBalancingSafe(t *testing.T) {
 	plan := Plan{
 		Master: MasterNodeGroup{
-			ExpectedCount:    2,
-			LoadBalancedFQDN: "someLoadBalancer",
+			ExpectedCount: 2,
+			LoadBalancer:  "someLoadBalancer:6443",
 			Nodes: []Node{
 				{
 					Host: "foo",

--- a/pkg/install/validate.go
+++ b/pkg/install/validate.go
@@ -512,12 +512,12 @@ func (mng *MasterNodeGroup) validate() (bool, []error) {
 		v.validateWithErrPrefix(fmt.Sprintf("Node #%d", i+1), &n)
 	}
 
-	if mng.LoadBalancedFQDN == "" {
-		v.addError(fmt.Errorf("Load balanced FQDN is required"))
-	}
-
-	if mng.LoadBalancedShortName == "" {
-		v.addError(fmt.Errorf("Load balanced shortname is required"))
+	if mng.LoadBalancer == "" {
+		v.addError(fmt.Errorf("Load Balancer IP or DNS is required"))
+	} else {
+		if _, _, err := net.SplitHostPort(mng.LoadBalancer); err != nil {
+			v.addError(fmt.Errorf("Could not read Load Balancer: %v", err))
+		}
 	}
 
 	return v.valid()

--- a/pkg/install/validate_test.go
+++ b/pkg/install/validate_test.go
@@ -75,8 +75,7 @@ func validPlan() Plan {
 					IP:   "192.168.205.11",
 				},
 			},
-			LoadBalancedFQDN:      "test",
-			LoadBalancedShortName: "test",
+			LoadBalancer: "test:6443",
 		},
 		Worker: NodeGroup{
 			ExpectedCount: 1,
@@ -370,15 +369,9 @@ func TestValidatePlanNegativeSSHPort(t *testing.T) {
 	assertInvalidPlan(t, p)
 }
 
-func TestValidatePlanEmptyLoadBalancedFQDN(t *testing.T) {
+func TestValidatePlanEmptyLoadBalancer(t *testing.T) {
 	p := validPlan()
-	p.Master.LoadBalancedFQDN = ""
-	assertInvalidPlan(t, p)
-}
-
-func TestValidatePlanEmptyLoadBalancedShortName(t *testing.T) {
-	p := validPlan()
-	p.Master.LoadBalancedShortName = ""
+	p.Master.LoadBalancer = ""
 	assertInvalidPlan(t, p)
 }
 


### PR DESCRIPTION
Finally fixes https://github.com/apprenda/kismatic/issues/750

Some new options.
```
cluster:
  # Generated certs configuration.
  certificates:
...
    # Optional extra Subject Alternative Names (SANs) to use for the API Server serving certificate.
    # Can be both IP addresses and DNS names.
    apiserver_cert_extra_sans: ""
...

master:
  expected_count: 2

  # If you have set up load balancing for master nodes, enter the IP or DNS and Port.
  # Otherwise, use the IP address of a single master node and port '6443'.
  load_balancer: ""
...
```
The old fields `load_balanced_fqdn` and `load_balanced_short_name` will still function properly and will be converted to the new structure.

New field `load_balancer` will be set to `load_balanced_fqdn:6443` and `load_balanced_short_name` will be automatically added to `apiserver_cert_extra_sans`

Part of this PR was also to modify `kube-dns` and `calico` to use the internal `kubernetes` service endpoint.