### PR TITLE
Make sure '\' symbol is not present on the last iteration of loop in …

### DIFF
--- a/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
+++ b/ansible/roles/kube-apiserver/templates/kube-apiserver.service.debug
@@ -7,7 +7,8 @@ ExecStart={{ bin_dir }}/kube-apiserver \
 {% set combined_options = kubernetes_api_server_option_defaults | combine(kubernetes_api_server_option_overrides) -%}
 {% for option in combined_options | dictsort %}
 {% if option[1] is defined and option[1] | string | length > 0 %}
-  --{{ option[0] }}={{ option[1] }} \
+  --{{ option[0] }}={{ option[1] }} {% if not loop.last %}\{% endif %}
+
 {% endif %}
 {% endfor %}
 Restart=on-failure

--- a/ansible/roles/kubelet/templates/kubelet.service
+++ b/ansible/roles/kubelet/templates/kubelet.service
@@ -9,7 +9,8 @@ ExecStart=/usr/bin/kubelet \
 {% set combined_options = kubelet_defaults | combine(kubelet_overrides) | combine(kubelet_node_overrides[inventory_hostname]) -%}
 {% for option in combined_options | dictsort %}
 {% if option[1] is defined and option[1] | string | length > 0 %}
-  --{{ option[0] }}={{ option[1] }} \
+  --{{ option[0] }}={{ option[1] }} {% if not loop.last %}\{% endif %}
+
 {% endif %}
 {% endfor %}
 Restart=on-failure


### PR DESCRIPTION
…kubelet.service template